### PR TITLE
Support source creation from consent, remove kit password

### DIFF
--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -288,13 +288,31 @@ def read_kit(kit_name):
         return jsonify(kit.to_api()), 200
 
 
-def consent_doc():
+def render_consent_doc(account_id):
     # return render_template("new_participant.jinja2",
     #                        message=MockJinja("message"),
     #                        media_locale=MockJinja("media_locale"),
     #                        tl=MockJinja("tl"))
 
+    # NB: Do NOT need to explicitly pass account_id into template for integration into form submission URL
+    # because form submit URL builds on the base of the URL that called it (which includes account_id)
     return render_template("new_participant.jinja2",
                            message=None,
                            media_locale=american_gut.media_locale,
                            tl=american_gut._NEW_PARTICIPANT)
+
+
+def create_human_source_from_consent(account_id, body):
+    parsed_form = dict()
+    for key, value in body.items():
+        if len(value) != 1:
+            raise ValueError("For form field '{0}', received unexpected values '{1}'".format(key, value))
+        parsed_form[key] = value[0]
+
+    # TODO: boolean deceased_parent will come through as
+    #  'deceased_parent': 'true'
+    # and will need to be converted to a boolean True ...
+    # think this should probably happen in source.HumanInfo.__init__
+
+    # NB: Don't expect to handle errors 404, 422 in this function; expect to farm out to `create_source`
+    return create_source(account_id, parsed_form)

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -278,11 +278,11 @@ def dissociate_answered_survey(account_id, source_id, sample_id, survey_id):
     return not_yet_implemented()
 
 
-def read_kit(kit_name, kit_password):
+def read_kit(kit_name):
     with Transaction() as t:
         kit_repo = KitRepo(t)
-        # TODO: Ensure this name and password are what the repo layer expects
-        kit = kit_repo.get_kit(kit_name, kit_password)
+        # TODO: Ensure this name is what the repo layer expects
+        kit = kit_repo.get_kit(kit_name)
         if kit is None:
             return jsonify(error=404, text="No such kit"), 404
         return jsonify(kit.to_api()), 200

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -294,8 +294,9 @@ def render_consent_doc(account_id):
     #                        media_locale=MockJinja("media_locale"),
     #                        tl=MockJinja("tl"))
 
-    # NB: Do NOT need to explicitly pass account_id into template for integration into form submission URL
-    # because form submit URL builds on the base of the URL that called it (which includes account_id)
+    # NB: Do NOT need to explicitly pass account_id into template for
+    # integration into form submission URL because form submit URL builds on the
+    # base of the URL that called it (which includes account_id)
     return render_template("new_participant.jinja2",
                            message=None,
                            media_locale=american_gut.media_locale,
@@ -306,7 +307,8 @@ def create_human_source_from_consent(account_id, body):
     parsed_form = dict()
     for key, value in body.items():
         if len(value) != 1:
-            raise ValueError("For form field '{0}', received unexpected values '{1}'".format(key, value))
+            raise ValueError("For form field '{0}', received unexpected values "
+                             "'{1}'".format(key, value))
         parsed_form[key] = value[0]
 
     # TODO: boolean deceased_parent will come through as
@@ -314,5 +316,6 @@ def create_human_source_from_consent(account_id, body):
     # and will need to be converted to a boolean True ...
     # think this should probably happen in source.HumanInfo.__init__
 
-    # NB: Don't expect to handle errors 404, 422 in this function; expect to farm out to `create_source`
+    # NB: Don't expect to handle errors 404, 422 in this function; expect to
+    # farm out to `create_source`
     return create_source(account_id, parsed_form)

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -303,19 +303,12 @@ def render_consent_doc(account_id):
                            tl=american_gut._NEW_PARTICIPANT)
 
 
+# This function simply passes its arguments on to the create_source function;
+# however, it is necessary because connexion will not allow two endpoints to
+# use the same implementation function (it throws an error
+# "AssertionError: View function mapping is overwriting an existing endpoint
+# function")
 def create_human_source_from_consent(account_id, body):
