### PR TITLE
St dh data migration 42

### DIFF
--- a/microsetta_private_api/LEGACY/env_management.py
+++ b/microsetta_private_api/LEGACY/env_management.py
@@ -200,7 +200,6 @@ def patch_db(patches_dir=PATCHES_DIR, verbose=False):
                 MigrationSupport.run_migration(TRN, patch_filename)
 
 
-
 def rebuild_test(verbose=False):
     conn = connect(user=AMGUT_CONFIG.user, password=AMGUT_CONFIG.password,
                    host=AMGUT_CONFIG.host, port=AMGUT_CONFIG.port,

--- a/microsetta_private_api/LEGACY/env_management.py
+++ b/microsetta_private_api/LEGACY/env_management.py
@@ -10,6 +10,8 @@ from natsort import natsorted
 from microsetta_private_api.config_manager import AMGUT_CONFIG
 from microsetta_private_api.LEGACY.sql_connection import TRN
 
+from microsetta_private_api.db.migration_support import MigrationSupport
+
 
 get_db_file = partial(join, join(dirname(dirname(abspath(__file__))),
                                  'db'))
@@ -195,6 +197,8 @@ def patch_db(patches_dir=PATCHES_DIR, verbose=False):
 
                 TRN.add(patch_file.read())
                 TRN.add(patch_update_sql, [patch_filename])
+                MigrationSupport.run_migration(TRN, patch_filename)
+
 
 
 def rebuild_test(verbose=False):

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -199,8 +199,6 @@ def read_survey_template(account_id, source_id, survey_template_id,
 
 
 def read_answered_surveys(account_id, source_id, language_tag):
-    # TODO: source_id is participant name until we make the proper schema
-    #  changes.  Sorry bout that
     with Transaction() as t:
         survey_answers_repo = SurveyAnswersRepo(t)
         return jsonify(
@@ -221,7 +219,6 @@ def read_answered_survey(account_id, source_id, survey_id):
 
 
 def submit_answered_survey(account_id, source_id, language_tag, body):
-    # TODO: source_id still needs to be participant name til we refactor
     # TODO: Is this supposed to return new survey id?
     # TODO: Rename survey_text to survey_model/model to match Vue's naming?
     with Transaction() as t:

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -45,8 +45,6 @@ class MigrationSupport:
                 "is_juvenile, "
                 "parent_1_name, "
                 "parent_2_name, "
-                # "parent_1_code, " # TODO: Can we drop these two?
-                # "parent_2_code, "
                 "deceased_parent, "
                 "date_signed, "
                 "assent_obtainer, "
@@ -102,7 +100,6 @@ class MigrationSupport:
                     "participant_name, participant_email, "
                     "is_juvenile, "
                     "parent_1_name, parent_2_name, "
-                    # "parent_1_code, parent_2_code " # Drop?
                     "deceased_parent, "
                     "date_signed, date_revoked, "
                     "assent_obtainer, age_range) "
@@ -111,7 +108,6 @@ class MigrationSupport:
                     "%s, %s, "
                     "%s, "
                     "%s, %s, "
-                    # "%s, %s, " # Drop parent_1_code?
                     "%s, "
                     "%s, %s, "
                     "%s, %s)",
@@ -119,7 +115,6 @@ class MigrationSupport:
                      r["participant_name"], r["participant_email"],
                      r["is_juvenile"],
                      r["parent_1_name"], r["parent_2_name"],
-                     # r["parent_1_code"], r["parent_2_code"],
                      new_deceased_parent,
                      r["date_signed"], r["date_revoked"],
                      r["assent_obtainer"], new_age_range)
@@ -154,7 +149,6 @@ class MigrationSupport:
                     "participant_name, participant_email, "
                     "is_juvenile, "
                     "parent_1_name, parent_2_name, "
-                    # "parent_1_code, parent_2_code " # Drop?
                     "deceased_parent, "
                     "date_signed, date_revoked, "
                     "assent_obtainer, age_range, description) "
@@ -163,7 +157,6 @@ class MigrationSupport:
                     "%s, %s, "
                     "%s, "
                     "%s, %s, "
-                    # "%s, %s, " # Drop parent_1_code?
                     "%s, "
                     "%s, %s, "
                     "%s, %s, %s)",
@@ -171,7 +164,6 @@ class MigrationSupport:
                      "Environmental Sample-" + str(name_suffix).zfill(3), None,
                      None,
                      None, None,
-                     # r["parent_1_code"], r["parent_2_code"],
                      None,
                      None, None,
                      None, None, r['environment_sampled'])

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -1,0 +1,200 @@
+import uuid
+import pycountry
+
+class MigrationSupport:
+    """
+    Contains methods for data migrations that are difficult to express as
+    pure SQL.  Methods are registered with script names in MIGRATION_LOOKUP.
+    These methods will be run immediately after the script with the associated
+    name, and as part of the same transaction.
+
+    Note that you must have a sql script in the patch folder to run a
+    migration method, even if no sql is required for the change
+    """
+
+    @staticmethod
+    def migrate_48(TRN):
+        """
+        In order to support the REST api, we need participants to have unique
+        ids.  This is a change from the previous keying in ag_consent
+        which worked off of a compound key (ag_login_id, participant_name).
+
+        As part of schema change 48, we are generating new unique IDs for all
+        sources, and migrating the consent information from ag_consent and
+        consent_revoked
+
+        This requires:
+
+        * Adding a new source table (Done in the 0048.sql)
+        * Mapping each ag_login_id, participant_name pair to a new unique id
+        * Migrating all data from the
+        * Migrating all data from the ag_consent table to source
+        * Migrating all data from the consent_revoked table to source
+
+        :param TRN: The active transaction
+        :return:
+        """
+
+        # TODO: We need to throw away the legacy sql_connection code.
+        TRN.add("SELECT "
+                "ag_login_id, "
+                "participant_name, "
+                "ag_consent_backup.participant_email, "
+                "is_juvenile, "
+                "parent_1_name, "
+                "parent_2_name, "
+                # "parent_1_code, " # TODO: Can we drop these two?
+                # "parent_2_code, "
+                "deceased_parent, "
+                "date_signed, "
+                "assent_obtainer, "
+                "age_range, "
+                "date_revoked "
+                "FROM "
+                "ag.ag_consent_backup "
+                "LEFT JOIN "
+                "ag.consent_revoked_backup "
+                "USING (ag_login_id, participant_name)")
+
+        rows = TRN.execute()[-1]
+        # For each distinct ag_login_id, participant_name pair:
+        for r in rows:
+            # Generate a new id
+            source_id = str(uuid.uuid4())
+
+            # Add that id to the correct rows of ag_login_surveys
+            TRN.add("UPDATE "
+                    "ag_login_surveys "
+                    "SET "
+                    "source_id = %s "
+                    "WHERE "
+                    "ag_login_id = %s AND "
+                    "participant_name = %s",
+                    (source_id,
+                     r["ag_login_id"],
+                     r["participant_name"]))
+
+            # Convert data formats:
+            # Fix age range to not store type information
+
+            # TODO: !!CRITICAL!! @Daniel, Can you verify this is the
+            #  correct logic for migrating source type, there doesn't
+            #  appear to be any way to specify an environment source type,
+            #  and there are existing primary surveys associated even when
+            #  age_range is None!!
+            new_age_range = r["age_range"]
+            source_type = "human"
+            if r["age_range"] == "ANIMAL_SURVEY":
+                source_type = "animal"
+                new_age_range = None
+
+            TRN.add("INSERT INTO source("
+                    "id, account_id, source_type, "
+                    "participant_name, participant_email, "
+                    "is_juvenile, "
+                    "parent_1_name, parent_2_name, "
+                    # "parent_1_code, parent_2_code " # Drop?
+                    "deceased_parent, "
+                    "date_signed, date_revoked, "
+                    "assent_obtainer, age_range) "
+                    "VALUES ("
+                    "%s, %s, %s, "
+                    "%s, %s, "
+                    "%s, "
+                    "%s, %s, "
+                    # "%s, %s, " # Drop parent_1_code?
+                    "%s, "
+                    "%s, %s, "
+                    "%s, %s)",
+                    (source_id, r["ag_login_id"], source_type,
+                     r["participant_name"], r["participant_email"],
+                     r["is_juvenile"],
+                     r["parent_1_name"], r["parent_2_name"],
+                     # r["parent_1_code"], r["parent_2_code"],
+                     r["deceased_parent"],
+                     r["date_signed"], r["date_revoked"],
+                     r["assent_obtainer"], new_age_range)
+                    )
+
+    @staticmethod
+    def migrate_50(TRN):
+        country_map = {x.name: x.alpha_2 for x in pycountry.countries}
+
+        # Apparently we have a few country strings pycountry can't map well,
+        # add any others we need to migrate right here to complete migration:
+        country_map[None] = ''
+        country_map[''] = ''
+        country_map['South Korea'] = 'KR'
+        country_map['US'] = 'US'
+        country_map['Czech Republic'] = 'CZ'
+
+        TRN.add("SELECT DISTINCT country FROM ag_login_backup")
+        rows = TRN.execute()[-1]
+        db_countries = [r['country'] for r in rows]
+
+        need_to_map_manually = []
+        for country in db_countries:
+            if country not in country_map:
+                need_to_map_manually.append(country)
+
+        if len(need_to_map_manually) > 0:
+            raise RuntimeError(
+                "ERROR: Cannot migrate ag_login: Require "
+                "country codes for: " + str(need_to_map_manually))
+
+        TRN.add("SELECT "
+                "ag_login_id, email, name, "
+                "address, city, state, zip, country, "
+                "latitude, longitude, cannot_geocode, elevation "
+                "FROM "
+                "ag_login_backup")
+
+        rows = TRN.execute()[-1]
+        for r in rows:
+            # Split name into first name last name with simple heuristic
+            first_name = None
+            last_name = None
+            if r['name'] is not None:
+                names = r['name'].split()
+                if len(names) == 1:
+                    first_name = names[0]
+                elif len(names) >= 2:
+                    first_name = names[0]
+                    last_name = names[-1]
+
+            # Look up country code
+            cc = country_map[r['country']]
+
+            TRN.add("INSERT INTO account("
+                    "id, email, account_type, auth_provider, "
+                    "first_name, last_name, "
+                    "street, city, state, post_code, country_code, "
+                    "latitude, longitude, "
+                    "cannot_geocode, elevation) "
+                    "VALUES("
+                    "%s, %s, %s, %s, "
+                    "%s, %s, "
+                    "%s, %s, %s, %s, %s, "
+                    "%s, %s, "
+                    "%s, %s)",
+                    (r['ag_login_id'], r['email'], 'standard', 'GLOBUS',
+                     first_name, last_name,
+                     r['address'], r['city'], r['state'], r['zip'], cc,
+                     r['latitude'], r['longitude'],
+                     r['cannot_geocode'], r['elevation']))
+
+
+    MIGRATION_LOOKUP = {
+        "0048.sql": migrate_48.__func__,
+        "0050.sql": migrate_50.__func__
+        # ...
+    }
+
+    @classmethod
+    def run_migration(cls, TRN, patch_name):
+        if patch_name in cls.MIGRATION_LOOKUP:
+            try:
+                cls.MIGRATION_LOOKUP[patch_name](TRN)
+            except Exception as e:
+                # TODO: We need to throw away the legacy sql_connection code!
+                TRN._raise_execution_error('', '', e)

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -1,6 +1,7 @@
 import uuid
 import pycountry
 
+
 class MigrationSupport:
     """
     Contains methods for data migrations that are difficult to express as
@@ -182,7 +183,6 @@ class MigrationSupport:
                      r['address'], r['city'], r['state'], r['zip'], cc,
                      r['latitude'], r['longitude'],
                      r['cannot_geocode'], r['elevation']))
-
 
     MIGRATION_LOOKUP = {
         "0048.sql": migrate_48.__func__,

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -97,7 +97,7 @@ class MigrationSupport:
 
             TRN.add("INSERT INTO source("
                     "id, account_id, source_type, "
-                    "participant_name, participant_email, "
+                    "source_name, participant_email, "
                     "is_juvenile, "
                     "parent_1_name, parent_2_name, "
                     "deceased_parent, "
@@ -146,7 +146,7 @@ class MigrationSupport:
             source_type = "environmental"
             TRN.add("INSERT INTO source("
                     "id, account_id, source_type, "
-                    "participant_name, participant_email, "
+                    "source_name, participant_email, "
                     "is_juvenile, "
                     "parent_1_name, parent_2_name, "
                     "deceased_parent, "

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -89,6 +89,18 @@ class MigrationSupport:
                 source_type = "animal"
                 new_age_range = None
 
+            new_deceased_parent = None
+            if r['deceased_parent'] is not None:
+                existing = r['deceased_parent'].lower()
+                if existing in ['yes', 'true']:
+                    new_deceased_parent = True
+                elif existing in ['no', 'false']:
+                    new_deceased_parent = False
+                else:
+                    raise RuntimeError(
+                        "ERROR: Cannot migrate source.deceased_parent: "
+                        "Unknown input: " + str(existing))
+
             TRN.add("INSERT INTO source("
                     "id, account_id, source_type, "
                     "participant_name, participant_email, "
@@ -112,7 +124,7 @@ class MigrationSupport:
                      r["is_juvenile"],
                      r["parent_1_name"], r["parent_2_name"],
                      # r["parent_1_code"], r["parent_2_code"],
-                     r["deceased_parent"],
+                     new_deceased_parent,
                      r["date_signed"], r["date_revoked"],
                      r["assent_obtainer"], new_age_range)
                     )

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -218,7 +218,6 @@ class MigrationSupport:
                     "WHERE barcode=%s",
                     (source_id, r['barcode']))
 
-
     @staticmethod
     def migrate_50(TRN):
         country_map = {x.name: x.alpha_2 for x in pycountry.countries}

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -17,12 +17,12 @@ $$ language 'plpgsql';
 -- source represents sources/participants.  We are migrating information
 -- from ag_login_surveys, ag_consent, consent_revoked into this table to
 -- make sources their own separate objects with types and ids rather than
--- being accessed by a combination of ag_login_id and participant_name
+-- being accessed by a combination of login id and name
 CREATE TABLE ag.source (
     id uuid PRIMARY KEY NOT NULL,
     account_id uuid NOT NULL,
     source_type varchar NOT NULL,
-    participant_name varchar(200) NOT NULL,
+    source_name varchar(200) NOT NULL,
     participant_email varchar,
     is_juvenile bool,
     parent_1_name varchar(200),

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -1,4 +1,11 @@
--- create table for individual accounts
+-- This script is the first half of migrating data and constraints from
+-- * ag_consent,
+-- * consent_revoked and,
+-- * ag_login_survey
+-- into a new ag.source table that represents sources/participants with their
+-- own unique ids
+
+-- Build update triggers for setting timestamps
 CREATE OR REPLACE FUNCTION update_trigger()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -7,31 +14,51 @@ BEGIN
 END
 $$ language 'plpgsql';
 
-CREATE TABLE ag.account (
-    id uuid PRIMARY KEY NOT NULL,
-    email varchar NOT NULL,
-    auth_provider varchar NOT NULL,
-    first_name varchar NOT NULL,
-    last_name varchar NOT NULL,
-    address varchar NOT NULL,
-    account_type varchar NOT NULL,
-    creation_time timestamp default current_timestamp,
-    update_time timestamp default current_timestamp
-);
-
+-- source represents sources/participants.  We are migrating information
+-- from ag_login_surveys, ag_consent, consent_revoked into this table to
+-- make sources their own separate objects with types and ids rather than
+-- being accessed by a combination of ag_login_id and participant_name
 CREATE TABLE ag.source (
     id uuid PRIMARY KEY NOT NULL,
     account_id uuid NOT NULL,
     source_type varchar NOT NULL,
-    source_data varchar NOT NULL,
+    participant_name varchar(200) NOT NULL,
+    participant_email varchar NOT NULL,
+    is_juvenile bool,
+    parent_1_name varchar(200),
+    parent_2_name varchar(200),
+--    parent_1_code varchar(200), -- TODO: Can we drop these two columns?
+--    parent_2_code varchar(200),
+    deceased_parent varchar(10),
+    date_signed date,
+    date_revoked date,
+    assent_obtainer varchar,
+    age_range varchar,
     creation_time timestamp default current_timestamp,
     update_time timestamp default current_timestamp
 );
 
-CREATE UNIQUE INDEX idx_account_email ON ag.account ( email );
-CREATE TRIGGER update_account_trigger BEFORE UPDATE ON account FOR EACH ROW
-  EXECUTE PROCEDURE update_trigger();
+-- We add space for the new source id, we will need to fill it in during the
+-- migration.
+-- TODO: Add foreign key ref from source_id to source table
+-- TODO: Add not null constraint to source_id
+--   TODO's can be done until after migration, verify they are in 0049.sql
 
-CREATE INDEX idx_source_account_id ON ag.source ( account_id, source_type);
+ALTER TABLE ag.ag_login_surveys
+ADD COLUMN source_id uuid;
+
+ALTER TABLE ag.ag_login_surveys
+DROP CONSTRAINT fk_ag_login_surveys0;
+
+-- We deprecate the ag_consent and consent_revoked tables, we will migrate
+-- all the data out of them, and then remove them in the next change script
+-- TODO: Remove ag_consent_backup, consent_revoked_backup in 0049.sql
+
+ALTER TABLE ag.ag_consent RENAME TO ag_consent_backup;
+
+ALTER TABLE ag.consent_revoked RENAME TO consent_revoked_backup;
+
+CREATE INDEX idx_source_account_id_type ON ag.source (account_id, source_type);
+CREATE UNIQUE INDEX idx_source_account_id_id ON ag.source (account_id, id);
 CREATE TRIGGER update_source_trigger BEFORE UPDATE ON source FOR EACH ROW
   EXECUTE PROCEDURE update_trigger();

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -29,7 +29,7 @@ CREATE TABLE ag.source (
     parent_2_name varchar(200),
 --    parent_1_code varchar(200), -- TODO: Can we drop these two columns?
 --    parent_2_code varchar(200),
-    deceased_parent varchar(10),
+    deceased_parent bool,
     date_signed date,
     date_revoked date,
     assent_obtainer varchar,

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -33,8 +33,8 @@ CREATE TABLE ag.source (
     assent_obtainer varchar,
     age_range varchar,
     description varchar,
-    creation_time timestamp default current_timestamp,
-    update_time timestamp default current_timestamp
+    creation_time timestamptz default current_timestamp,
+    update_time timestamptz default current_timestamp
 );
 
 -- We add space for the new source id, we will need to fill it in during the

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -45,12 +45,24 @@ CREATE TABLE ag.source (
 ALTER TABLE ag.ag_login_surveys
 ADD COLUMN source_id uuid;
 
+-- We add space for the source id in samples as well, as any environmental
+-- sourced samples used to specify their environment directly, but now must
+-- link to the source table.
+-- Note:  We cannot make source_id NOT NULL in ag_kit_barcodes ever, as
+-- there is a time point during the process when samples are unassociated with
+-- sources.  That said, we can still enforce that samples are assigned sources
+-- that do exist within the source table.
+ALTER TABLE ag_kit_barcodes
+ADD COLUMN source_id uuid;
+
+ALTER TABLE ag_kit_barcodes ADD CONSTRAINT fk_ag_kit_barcodes_sources
+FOREIGN KEY (source_id) REFERENCES ag.source (id);
+
 -- Note:  This foreign key reference needs to be detached from ag_consent,
 -- as we are detaching that table.  We will replace this foreign key with a
 -- new one linking the source table in schema 0049 after the data migration.
 ALTER TABLE ag.ag_login_surveys
 DROP CONSTRAINT fk_ag_login_surveys0;
-
 
 -- We deprecate the ag_consent and consent_revoked tables, we will migrate
 -- all the data from them

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -43,7 +43,7 @@ CREATE TABLE ag.source (
 -- migration.
 -- TODO: Add foreign key ref from source_id to source table
 -- TODO: Add not null constraint to source_id
---   TODO's can be done until after migration, verify they are in 0049.sql
+--   TODO's can't be done until after migration, verify they are in 0049.sql
 
 ALTER TABLE ag.ag_login_surveys
 ADD COLUMN source_id uuid;

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -40,11 +40,17 @@ CREATE TABLE ag.source (
 -- We add space for the new source id, we will need to fill it in during the
 -- migration.
 
+-- Note:  We cannot make source_id NOT NULL until after we have filled it
+-- during the migration.  That constraint will be added in 0049.
 ALTER TABLE ag.ag_login_surveys
 ADD COLUMN source_id uuid;
 
+-- Note:  This foreign key reference needs to be detached from ag_consent,
+-- as we are detaching that table.  We will replace this foreign key with a
+-- new one linking the source table in schema 0049 after the data migration.
 ALTER TABLE ag.ag_login_surveys
 DROP CONSTRAINT fk_ag_login_surveys0;
+
 
 -- We deprecate the ag_consent and consent_revoked tables, we will migrate
 -- all the data from them

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -23,7 +23,7 @@ CREATE TABLE ag.source (
     account_id uuid NOT NULL,
     source_type varchar NOT NULL,
     participant_name varchar(200) NOT NULL,
-    participant_email varchar NOT NULL,
+    participant_email varchar,
     is_juvenile bool,
     parent_1_name varchar(200),
     parent_2_name varchar(200),
@@ -34,6 +34,7 @@ CREATE TABLE ag.source (
     date_revoked date,
     assent_obtainer varchar,
     age_range varchar,
+    description varchar,
     creation_time timestamp default current_timestamp,
     update_time timestamp default current_timestamp
 );

--- a/microsetta_private_api/db/patches/0048.sql
+++ b/microsetta_private_api/db/patches/0048.sql
@@ -27,8 +27,6 @@ CREATE TABLE ag.source (
     is_juvenile bool,
     parent_1_name varchar(200),
     parent_2_name varchar(200),
---    parent_1_code varchar(200), -- TODO: Can we drop these two columns?
---    parent_2_code varchar(200),
     deceased_parent bool,
     date_signed date,
     date_revoked date,
@@ -41,9 +39,6 @@ CREATE TABLE ag.source (
 
 -- We add space for the new source id, we will need to fill it in during the
 -- migration.
--- TODO: Add foreign key ref from source_id to source table
--- TODO: Add not null constraint to source_id
---   TODO's can't be done until after migration, verify they are in 0049.sql
 
 ALTER TABLE ag.ag_login_surveys
 ADD COLUMN source_id uuid;
@@ -52,8 +47,7 @@ ALTER TABLE ag.ag_login_surveys
 DROP CONSTRAINT fk_ag_login_surveys0;
 
 -- We deprecate the ag_consent and consent_revoked tables, we will migrate
--- all the data out of them, and then remove them in the next change script
--- TODO: Remove ag_consent_backup, consent_revoked_backup in 0049.sql
+-- all the data from them
 
 ALTER TABLE ag.ag_consent RENAME TO ag_consent_backup;
 

--- a/microsetta_private_api/db/patches/0049.sql
+++ b/microsetta_private_api/db/patches/0049.sql
@@ -1,0 +1,38 @@
+-- This script is the second half of migrating data and constraints from
+-- ag_consent, consent_revoked and ag_login_survey into a new ag.source table
+
+-- Clean up foreign keys and leftover tables after the migration
+
+-- TODO: !!CRITICAL!! - Do we have automated backups in place, or are these
+-- tables our -only- record of data before the migration?  If this is it,
+-- we should drop foreign keys and indexes, but not delete the data until
+-- we're absolutely confident the migration is 100% successful.
+
+-- These alter tables can be removed if we are confident to drop the backups
+ALTER TABLE ag.consent_revoked_backup
+DROP CONSTRAINT fk_consent_revoked;
+
+ALTER TABLE ag.ag_consent_backup
+DROP CONSTRAINT fk_american_gut_consent;
+
+--DROP TABLE ag.consent_revoked_backup;
+--DROP TABLE ag.ag_consent_backup;
+
+-- Replace foreign key constraints in the new schema
+-- Replaces consent_revoked.fk_consent_revoked AND
+-- ag_consent.fk_american_gut_consent
+ALTER TABLE ag.source
+ADD CONSTRAINT fk_source FOREIGN KEY (account_id)
+REFERENCES ag.ag_login (ag_login_id);
+
+-- Replaces ag_login_surveys.fk_ag_login_surveys0
+ALTER TABLE ag.ag_login_surveys
+ADD CONSTRAINT fk_ag_login_surveys0 FOREIGN KEY (ag_login_id, source_id)
+REFERENCES ag.source (account_id, id);
+
+-- Remove duplication of participant_name, this is now keyed by source_id
+DROP INDEX idx_ag_login_surveys;
+DROP INDEX idx_ag_login_surveys_0;
+
+ALTER TABLE ag.ag_login_surveys
+DROP COLUMN participant_name;

--- a/microsetta_private_api/db/patches/0049.sql
+++ b/microsetta_private_api/db/patches/0049.sql
@@ -1,22 +1,16 @@
 -- This script is the second half of migrating data and constraints from
 -- ag_consent, consent_revoked and ag_login_survey into a new ag.source table
 
--- Clean up foreign keys and leftover tables after the migration
-
--- TODO: !!CRITICAL!! - Do we have automated backups in place, or are these
--- tables our -only- record of data before the migration?  If this is it,
--- we should drop foreign keys and indexes, but not delete the data until
--- we're absolutely confident the migration is 100% successful.
-
--- These alter tables can be removed if we are confident to drop the backups
+-- Unlink foreign keys after migration, we will not delete the backups yet.
 ALTER TABLE ag.consent_revoked_backup
 DROP CONSTRAINT fk_consent_revoked;
 
 ALTER TABLE ag.ag_consent_backup
 DROP CONSTRAINT fk_american_gut_consent;
 
---DROP TABLE ag.consent_revoked_backup;
---DROP TABLE ag.ag_consent_backup;
+-- Remove the replaced environmental data column so we don't get out of sync
+ALTER TABLE ag_kit_barcodes
+DROP COLUMN environment_sampled;
 
 -- Replace foreign key constraints in the new schema
 -- Replaces consent_revoked.fk_consent_revoked AND
@@ -29,6 +23,8 @@ REFERENCES ag.ag_login (ag_login_id);
 ALTER TABLE ag.ag_login_surveys
 ADD CONSTRAINT fk_ag_login_surveys0 FOREIGN KEY (ag_login_id, source_id)
 REFERENCES ag.source (account_id, id);
+
+ALTER TABLE ag.ag_login_surveys ALTER COLUMN source_id SET NOT NULL;
 
 -- Remove duplication of participant_name, this is now keyed by source_id
 DROP INDEX idx_ag_login_surveys;

--- a/microsetta_private_api/db/patches/0050.sql
+++ b/microsetta_private_api/db/patches/0050.sql
@@ -30,8 +30,8 @@ CREATE TABLE ag.account (
     longitude double precision,
     cannot_geocode character(1),
     elevation double precision,
-    creation_time timestamp default current_timestamp,
-    update_time timestamp default current_timestamp
+    creation_time timestamptz default current_timestamp,
+    update_time timestamptz default current_timestamp
 );
 
 CREATE UNIQUE INDEX idx_account_email ON ag.account ( email );

--- a/microsetta_private_api/db/patches/0050.sql
+++ b/microsetta_private_api/db/patches/0050.sql
@@ -1,0 +1,40 @@
+-- This script enables the migration of ag.ag_login into the new schema for
+-- accounts.
+
+-- Build update triggers for setting timestamps
+CREATE OR REPLACE FUNCTION update_trigger()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.update_time = current_timestamp;
+    RETURN NEW;
+END
+$$ language 'plpgsql';
+
+ALTER TABLE ag.ag_login RENAME TO ag_login_backup;
+
+-- create table for individual accounts.  Migrated accounts will use
+-- the ag_login_id as their id.
+CREATE TABLE ag.account (
+    id uuid PRIMARY KEY NOT NULL,
+    email varchar,
+    account_type varchar NOT NULL,
+    auth_provider varchar NOT NULL,
+    first_name varchar,
+    last_name varchar,
+    street varchar,
+    city varchar,
+    state varchar,
+    post_code varchar,
+    country_code varchar,
+    latitude double precision,
+    longitude double precision,
+    cannot_geocode character(1),
+    elevation double precision,
+    creation_time timestamp default current_timestamp,
+    update_time timestamp default current_timestamp
+);
+
+CREATE UNIQUE INDEX idx_account_email ON ag.account ( email );
+CREATE TRIGGER update_account_trigger BEFORE UPDATE ON account FOR EACH ROW
+  EXECUTE PROCEDURE update_trigger();
+

--- a/microsetta_private_api/db/patches/0051.sql
+++ b/microsetta_private_api/db/patches/0051.sql
@@ -1,0 +1,29 @@
+-- This script completes the migration of ag.ag_login into accounts
+
+ALTER TABLE ag.ag_kit
+DROP CONSTRAINT fk_ag_kit_to_login_id;
+
+ALTER TABLE ag.ag_login_surveys
+DROP CONSTRAINT fk_ag_login_surveys;
+
+ALTER TABLE ag.source
+DROP CONSTRAINT fk_source;
+
+-- Replaces ag.ag_kit.fk_ag_kit_to_login_id
+ALTER TABLE ag.ag_kit
+ADD CONSTRAINT fk_ag_kit_to_login_id FOREIGN KEY (ag_login_id)
+REFERENCES ag.account (id);
+
+-- Replaces ag.ag_login_surveys.fk_ag_login_surveys
+ALTER TABLE ag.ag_login_surveys
+ADD CONSTRAINT fk_ag_login_surveys FOREIGN KEY (ag_login_id)
+REFERENCES ag.account (id);
+
+-- Replaces ag.source.fk_source
+ALTER TABLE ag.source
+ADD CONSTRAINT fk_source_account FOREIGN KEY (account_id)
+REFERENCES ag.account (id);
+
+-- TODO: !!CRITICAL!! Are we confident to remove the backup table at this time
+--  due to existence of other backup mechanisms?
+--DROP TABLE ag.ag_login_backup

--- a/microsetta_private_api/db/patches/0051.sql
+++ b/microsetta_private_api/db/patches/0051.sql
@@ -23,7 +23,3 @@ REFERENCES ag.account (id);
 ALTER TABLE ag.source
 ADD CONSTRAINT fk_source_account FOREIGN KEY (account_id)
 REFERENCES ag.account (id);
-
--- TODO: !!CRITICAL!! Are we confident to remove the backup table at this time
---  due to existence of other backup mechanisms?
---DROP TABLE ag.ag_login_backup

--- a/microsetta_private_api/model/account.py
+++ b/microsetta_private_api/model/account.py
@@ -2,16 +2,18 @@ from microsetta_private_api.model.model_base import ModelBase
 
 
 class Account(ModelBase):
-    def __init__(self, account_id, email, auth_provider,
-                 first_name, last_name, address, account_type,
+    def __init__(self, account_id, email,
+                 account_type, auth_provider,
+                 first_name, last_name,
+                 address,
                  creation_time=None, update_time=None):
         self.id = account_id
         self.email = email
+        self.account_type = account_type
         self.auth_provider = auth_provider
         self.first_name = first_name
         self.last_name = last_name
         self.address = address
-        self.account_type = account_type
         self.creation_time = creation_time
         self.update_time = update_time
 

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -33,7 +33,7 @@ def environment_decoder(obj):
 class HumanInfo:
     def __init__(self, name, email, is_juvenile,
                  parent1_name, parent2_name, deceased_parent,
-                 consent_date, assent_obtainer, age_range):
+                 consent_date, date_revoked, assent_obtainer, age_range):
         self.name = name
         self.email = email
         self.is_juvenile = is_juvenile
@@ -41,6 +41,7 @@ class HumanInfo:
         self.parent2_name = parent2_name
         self.deceased_parent = deceased_parent
         self.consent_date = consent_date
+        self.date_revoked = date_revoked
         self.assent_obtainer = assent_obtainer
         self.age_range = age_range
 

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -12,6 +12,7 @@ def human_decoder(obj):
             obj["parent2_name"],
             obj["deceased_parent"],
             obj["consent_date"],
+            obj["date_revoked"],
             obj["assent_obtainer"],
             obj["age_range"])
     return obj

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -85,7 +85,7 @@ class Source(ModelBase):
                         "parent_2_name": self.parent2_name,
                         "deceased_parent": (self.parent1_deceased or
                                             self.parent2_deceased),
-                        "obtainer_name": None  # TODO: What is this???
+                        "obtainer_name": self.source_data.assent_obtainer
                     }
                 else:
                     consent = {

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -9,10 +9,10 @@ def human_decoder(obj):
             obj["email"],
             obj["is_juvenile"],
             obj["parent1_name"],
-            obj["parent1_deceased"],
             obj["parent2_name"],
-            obj["parent2_deceased"],
+            obj["deceased_parent"],
             obj["consent_date"],
+            obj["assent_obtainer"],
             obj["age_range"])
     return obj
 
@@ -31,17 +31,16 @@ def environment_decoder(obj):
 
 class HumanInfo:
     def __init__(self, name, email, is_juvenile,
-                 parent1_name, parent1_deceased,
-                 parent2_name, parent2_deceased,
-                 consent_date, age_range):
+                 parent1_name, parent2_name, deceased_parent,
+                 consent_date, assent_obtainer, age_range):
         self.name = name
         self.email = email
         self.is_juvenile = is_juvenile
         self.parent1_name = parent1_name
-        self.parent1_deceased = parent1_deceased
         self.parent2_name = parent2_name
-        self.parent2_deceased = parent2_deceased
+        self.deceased_parent = deceased_parent
         self.consent_date = consent_date
+        self.assent_obtainer = assent_obtainer
         self.age_range = age_range
 
 

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -1,6 +1,5 @@
 from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.model.account import Account
-import json
 
 
 class AccountRepo(BaseRepo):

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -66,9 +66,12 @@ class AccountRepo(BaseRepo):
     def update_account(self, account):
         with self._transaction.cursor() as cur:
             row = AccountRepo._account_to_row(account)
+
+            # Shift id to end since it appears in the WHERE clause
             row_id = row[0:1]
             row_email_to_cc = row[1:]
             final_row = row_email_to_cc + row_id
+
             cur.execute("UPDATE account "
                         "SET "
                         "email = %s, "

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -7,23 +7,53 @@ class AccountRepo(BaseRepo):
     def __init__(self, transaction):
         super().__init__(transaction)
 
-    read_cols = "id, email, auth_provider, first_name, last_name, address, " \
-                "account_type, creation_time, update_time"
-    write_cols = "id, email, auth_provider, first_name, last_name, address, " \
-                 "account_type"
+    read_cols = "id, email, " \
+                "account_type, auth_provider, " \
+                "first_name, last_name, " \
+                "street, city, state, post_code, country_code, " \
+                "creation_time, update_time"
+
+    write_cols = "id, email, " \
+                 "account_type, auth_provider, " \
+                 "first_name, last_name, " \
+                 "street, city, state, post_code, country_code"
+
+    @staticmethod
+    def _row_to_addr(r):
+        return {
+            "street": r["street"],
+            "city": r["city"],
+            "state": r["state"],
+            "post_code": r["post_code"],
+            "country_code": r["country_code"]
+        }
+
+    @staticmethod
+    def _addr_to_row(addr):
+        return (addr["street"],
+                addr["city"],
+                addr["state"],
+                addr["post_code"],
+                addr["country_code"])
 
     @staticmethod
     def _row_to_account(r):
-        return Account(r[0], r[1], r[2], r[3], r[4],
-                       json.loads(r[5]), r[6], r[7], r[8])
+        return Account(
+            r['id'], r['email'],
+            r['account_type'], r['auth_provider'],
+            r['first_name'], r['last_name'],
+            AccountRepo._row_to_addr(r),
+            r['creation_time'], r['update_time'])
 
     @staticmethod
     def _account_to_row(a):
-        return (a.id, a.email, a.auth_provider, a.first_name, a.last_name,
-                json.dumps(a.address), a.account_type)
+        return (a.id, a.email,
+                a.account_type, a.auth_provider,
+                a.first_name, a.last_name) + \
+               AccountRepo._addr_to_row(a.address)
 
     def get_account(self, account_id):
-        with self._transaction.cursor() as cur:
+        with self._transaction.dict_cursor() as cur:
             cur.execute("SELECT " + AccountRepo.read_cols + " FROM "
                         "account "
                         "WHERE "
@@ -36,23 +66,38 @@ class AccountRepo(BaseRepo):
 
     def update_account(self, account):
         with self._transaction.cursor() as cur:
+            row = AccountRepo._account_to_row(account)
+            row_id = row[0:1]
+            row_email_to_cc = row[1:]
+            final_row = row_email_to_cc + row_id
             cur.execute("UPDATE account "
                         "SET "
-                        "email = %s, auth_provider = %s, first_name = %s, "
-                        "last_name = %s, address = %s, account_type = %s "
+                        "email = %s, "
+                        "account_type = %s, "
+                        "auth_provider = %s, "
+                        "first_name = %s, "
+                        "last_name = %s, "
+                        "street = %s, "
+                        "city = %s, "
+                        "state = %s, "
+                        "post_code = %s, "
+                        "country_code = %s "
                         "WHERE "
                         "account.id = %s",
-                        (account.email, account.auth_provider,
-                         account.first_name, account.last_name,
-                         json.dumps(account.address), account.account_type,
-                         account.id)
+                        final_row
                         )
             return cur.rowcount == 1
 
     def create_account(self, account):
         with self._transaction.cursor() as cur:
-            cur.execute("INSERT INTO account (" + AccountRepo.write_cols + ") "
-                        "VALUES(%s, %s, %s, %s, %s, %s, %s)",
+            cur.execute("INSERT INTO account (" +
+                        AccountRepo.write_cols +
+                        ") "
+                        "VALUES("
+                        "%s, %s, "
+                        "%s, %s, "
+                        "%s, %s, "
+                        "%s, %s, %s, %s, %s)",
                         AccountRepo._account_to_row(account))
             return cur.rowcount == 1
 

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -12,74 +12,132 @@ class SourceRepo(BaseRepo):
     def __init__(self, transaction):
         super().__init__(transaction)
 
-    read_cols = "id, account_id, source_type, source_data, " \
+    read_cols = "id, account_id, " \
+                "source_type, participant_name, participant_email, " \
+                "is_juvenile, parent_1_name, parent_2_name, " \
+                "deceased_parent, date_signed, date_revoked, " \
+                "assent_obtainer, age_range, description, " \
                 "creation_time, update_time"
-    write_cols = "id, account_id, source_type, source_data"
+
+    write_cols = "id, account_id, source_type, " \
+                 "participant_name, participant_email, " \
+                 "is_juvenile, parent_1_name, parent_2_name, " \
+                 "deceased_parent, date_signed, date_revoked, " \
+                 "assent_obtainer, age_range, description"
 
     @staticmethod
     def _row_to_source(r):
-        hook = DECODER_HOOKS[r[2]]
-        return Source(r[0], r[1], r[2], json.loads(r[3], object_hook=hook))
+        hook = DECODER_HOOKS[r['source_type']]
+        source_data = {
+            'name': r['participant_name'],
+            'email': r['participant_email'],
+            'is_juvenile': r['is_juvenile'],
+            'parent1_name': r['parent_1_name'],
+            'parent2_name': r['parent_2_name'],
+            'deceased_parent': r['deceased_parent'],
+            'consent_date': r['date_signed'],
+            'date_revoked': r['date_revoked'],
+            'assent_obtainer': r['assent_obtainer'],
+            'age_range': r['age_range'],
+            'description': r['description']
+        }
+        return Source(r[0], r[1], r[2], hook(source_data))
 
     @staticmethod
     def _source_to_row(s):
-        row = (s.id, s.account_id, s.source_type,
-               json.dumps(s.source_data, default=json_converter))
+        d = s.source_data
+        row = (s.id,
+               s.account_id,
+               s.source_type,
+               getattr(d, 'name', None),
+               getattr(d, 'email', None),
+               getattr(d, 'is_juvenile', None),
+               getattr(d, 'parent1_name', None),
+               getattr(d, 'parent2_name', None),
+               getattr(d, 'deceased_parent', None),
+               getattr(d, 'consent_date', None),
+               getattr(d, 'date_revoked', None),
+               getattr(d, 'assent_obtainer', None),
+               getattr(d, 'age_range', None),
+               getattr(d, 'description', None))
         return row
 
     def get_sources_in_account(self, account_id, source_type=None):
-        with self._transaction.cursor() as cur:
+        with self._transaction.dict_cursor() as cur:
             if source_type is None:
                 cur.execute("SELECT " + SourceRepo.read_cols + " FROM "
                             "source "
                             "WHERE "
-                            "source.account_id = %s", (account_id,))
+                            "source.account_id = %s AND "
+                            "source.date_revoked IS NULL",
+                            (account_id,))
             else:
                 cur.execute("SELECT " + SourceRepo.read_cols + " FROM "
                             "source "
                             "WHERE "
                             "source.account_id = %s AND "
-                            "source.source_type = %s",
+                            "source.source_type = %s AND "
+                            "source.date_revoked IS NULL",
                             (account_id, source_type))
 
             rows = cur.fetchall()
             return [SourceRepo._row_to_source(x) for x in rows]
 
     def get_source(self, account_id, source_id):
-        with self._transaction.cursor() as cur:
+        with self._transaction.dict_cursor() as cur:
             cur.execute("SELECT " + SourceRepo.read_cols + " FROM "
                         "source "
                         "WHERE "
                         "source.id = %s AND "
-                        "source.account_id = %s", (source_id, account_id))
+                        "source.account_id = %s AND "
+                        "source.date_revoked IS NULL",
+                        (source_id, account_id))
             r = cur.fetchone()
             if r is None:
                 return None
             return SourceRepo._row_to_source(r)
 
     def update_source_data(self, source):
+        row = SourceRepo._source_to_row(source)
+        row_type_to_desc = row[2:]
+        row_id_and_acct = row[0:2]
+        final_row = row_type_to_desc + row_id_and_acct
         with self._transaction.cursor() as cur:
             cur.execute("UPDATE source "
                         "SET "
-                        "source_data = %s "
+                        "source_type = %s, "
+                        "participant_name = %s, "
+                        "participant_email = %s, "
+                        "is_juvenile = %s, "
+                        "parent_1_name = %s, "
+                        "parent_2_name = %s, "
+                        "deceased_parent = %s, "
+                        "date_signed = %s, "
+                        "date_revoked = %s, "
+                        "assent_obtainer = %s, "
+                        "age_range = %s, "
+                        "description = %s"                        
                         "WHERE "
                         "source.id = %s AND "
                         "source.account_id = %s",
-                        (json.dumps(source.source_data),
-                         source.id, source.account_id)
-                        )
+                        final_row)
             return cur.rowcount == 1
 
     def create_source(self, source):
         with self._transaction.cursor() as cur:
             cur.execute("INSERT INTO source (" + SourceRepo.write_cols + ") "
-                        "VALUES(%s, %s, %s, %s)",
+                        "VALUES("
+                        "%s, %s, %s, "
+                        "%s, %s, "
+                        "%s, %s, %s, "
+                        "%s, %s, %s, "
+                        "%s, %s, %s)",
                         SourceRepo._source_to_row(source))
             return cur.rowcount == 1
 
     def delete_source(self, account_id, source_id):
         with self._transaction.cursor() as cur:
             cur.execute("DELETE FROM source WHERE source.id = %s AND "
-                        "source.account_id=%s",
+                        "source.account_id = %s",
                         (source_id, account_id))
             return cur.rowcount == 1

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -11,14 +11,14 @@ class SourceRepo(BaseRepo):
         super().__init__(transaction)
 
     read_cols = "id, account_id, " \
-                "source_type, participant_name, participant_email, " \
+                "source_type, source_name, participant_email, " \
                 "is_juvenile, parent_1_name, parent_2_name, " \
                 "deceased_parent, date_signed, date_revoked, " \
                 "assent_obtainer, age_range, description, " \
                 "creation_time, update_time"
 
     write_cols = "id, account_id, source_type, " \
-                 "participant_name, participant_email, " \
+                 "source_name, participant_email, " \
                  "is_juvenile, parent_1_name, parent_2_name, " \
                  "deceased_parent, date_signed, date_revoked, " \
                  "assent_obtainer, age_range, description"
@@ -27,7 +27,7 @@ class SourceRepo(BaseRepo):
     def _row_to_source(r):
         hook = DECODER_HOOKS[r['source_type']]
         source_data = {
-            'name': r['participant_name'],
+            'name': r['source_name'],
             'email': r['participant_email'],
             'is_juvenile': r['is_juvenile'],
             'parent1_name': r['parent_1_name'],
@@ -107,7 +107,7 @@ class SourceRepo(BaseRepo):
             cur.execute("UPDATE source "
                         "SET "
                         "source_type = %s, "
-                        "participant_name = %s, "
+                        "source_name = %s, "
                         "participant_email = %s, "
                         "is_juvenile = %s, "
                         "parent_1_name = %s, "

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -97,9 +97,12 @@ class SourceRepo(BaseRepo):
 
     def update_source_data(self, source):
         row = SourceRepo._source_to_row(source)
+
+        # Rotate id, account.id to end for the where clause
         row_type_to_desc = row[2:]
         row_id_and_acct = row[0:2]
         final_row = row_type_to_desc + row_id_and_acct
+
         with self._transaction.cursor() as cur:
             cur.execute("UPDATE source "
                         "SET "

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -1,7 +1,5 @@
 from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.model.source import (Source, DECODER_HOOKS)
-import json
-from microsetta_private_api.util.util import json_converter
 
 
 # Note: By convention, this references sources by both account_id AND source_id
@@ -116,7 +114,7 @@ class SourceRepo(BaseRepo):
                         "date_revoked = %s, "
                         "assent_obtainer = %s, "
                         "age_range = %s, "
-                        "description = %s"                        
+                        "description = %s "
                         "WHERE "
                         "source.id = %s AND "
                         "source.account_id = %s",

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -1,5 +1,6 @@
 from microsetta_private_api.config_manager import AMGUT_CONFIG
 import psycopg2.pool
+import psycopg2.extras
 import atexit
 
 

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -53,3 +53,10 @@ class Transaction:
         cur = self._conn.cursor()
         cur.execute('SET search_path TO ag, barcodes, public')
         return cur
+
+    def dict_cursor(self):
+        if self._closed:
+            raise RuntimeError("Cannot open cursor from closed Transaction")
+        cur = self._conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+        cur.execute('SET search_path TO ag, barcodes, public')
+        return cur

--- a/repo_test_scratch.py
+++ b/repo_test_scratch.py
@@ -85,7 +85,7 @@ with Transaction() as t:
         ACCT_ID,
         HumanInfo("Bo", "bo@bo.com", False, "Mr Bo", "Mrs Bo",
                   False, datetime.datetime.utcnow(), None, "Mr. Obtainer",
-                  "18+")
+                  "18-plus")
     ))
     source_repo.create_source(Source.create_animal(
         DOGGY_ID,

--- a/repo_test_scratch.py
+++ b/repo_test_scratch.py
@@ -17,6 +17,8 @@ import microsetta_private_api.util.vue_adapter
 def json_converter(o):
     if isinstance(o, datetime.datetime):
         return str(o)
+    elif isinstance(o, datetime.date):
+        return str(o)
     return o.__dict__
 
 
@@ -36,11 +38,17 @@ with Transaction() as t:
     acct_repo.delete_account(ACCT_ID)
     acc = Account(ACCT_ID,
                   "foo@baz.com",
-                  "globus",
+                  "standard",
+                  "GLOBUS",
                   "Dan",
                   "H",
-                  '{"a":5, "b":7}',
-                  "USER")
+                  {
+                      "street": "123 Dan Lane",
+                      "city": "Danville",
+                      "state": "CA",
+                      "post_code": 12345,
+                      "country_code": "US"
+                  })
     print(acct_repo.create_account(acc))
     t.commit()
 
@@ -69,8 +77,8 @@ with Transaction() as t:
     source_repo.create_source(Source.create_human(
         HUMAN_ID,
         ACCT_ID,
-        HumanInfo("Bo", "bo@bo.com", False, "Mr Bo", False, "Mrs Bo",
-                  False, datetime.datetime.utcnow(), "TODO,WutDis?")
+        HumanInfo("Bo", "bo@bo.com", False, "Mr Bo", "Mrs Bo",
+                  False, datetime.datetime.utcnow(), None, "Mr. Obtainer", "18+")
     ))
     source_repo.create_source(Source.create_animal(
         DOGGY_ID,

--- a/repo_test_scratch.py
+++ b/repo_test_scratch.py
@@ -13,7 +13,6 @@ import microsetta_private_api.util.vue_adapter
 
 # TODO: Refactor me into proper unit tests!
 
-
 def json_converter(o):
     if isinstance(o, datetime.datetime):
         return str(o)
@@ -29,13 +28,22 @@ PLANTY_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
 
 
 with Transaction() as t:
+    source_repo = SourceRepo(t)
+    acct_repo = AccountRepo(t)
+    source_repo.delete_source(ACCT_ID, DOGGY_ID)
+    source_repo.delete_source(ACCT_ID, PLANTY_ID)
+    source_repo.delete_source(ACCT_ID, HUMAN_ID)
+    acct_repo.delete_account(ACCT_ID)
+    t.commit()
+
+
+with Transaction() as t:
+    acct_repo = AccountRepo(t)
     kit_repo = KitRepo(t)
     kit = kit_repo.get_kit("eba20873-b88d-33cc-e040-8a80115d392c", "#6á$E")
     print("Kit: ")
     print(json.dumps(kit, default=json_converter, indent=2))
 
-    acct_repo = AccountRepo(t)
-    acct_repo.delete_account(ACCT_ID)
     acc = Account(ACCT_ID,
                   "foo@baz.com",
                   "standard",
@@ -70,9 +78,6 @@ with Transaction() as t:
 
 with Transaction() as t:
     source_repo = SourceRepo(t)
-    source_repo.delete_source(ACCT_ID, DOGGY_ID)
-    source_repo.delete_source(ACCT_ID, PLANTY_ID)
-    source_repo.delete_source(ACCT_ID, HUMAN_ID)
 
     source_repo.create_source(Source.create_human(
         HUMAN_ID,
@@ -127,7 +132,7 @@ with Transaction() as t:
     survey_answers_repo = SurveyAnswersRepo(t)
     survey_ids = survey_answers_repo.list_answered_surveys(
         'd8592c74-7fc4-2135-e040-8a80115d6401',
-        'Name - 7O],Gß[1Y1')
+        'f1ee05c8-7d0d-466a-b200-868eded0edec')
 
     print(survey_ids)
 
@@ -138,15 +143,15 @@ with Transaction() as t:
     print(survey_model)
 
     answer_id = survey_answers_repo.submit_answered_survey(
-        'd8592c74-7fc4-2135-e040-8a80115d6401',
-        "DOGGY!",
+        ACCT_ID,
+        DOGGY_ID,
         "en_us",
         1,
         survey_model
     )
 
     survey_model2 = survey_answers_repo.get_answered_survey(
-        'd8592c74-7fc4-2135-e040-8a80115d6401',
+        ACCT_ID,
         answer_id)
 
     print(survey_model2)

--- a/repo_test_scratch.py
+++ b/repo_test_scratch.py
@@ -13,6 +13,7 @@ import microsetta_private_api.util.vue_adapter
 
 # TODO: Refactor me into proper unit tests!
 
+
 def json_converter(o):
     if isinstance(o, datetime.datetime):
         return str(o)
@@ -83,7 +84,8 @@ with Transaction() as t:
         HUMAN_ID,
         ACCT_ID,
         HumanInfo("Bo", "bo@bo.com", False, "Mr Bo", "Mrs Bo",
-                  False, datetime.datetime.utcnow(), None, "Mr. Obtainer", "18+")
+                  False, datetime.datetime.utcnow(), None, "Mr. Obtainer",
+                  "18+")
     ))
     source_repo.create_source(Source.create_animal(
         DOGGY_ID,
@@ -158,4 +160,3 @@ with Transaction() as t:
     print(survey_model == survey_model2)
 
     survey_answers_repo.delete_answered_survey(ACCT_ID, answer_id)
-

--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,3 @@ setup(
     description="A RESTful API to support The Microsetta Initiative",
     license='BSD-3-Clause',
 )
-


### PR DESCRIPTION
Implements data migration!  
This Fixes #24, Fixes #29, Fixes #30, Fixes #40, Fixes #42 

There is now a small framework for using python to migrate existing data
There is now an account table and a source table.
The account table has the migrated data from ag_login.
The source table has the migrated data from ag_consent, consent_revoked
Foreign key constraints have been dropped and re-added to point to the new tables
ag_login_surveys now references sources by their source id, rather than their name.  

This one is a hefty change, and migrations are hard to revert.  Suggest we do a full in person review before merging.  