### PR TITLE
Updated style for classmethod vs staticmethod

### DIFF
--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -25,4 +25,4 @@ class Sample:
         # NB a sample may NOT have date and time collected if it has been sent out but not yet used
         if date_collected is not None and time_collected is not None:
             datetime_collected = datetime.combine(date_collected, time_collected)
-        return Sample(sample_id, datetime_collected, site, notes, barcode, scan_date)
+        return cls(sample_id, datetime_collected, site, notes, barcode, scan_date)

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -75,18 +75,18 @@ class Source:
 
     @classmethod
     def create_human(cls, source_id, account_id, human_info):
-        return Source(source_id, account_id, 'human', human_info)
+        return cls(source_id, account_id, 'human', human_info)
 
     @classmethod
     def create_canine(cls, source_id, account_id, canine_info):
-        return Source(source_id, account_id, 'canine', canine_info)
+        return cls(source_id, account_id, 'canine', canine_info)
 
     @classmethod
     def create_environment(cls, source_id, account_id, env_info):
-        return Source(source_id, account_id, 'environment', env_info)
+        return cls(source_id, account_id, 'environment', env_info)
 
     @classmethod
     def from_json(cls, source_id, account_id, typed_json_data):
         decoder_hook = DECODER_HOOKS[typed_json_data["source_type"]]
-        return Source(source_id, account_id, typed_json_data["source_type"],
-                      json.loads(typed_json_data, object_hook=decoder_hook))
+        return cls(source_id, account_id, typed_json_data["source_type"],
+                   json.loads(typed_json_data, object_hook=decoder_hook))

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -12,13 +12,13 @@ class AccountRepo(BaseRepo):
     write_cols = "id, email, auth_provider, first_name, last_name, address, " \
                  "account_type"
 
-    @classmethod
-    def _row_to_account(cls, r):
+    @staticmethod
+    def _row_to_account(r):
         return Account(r[0], r[1], r[2], r[3], r[4],
                        json.loads(r[5]), r[6], r[7], r[8])
 
-    @classmethod
-    def _account_to_row(cls, a):
+    @staticmethod
+    def _account_to_row(a):
         return (a.id, a.email, a.auth_provider, a.first_name, a.last_name,
                 json.dumps(a.address), a.account_type)
 

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -18,13 +18,13 @@ class SourceRepo(BaseRepo):
                 "creation_time, update_time"
     write_cols = "id, account_id, source_type, source_data"
 
-    @classmethod
-    def _row_to_source(cls, r):
+    @staticmethod
+    def _row_to_source(r):
         hook = DECODER_HOOKS[r[2]]
         return Source(r[0], r[1], r[2], json.loads(r[3], object_hook=hook))
 
-    @classmethod
-    def _source_to_row(cls, s):
+    @staticmethod
+    def _source_to_row(s):
         row = (s.id, s.account_id, s.source_type,
                json.dumps(s.source_data, default=json_converter))
         return row


### PR DESCRIPTION
Resolves #4   

This is almost entirely stylistic, but it can't hurt to define a particular style.  

Factory methods will use @classmethod, and will use the cls parameter for object construction, allowing for subclasses to use these methods (so long as their __init__ parameter lists match).  Honestly if we are subclassing classes with factory methods, we are probably going to have a bad time anyway, so this shouldn't come up often.  

Utility methods (that don't require a class instance, but should be associated with a class for namespacing purposes) will use @staticmethod