-    parsed_form = dict()
-    for key, value in body.items():
-        if len(value) != 1:
-            raise ValueError("For form field '{0}', received unexpected values"
-                             " '{1}'".format(key, value))
-        parsed_form[key] = value[0]
-
-    # TODO: boolean deceased_parent will come through as
-    #  'deceased_parent': 'true'
-    # and will need to be converted to a boolean True ...
-    # think this should probably happen in source.HumanInfo.__init__
-
     # NB: Don't expect to handle errors 404, 422 in this function; expect to
     # farm out to `create_source`
-    return create_source(account_id, parsed_form)
+    return create_source(account_id, body)

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -295,8 +295,8 @@ def render_consent_doc(account_id):
     #                        tl=MockJinja("tl"))
 
     # NB: Do NOT need to explicitly pass account_id into template for
-    # integration into form submission URL because form submit URL builds on the
-    # base of the URL that called it (which includes account_id)
+    # integration into form submission URL because form submit URL builds on
+    # the base of the URL that called it (which includes account_id)
     return render_template("new_participant.jinja2",
                            message=None,
                            media_locale=american_gut.media_locale,
@@ -307,8 +307,8 @@ def create_human_source_from_consent(account_id, body):
     parsed_form = dict()
     for key, value in body.items():
         if len(value) != 1:
-            raise ValueError("For form field '{0}', received unexpected values "
-                             "'{1}'".format(key, value))
+            raise ValueError("For form field '{0}', received unexpected values"
+                             " '{1}'".format(key, value))
         parsed_form[key] = value[0]
 
     # TODO: boolean deceased_parent will come through as

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -131,36 +131,23 @@ paths:
         content:
           application/x-www-form-urlencoded:
             schema:
+              type: object
               properties:  # each is a form field name
                 age_range:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/age_range'
+                  $ref: '#/components/schemas/age_range'
                 participant_name:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/participant_name'
+                  $ref: '#/components/schemas/participant_name'
                 participant_email:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/participant_email'
+                  $ref: '#/components/schemas/participant_email'
                 parent_1_name:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/parent_1_name'
+                  $ref: '#/components/schemas/parent_1_name'
                 parent_2_name:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/parent_2_name'
+                  $ref: '#/components/schemas/parent_2_name'
                 deceased_parent:
-                  type: array
-                  items:
-                    type: boolean
-                    example: true
+                  type: boolean
+                  example: true
                 obtainer_name:
-                  type: array
-                  items:
-                    $ref: '#/components/schemas/obtainer_name'
+                  $ref: '#/components/schemas/obtainer_name'
               required:
                 - age_range
                 - participant_name

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -20,23 +20,17 @@ paths:
       requestBody:
         content:
           application/json:
-            # NB: this doesn't use $ref: '#/components/schemas/account' because--for account creation ONLY--it is
-            # required to pass in kit info, which is not part of the account object schema
+            # Send (non-readOnly) values of account schema PLUS kit name
             schema:
-              type: object
-              properties:
-                first_name:
-                  $ref: '#/components/schemas/first_name'
-                last_name:
-                  $ref: '#/components/schemas/last_name'
-                email:
-                  $ref: '#/components/schemas/email'
-                address:
-                  $ref: '#/components/schemas/address'
-                kit_name:
-                  $ref: '#/components/schemas/kit_name'
-                kit_password:
-                  $ref: '#/components/schemas/kit_password'
+              allOf:
+                - $ref: '#/components/schemas/account'
+                - type: "object"
+                  properties:
+                    kit_name:
+                      $ref: '#/components/schemas/kit_name'
+                  required:
+                    - account
+                    - kit_name
       responses:
         '201':
           description: Successfully registered new user account
@@ -103,6 +97,97 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
+  '/accounts/{account_id}/consent':
+    get:
+      operationId: microsetta_private_api.api.implementation.render_consent_doc
+      tags:
+        - Consent
+      summary: Retrieve personalized consent form for display to user
+      description: Retrieve personalized consent form for display to user
+      parameters:
+        - $ref: '#/components/parameters/account_id'
+      responses:
+        '200':
+          description: Consent form
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            text/html:
+              schema:
+                type: string
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+    post:
+      operationId: microsetta_private_api.api.implementation.create_human_source_from_consent
+      tags:
+        - Source (from Consent)
+      summary: Create a new human source based on a consent form
+      description: Create a new human source based on a consent form
+      parameters:
+        - $ref: '#/components/parameters/account_id'
+      requestBody:
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              properties:  # each is a form field name
+                age_range:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/age_range'
+                participant_name:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/participant_name'
+                participant_email:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/participant_email'
+                parent_1_name:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/parent_1_name'
+                parent_2_name:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/parent_2_name'
+                deceased_parent:
+                  type: array
+                  items:
+                    type: boolean
+                    example: true
+                obtainer_name:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/obtainer_name'
+              required:
+                - age_range
+                - participant_name
+                - participant_email
+      responses:
+        '201':
+          description: Successfully created new human source based on consent form
+          headers:
+            Location:
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/human_source'
+              examples:
+                human_adult_source:
+                  $ref: '#/components/examples/human_adult_source_w_id'
+                human_child_source:
+                  $ref: '#/components/examples/human_child_source_w_id'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
+
   '/accounts/{account_id}/sources':
     get:
       operationId: microsetta_private_api.api.implementation.read_sources
@@ -131,7 +216,7 @@ paths:
                   consent:
                     participant_name: "Ophelia Q. Doe"
                     participant_email: "nunnery@example.com"
-                    age_range: "18+"
+                    age_range: "18-plus"
                 - source_id: "df077cd7-f2c7-42e4-b8ed-9c7e9dd47ce5"
                   source_name: "P. Doe"
                   source_type: human
@@ -170,7 +255,6 @@ paths:
                 $ref: '#/components/examples/human_child_source'
               nonhuman_source:
                 $ref: '#/components/examples/nonhuman_source'
-
       responses:
         '201':
           description: Successfully created new source
@@ -709,28 +793,6 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
-  # TODO: Move this out of /api ?
-  '/consent':
-    get:
-      operationId: microsetta_private_api.api.implementation.consent_doc
-      tags:
-        - Consent
-      summary: Retrieve consent forms for display to user
-      description: Retrieve consent forms for display to user
-      responses:
-        '200':
-          description: Consent form
-          headers:
-            Location:
-              schema:
-                type: string
-          content:
-            text/html:
-              schema:
-                type: string
-        '401':
-          $ref: '#/components/responses/401Unauthorized'
-
 
 components:
   parameters:
@@ -968,6 +1030,29 @@ components:
       type: string
       enum: [human, animal, environmental]
       example: human
+    participant_name:
+      type: string
+      example: "Hija Doe"
+    participant_email:
+      type: string
+      format: email
+      example: "mdoe@example.com"
+    age_range:
+      type: string
+      enum: ["0-6", "7-12", "13-17", "18-plus"]
+    parent_1_name:
+      type: string
+      example: "Madre Doe"
+    parent_2_name:
+      type: string
+      nullable: true
+      example: "Padre Doe"
+    deceased_parent:
+      type: boolean
+      example: false
+    obtainer_name:
+      type: string
+      example: "Professor X"
     nonhuman_source:
       type: object
       properties:
@@ -997,21 +1082,20 @@ components:
           type: object
           properties:
             participant_name:
-              type: string
+              $ref: '#/components/schemas/participant_name'
             participant_email:
-              type: string
+              $ref: '#/components/schemas/participant_email'
             age_range:
-              type: string
-              enum: ["0-6", "7-12", "13-17", "18+"]
+              $ref: '#/components/schemas/age_range'
             child_info:
               type: object
               properties:
                 parent_1_name:
-                  type: string
+                  $ref: '#/components/schemas/parent_1_name'
                 parent_2_name:
-                  type: string
+                  $ref: '#/components/schemas/parent_2_name'
                 deceased_parent:
-                  type: boolean
+                  $ref: '#/components/schemas/deceased_parent'
                 obtainer_name:
                   type: string
               additionalProperties: false
@@ -1160,7 +1244,7 @@ components:
         consent:
           participant_name: "Nellie Doe"
           participant_email: "nell@example.com"
-          age_range: "18+"
+          age_range: "18-plus"
     human_child_source:
       value:
         source_name: "K. Doe"
@@ -1186,7 +1270,7 @@ components:
         consent:
           participant_name: "Nellie Doe"
           participant_email: "nell@example.com"
-          age_range: "18+"
+          age_range: "18-plus"
     human_child_source_w_id:
       value:
         source_id: "b06825c2-e808-4606-8819-861b0fa8a5ce"

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -693,7 +693,6 @@ paths:
       description: Get list of samples in kit that are not assigned to a source
       parameters:
         - $ref: '#/components/parameters/kit_name'
-        - $ref: '#/components/parameters/kit_password'
       responses:
         '200':
           description: Successfully returned list of unassigned samples
@@ -781,13 +780,6 @@ components:
       required: true
 
     # query parameters
-    kit_password:
-      name: kit_password
-      in: query
-      description: User-facing code of kit
-      schema:
-        $ref: '#/components/schemas/kit_password'
-      required: true
     kit_name:
       name: kit_name
       in: query
@@ -912,8 +904,6 @@ components:
         - country_code
 
     # kit section
-    kit_password:
-      type: string
     kit_name:
       type: string
       example: "jb_qhxqe"

--- a/microsetta_private_api/repo/kit_repo.py
+++ b/microsetta_private_api/repo/kit_repo.py
@@ -7,7 +7,7 @@ class KitRepo(BaseRepo):
     def __init__(self, transaction):
         super().__init__(transaction)
 
-    def get_kit(self, supplied_kit_id, kit_password):
+    def get_kit(self, supplied_kit_id):
 
         sample_repo = SampleRepo(self._transaction)
 
@@ -18,9 +18,8 @@ class KitRepo(BaseRepo):
                         "FROM ag_kit LEFT JOIN ag_kit_barcodes ON "
                         "ag_kit.ag_kit_id = ag_kit_barcodes.ag_kit_id "
                         "WHERE "
-                        "ag_kit.supplied_kit_id = %s AND "
-                        "ag_kit.kit_password = %s",
-                        (supplied_kit_id, kit_password))
+                        "ag_kit.supplied_kit_id = %s",
+                        supplied_kit_id)
             rows = cur.fetchall()
             if len(rows) == 0:
                 return None

