### PR TITLE
Issue 81

### DIFF
--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -29,7 +29,7 @@ from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.sample_repo import SampleRepo
 
 from microsetta_private_api.model.account import Account
-from microsetta_private_api.model.source import Source
+from microsetta_private_api.model.source import Source, info_from_api
 from microsetta_private_api.model.source import human_info_from_api
 from microsetta_private_api.LEGACY.locale_data import american_gut, british_gut
 
@@ -205,11 +205,7 @@ def update_source(account_id, source_id, body):
         source_repo = SourceRepo(t)
         source = source_repo.get_source(account_id, source_id)
 
-        # Uhhh, where do I get source_data from???
-        # source.source_data = something?
-        # TODO: Answer: source data is coming in in the request body,
-        #  Fill it in!
-
+        source.source_data = Source.info_from_api(body)
         source_repo.update_source_data(source)
         # I wonder if there's some way to get the creation_time/update_time
         # during the insert/update...

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -205,8 +205,8 @@ def update_source(account_id, source_id, body):
         source_repo = SourceRepo(t)
         source = source_repo.get_source(account_id, source_id)
 
-        source.source_data = Source.info_from_api(body)
-        source_repo.update_source_data(source)
+        source.source_data = info_from_api(body)
+        source_repo.update_source_data_api_fields(source)
         # I wonder if there's some way to get the creation_time/update_time
         # during the insert/update...
         source = source_repo.get_source(account_id, source_id)

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -275,7 +275,6 @@ class IntegrationTests(TestCase):
         self.assertEqual(to_edit["source_description"],
                          edit_resp["source_description"])
 
-
     def test_surveys(self):
         resp = self.client.get(
             '/api/accounts/%s/sources?language_tag=en-US' % ACCT_ID)

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -3,18 +3,18 @@ from werkzeug.exceptions import BadRequest
 
 
 def info_from_api(api_obj):
-    if api_obj.source_type == Source.SOURCE_TYPE_HUMAN:
+    if api_obj["source_type"] == Source.SOURCE_TYPE_HUMAN:
         # Note: consent_date and date_revoked aren't sent over the api
         # so will be lost in translation
         return human_info_from_api(api_obj,
                                    consent_date=None,
                                    date_revoked=None)
-    elif api_obj.source_type == Source.SOURCE_TYPE_ANIMAL:
+    elif api_obj["source_type"] == Source.SOURCE_TYPE_ANIMAL:
         return animal_decoder(api_obj)
-    elif api_obj.source_type == Source.SOURCE_TYPE_ENVIRONMENT:
+    elif api_obj["source_type"] == Source.SOURCE_TYPE_ENVIRONMENT:
         return environment_decoder(api_obj)
     else:
-        raise BadRequest("Unknown source_type: " + str(api_obj.source_type))
+        raise BadRequest("Unknown source_type: " + str(api_obj["source_type"]))
 
 
 def human_info_from_api(human_source, consent_date, date_revoked):


### PR DESCRIPTION
Fixes #81 

Looks like I missed implementing the PUT Source functionality.  Had to specify which fields they could edit, so I restricted them to just source_name and source_description for now.  Not sure how much of a pain it would be to specify just these fields in the yaml and everything else readonly.  

Also noticed the GET on source was never updated after we added the source_description fields, so we that's in now too.  

Unit tests for both.  