--- a/microsetta_private_api/templates/new_participant.jinja2
+++ b/microsetta_private_api/templates/new_participant.jinja2
@@ -136,7 +136,7 @@
     <div class="" id="consent">
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-        <form method="post" id="0-6-form" name="consent_info" onsubmit="return validate06();" action="{{ media_locale['SITEBASE'] |e}}/authed/new_participant/">
+        <form method="post" id="0-6-form" name="consent_info" onsubmit="return validate06();" action="consent">
            <input type="hidden" name="age_range" value="0-6">
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}}</p>
     </div>
@@ -145,7 +145,7 @@
         <tr><td>{{ tl['PARTICIPANT_EMAIL'] |e}}</td><td><input tabindex="3" type="email"  name="participant_email" id="participant_email" required data-rule-required="true"><div class="red right" required data-rule-required="true">*</div></td></tr>
         <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="0-6-form_parent_1_name" required data-rule-required="true"></td></tr>
         <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="0-6-form_parent_2_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="yes" onclick="relax_parents(this)"></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" value="I Accept"></td><td></td></tr>
     </table>
     </form>
@@ -156,7 +156,7 @@
 </div>
     <div class="" id="consent">
         <hr>
-        <form method="post" id="7-12-form" name="consent_info" onsubmit="return validate712();" action="{{ media_locale['SITEBASE'] |e}}/authed/new_participant/">
+        <form method="post" id="7-12-form" name="consent_info" onsubmit="return validate712();" action="consent">
         <input type="hidden" name="age_range" value="7-12">
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_SIMPLIFIED'] |e}}</p>
     </div>
@@ -185,7 +185,7 @@
     <table>
         <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="7-12-form_parent_1_name" required data-rule-required="true"></td></tr>
         <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="8" type="text" name="parent_2_name" id="7-12-form_parent_2_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="yes" onclick="relax_parents(this)"></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" value="I Accept"></td><td></td></tr>
     </table>
     </form>
@@ -197,7 +197,7 @@
 </div>
     <div class="" id="consent">
         <hr>
-        <form method="post" id="13-17-form" name="consent_info" onsubmit="return validate1317();" action="{{ media_locale['SITEBASE'] |e}}/authed/new_participant/">
+        <form method="post" id="13-17-form" name="consent_info" onsubmit="return validate1317();" action="consent">
            <input type="hidden" name="age_range" value="13-17">
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
     </div>
@@ -219,7 +219,7 @@
     <table>
         <tr><td>{{ tl['PARTICIPANT_PARENT_1'] |e}}</td><td><input tabindex="7" type="text" name="parent_1_name" id="13-17-form_parent_1_name" required data-rule-required="true"></td></tr>
         <tr><td>{{ tl['PARTICIPANT_PARENT_2'] |e}}</td><td><input tabindex="7" type="text" name="parent_2_name" id="13-17-form_parent_2_name" required data-rule-required="true"></td></tr>
-        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="yes" onclick="relax_parents(this)"></td></tr>
+        <tr><td>{{ tl['PARTICIPANT_DECEASED_PARENTS'] |e}}</td><td><input  tabindex="9" type="checkbox" name="deceased_parent" id="deceased_parent" value="true" onclick="relax_parents(this)"></td></tr>
         <tr><td><input type="submit" value="I Accept"></td><td></td></tr>
     </table>
     </form>
@@ -234,7 +234,7 @@
 <div class="" id="consent">
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-        <form method="post" id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="{{ media_locale['SITEBASE'] |e}}/authed/new_participant/">
+        <form method="post" id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="consent">
         <input type="hidden" name="age_range" value="18-plus">
            <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
     </div>


### PR DESCRIPTION
Fixes #27, moving the consent endpoint under account and adding a post to enable creation of a human source from a submitted consent form.  

Unfortunately, those who live by the shiny new supporting library also die by the shiny new supporting library: although the openapi3 specs support allowing different media types to be passed into a single endpoint (which would have allowed us to add creating a human source from consent form data as another aspect of the /accounts/{account_id}/sources POST that already can take in json data), *`connexion`* doesn't currently implement the "multiple media types per endpoint" aspect of openapi3 (https://github.com/zalando/connexion/issues/655, https://github.com/zalando/connexion/issues/805 ).  Therefore it was necessary to kludge a little.  The new /accounts/{account_id}/consent endpoint has a GET that gets consent form html as well as, now, a **POST** that creates a human source from a submitted consent form (using ONLY the form data media type).  I am open to suggestions for better ways to do this. 

Because @dhakim87 has ongoing work on `source.py`, I can't carry through the full implementation of creating a source from the consent form, but I have verified I can parse the incoming data and toss it over to the existing `create_source` call.  ~~Note that, for some reason I can't fathom, connexion sends *all* form field values to the back end as lists, regardless of the input element type ... e.g.,~~

~~`{'age_range': ['7-12'], 'consent_child': ['Yes'], 'participant_name': ['a'], 'participant_email': ['b@c.com'], 'consent_witness': ['Yes'], 'obtainer_name': ['Me'], 'consent_parent': ['Yes'], 'parent_1_name': ['b'], 'parent_2_name': ['c'], 'deceased_parent': ['true']}`~~

~~... Given this, the main thing I do with the form data is ensure each of these lists is really just a single value and then dig it out to make, e.g.,~~

~~`{'age_range': '7-12', 'consent_child': 'Yes', 'participant_name': 'a', 'participant_email': 'b@c.com', 'consent_witness': 'Yes', 'obtainer_name': 'Me', 'consent_parent': 'Yes', 'parent_1_name': 'b', 'parent_2_name': 'c', 'deceased_parent': 'true'}`~~

 ~~... which is what I thought we should get anyway ...~~

This PR also fixes #27, removing use of kit_password from the yaml api, `implementation.py`, and `kit_repo.py`.