### PR TITLE
403 removal and more

### DIFF
--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -240,10 +240,13 @@ def read_survey_templates(account_id, source_id, language_tag):
         source = source_repo.get_source(account_id, source_id)
         if source is None:
             return jsonify(code=404, message="No source found"), 404
+        template_repo = SurveyTemplateRepo(t)
         if source.source_type == Source.SOURCE_TYPE_HUMAN:
-            return jsonify([1, 3, 4, 5]), 200
+            return jsonify([template_repo.get_survey_template_link_info(x)
+                           for x in [1, 3, 4, 5]]), 200
         elif source.source_type == Source.SOURCE_TYPE_ANIMAL:
-            return jsonify([2]), 200
+            return jsonify([template_repo.get_survey_template_link_info(x)
+                           for x in [2]]), 200
         else:
             return jsonify([]), 200
 
@@ -284,7 +287,12 @@ def read_answered_survey(account_id, source_id, survey_id, language_tag):
         if not survey_answers:
             return jsonify(code=404, message="No survey answers found"), 404
 
-        return jsonify(survey_answers), 200
+        template_id = survey_answers_repo.find_survey_template_id(survey_id)
+        template_repo = SurveyTemplateRepo(t)
+        link_info = template_repo.get_survey_template_link_info(template_id)
+        link_info.survey_id = survey_id
+        link_info.survey_text = survey_answers
+        return jsonify(link_info), 200
 
 
 def submit_answered_survey(account_id, source_id, language_tag, body):

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -85,7 +85,7 @@ def register_account(body):
         kit_repo = KitRepo(t)
         kit = kit_repo.get_kit(body['kit_name'])
         if kit is None:
-            return jsonify(error=403, text="Incorrect kit_name"), 403
+            return jsonify(error=404, text="Kit name not found"), 404
 
         acct_repo = AccountRepo(t)
         acct_repo.create_account(Account(

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -447,7 +447,6 @@ def dissociate_answered_survey(account_id, source_id, sample_id, survey_id):
 def read_kit(kit_name):
     with Transaction() as t:
         kit_repo = KitRepo(t)
-        # TODO: Ensure this name is what the repo layer expects
         kit = kit_repo.get_kit(kit_name)
         if kit is None:
             return jsonify(code=404, message="No such kit"), 404

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -256,9 +256,12 @@ def read_survey_template(account_id, source_id, survey_template_id,
 
     with Transaction() as t:
         survey_template_repo = SurveyTemplateRepo(t)
+        info = survey_template_repo.get_survey_template_link_info(
+            survey_template_id)
         survey_template = survey_template_repo.get_survey_template(
             survey_template_id, language_tag)
-        return jsonify(vue_adapter.to_vue_schema(survey_template)), 200
+        info.survey_template_text = vue_adapter.to_vue_schema(survey_template)
+        return jsonify(info), 200
 
 
 def read_answered_surveys(account_id, source_id, language_tag):

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -483,7 +483,8 @@ def render_consent_doc(account_id, language_tag):
     return render_template("new_participant.jinja2",
                            message=None,
                            media_locale=media_locales[language_tag],
-                           tl=tls[language_tag])
+                           tl=tls[language_tag],
+                           lang_tag=language_tag)
 
 
 def create_human_source_from_consent(account_id, body):

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1127,8 +1127,8 @@ components:
       type: string # someday could be an enum if we know choices
       example: "local"
     survey_template_version:
-      type: number
-      example: 0.1
+      type: string
+      example: "0.1"
     survey_template_text:
       # The contents of this string ARE structured, but their structure is not specified in THIS api.
       # Could be *either* vue-compatible json to be used to generate an HTML form OR

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -45,8 +45,8 @@ paths:
                 $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
-        '403':
-          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
@@ -869,12 +869,6 @@ components:
   responses:
     401Unauthorized:   # Can be referenced as '#/components/responses/401Unauthorized'
       description: Invalid or missing token.
-    403Forbidden:      # Can be referenced as '#/components/responses/403Forbidden'
-      description: Incorrect required parameter.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Error'
     404NotFound:       # Can be referenced as '#/components/responses/404NotFound'
       description: The specified resource was not found.
     422UnprocessableEntity:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1007,6 +1007,7 @@ components:
     sample_projects:
       type: array
       readOnly: true # sent in GET, not in POST/PUT/PATCH
+      nullable: true
       items:
         $ref: '#/components/schemas/sample_project'
       example:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1133,7 +1133,7 @@ components:
       # The contents of this string ARE structured, but their structure is not specified in THIS api.
       # Could be *either* vue-compatible json to be used to generate an HTML form OR
       # a customized link to direct to an external survey
-      type: string
+      type: object
       example: '{ |
                   "groups": [ |
                     { |
@@ -1208,7 +1208,6 @@ components:
         - survey_template_title
         - survey_template_version
         - survey_template_type
-      additionalProperties: false
 
     # survey section
     survey_id:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -987,6 +987,7 @@ components:
       type: string
       format: date-time
       example: "2017-07-21T17:32:28Z"
+      nullable: true
     sample_id:
       type: string
       readOnly: true # sent in GET, not in POST/PUT/PATCH

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -115,10 +115,6 @@ paths:
       responses:
         '200':
           description: Consent form
-          headers:
-            Location:
-              schema:
-                type: string
           content:
             text/html:
               schema:
@@ -940,6 +936,11 @@ components:
           $ref: '#/components/schemas/creation_time'
         update_time:
           $ref: '#/components/schemas/update_time'
+      required:
+        - first_name
+        - last_name
+        - email
+        - address
     address:   # taken from https://opensource.zalando.com/restful-api-guidelines/#address-fields
       description:
         an address of a location/destination

--- a/microsetta_private_api/api/tests/test_api_yaml.py
+++ b/microsetta_private_api/api/tests/test_api_yaml.py
@@ -5,10 +5,13 @@ import json
 import microsetta_private_api.server
 from urllib.parse import urlencode
 from unittest import TestCase
-from microsetta_private_api.api.tests.test_integration import ACCT_ID
 
 
 # region helper methods
+QUERY_KEY = "query"
+CONTENT_KEY = "content"
+
+
 def dictionary_mangler(a_dict, delete_fields=True, parent_dicts=None):
     """Generator to delete fields or add bogus fields in nested dictionary.
 
@@ -36,11 +39,6 @@ def dictionary_mangler(a_dict, delete_fields=True, parent_dicts=None):
         if curr_dicts is None:
             curr_dicts = copy.deepcopy(parent_dicts)
         yield mangle_dictionary(a_dict, curr_dicts)
-
-
-URL_KEY = "url"
-QUERY_KEY = "query"
-CONTENT_KEY = "content"
 
 
 def mangle_dictionary(a_dict, curr_dicts, key_to_delete=None):
@@ -135,8 +133,6 @@ class IntegrationTests(TestCase):
             # next deleted field
         # next dict to test
 
-    # region account
-
     def test_accounts_post_without_required_fields(self):
         """Not providing any required field returns validation fail code"""
 
@@ -161,50 +157,3 @@ class IntegrationTests(TestCase):
                                                        dicts_to_test,
                                                        content_dict,
                                                        self.lang_query_dict)
-
-    # def test_account_get_without_required_fields(self):
-    #     """Not providing any required field returns validation fail code"""
-    #
-    #     content_dict = {}
-    #
-    #     dicts_to_test = {QUERY_KEY: self.lang_query_dict,
-    #                      CONTENT_KEY: content_dict}
-    #
-    #     url = "/api/account/{0}".format(ACCT_ID)
-    #     self.run_query_and_content_required_field_test(url,
-    #                                                    dicts_to_test,
-    #                                                    content_dict,
-    #                                                    self.lang_query_dict)
-
-    # def test_accounts_post_with_extra_fields(self):
-    #     """Providing any field not in api returns validation fail code"""
-    #     my_dict = {
-    #         "address": {
-    #             "city": "Springfield",
-    #             "country_code": "US",
-    #             "post_code": "12345",
-    #             "state": "shouldn't have to be here",
-    #             "street": "123 Main St. E. Apt. 2"
-    #         },
-    #         "email": "janedoe@example.com",
-    #         "first_name": "Jane",
-    #         "last_name": "Doe",
-    #         "kit_name": "jb_qhxqe"
-    #     }
-    #
-    #     field_adder = dictionary_mangler(my_dict, delete_fields=False)
-    #     for i in field_adder:
-    #         print(i)
-    #         acct_json = json.dumps(i)
-    #         continue
-    #
-    #         response = self.client.post(
-    #             '/api/accounts?language_tag=en-US',
-    #             content_type='application/json',
-    #             data=acct_json
-    #         )
-    #
-    #         self.assertEqual(400, response.status_code)
-    #         resp_obj = json.loads(response.data)
-    #         self.assertTrue("is a required property" in resp_obj['detail'])
-    # endregion account post

--- a/microsetta_private_api/api/tests/test_api_yaml.py
+++ b/microsetta_private_api/api/tests/test_api_yaml.py
@@ -1,0 +1,211 @@
+import pytest
+import copy
+import collections
+import json
+import microsetta_private_api.server
+from urllib.parse import urlencode
+from unittest import TestCase
+from microsetta_private_api.api.tests.test_integration import ACCT_ID
+
+
+# region helper methods
+def dictionary_mangler(a_dict, delete_fields=True, parent_dicts=None):
+    """Generator to delete fields or add bogus fields in nested dictionary.
+
+    Create a generator to travel recursively through the provided dictionary
+    (which may contain child dictionaries).  If delete_fields, then for every
+    leaf field, yield a copy of the whole dictionary with just that field
+    deleted.  If not delete_fields, then for every leaf dictionary, yield a
+    copy of the whole dictionary with one unexpected, bogus field added."""
+    if parent_dicts is None:
+        parent_dicts = collections.OrderedDict()
+        parent_dicts["top"] = copy.deepcopy(a_dict)
+    curr_dicts = {}
+
+    for curr_key, curr_val in a_dict.items():
+        curr_dicts = copy.deepcopy(parent_dicts)
+        if isinstance(curr_val, dict):
+            curr_dicts[curr_key] = curr_val
+            yield from dictionary_mangler(curr_val, delete_fields,
+                                          curr_dicts)
+        else:
+            if delete_fields:
+                yield mangle_dictionary(a_dict, curr_dicts, curr_key)
+
+    if not delete_fields:
+        if curr_dicts is None:
+            curr_dicts = copy.deepcopy(parent_dicts)
+        yield mangle_dictionary(a_dict, curr_dicts)
+
+
+URL_KEY = "url"
+QUERY_KEY = "query"
+CONTENT_KEY = "content"
+
+
+def mangle_dictionary(a_dict, curr_dicts, key_to_delete=None):
+    """Return copy of nested dictionary with a field popped or added.
+
+     The popped or added field may be at any level of nesting within the
+     original dictionary.  `curr_dicts` is an OrderedDict containing each
+     nested dictionary in the original dictionary we are looping through
+     (not necessarily the same as a_dict).  The first entry has the key "top"
+     and holds the entire original dictionary. The second entry has the key of
+     whatever the first nested dictionary is, and the value of that whole
+     nested dictionary.  If that has nested dictionaries
+     within it, they will be represented in the subsequent key/values, etc."""
+    curr_dict = a_dict.copy()
+    if key_to_delete is not None:
+        curr_dict.pop(key_to_delete)
+    else:
+        curr_dict["disallowed_key"] = "bogus_value"
+    curr_parent_key, _ = curr_dicts.popitem(True)
+
+    q = len(curr_dicts.keys())
+    while q > 0:
+        next_parent_key, next_parent_dict = curr_dicts.popitem(True)
+        next_parent_dict[curr_parent_key] = copy.deepcopy(curr_dict)
+        curr_dict = copy.deepcopy(next_parent_dict)
+        curr_parent_key = next_parent_key
+        q = q - 1
+
+    return curr_dict
+# endregion help methods
+
+
+@pytest.fixture(scope="class")
+def client(request):
+    app = microsetta_private_api.server.build_app()
+    app.app.testing = True
+    with app.app.test_client() as client:
+        request.cls.client = client
+        yield client
+
+
+@pytest.mark.usefixtures("client")
+class IntegrationTests(TestCase):
+    lang_query_dict = {
+        "language_tag": "en_US"
+    }
+
+    def setUp(self):
+        app = microsetta_private_api.server.build_app()
+        self.client = app.app.test_client()
+        # This isn't perfect, due to possibility of exceptions being thrown
+        # is there some better pattern I can use to split up what should be
+        # a 'with' call?
+        self.client.__enter__()
+
+    def tearDown(self):
+        # This isn't perfect, due to possibility of exceptions being thrown
+        # is there some better pattern I can use to split up what should be
+        # a 'with' call?
+        self.client.__exit__(None, None, None)
+
+    def run_query_and_content_required_field_test(self, url, dicts_to_test,
+                                                  content_dict,
+                                                  query_dict):
+        for key in dicts_to_test:
+            curr_query_dict = query_dict
+            curr_content_dict = content_dict
+            curr_expected_msg = None
+
+            dict_to_test = dicts_to_test[key]
+            field_deleter = dictionary_mangler(dict_to_test,
+                                               delete_fields=True)
+            for i in field_deleter:
+                if key == QUERY_KEY:
+                    curr_query_dict = i
+                    curr_expected_msg = "Missing query parameter "
+                elif key == CONTENT_KEY:
+                    curr_content_dict = i
+                    curr_expected_msg = "is a required property"
+
+                curr_query_str = urlencode(curr_query_dict)
+                curr_content_json = json.dumps(curr_content_dict)
+                response = self.client.post(
+                    '{0}?{1}'.format(url, curr_query_str),
+                    content_type='application/json',
+                    data=curr_content_json
+                )
+
+                self.assertEqual(400, response.status_code)
+                resp_obj = json.loads(response.data)
+                self.assertTrue(curr_expected_msg in resp_obj['detail'])
+            # next deleted field
+        # next dict to test
+
+    # region account
+
+    def test_accounts_post_without_required_fields(self):
+        """Not providing any required field returns validation fail code"""
+
+        content_dict = {
+            "address": {
+                "city": "Springfield",
+                "country_code": "US",
+                "post_code": "12345",
+                # No state because state is optional
+                "street": "123 Main St. E. Apt. 2"
+            },
+            "email": "janedoe@example.com",
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "kit_name": "jb_qhxqe"
+        }
+
+        dicts_to_test = {QUERY_KEY: self.lang_query_dict,
+                         CONTENT_KEY: content_dict}
+
+        self.run_query_and_content_required_field_test("/api/accounts",
+                                                       dicts_to_test,
+                                                       content_dict,
+                                                       self.lang_query_dict)
+
+    def test_account_get_without_required_fields(self):
+        """Not providing any required field returns validation fail code"""
+
+        content_dict = {}
+
+        dicts_to_test = {QUERY_KEY: self.lang_query_dict,
+                         CONTENT_KEY: content_dict}
+
+        url = "/api/account/{0}".format(ACCT_ID)
+        self.run_query_and_content_required_field_test(url,
+                                                       dicts_to_test,
+                                                       content_dict,
+                                                       self.lang_query_dict)
+
+
+    # def test_accounts_post_with_extra_fields(self):
+    #     """Providing any field not in api returns validation fail code"""
+    #     my_dict = {
+    #         "address": {
+    #             "city": "Springfield",
+    #             "country_code": "US",
+    #             "post_code": "12345",
+    #             "state": "shouldn't have to be here",
+    #             "street": "123 Main St. E. Apt. 2"
+    #         },
+    #         "email": "janedoe@example.com",
+    #         "first_name": "Jane",
+    #         "last_name": "Doe",
+    #         "kit_name": "jb_qhxqe"
+    #     }
+    #
+    #     field_adder = dictionary_mangler(my_dict, delete_fields=False)
+    #     for i in field_adder:
+    #         print(i)
+    #         acct_json = json.dumps(i)
+    #         continue
+    #
+    #         response = self.client.post(
+    #             '/api/accounts?language_tag=en-US',
+    #             content_type='application/json',
+    #             data=acct_json
+    #         )
+    #
+    #         self.assertEqual(400, response.status_code)
+    #         resp_obj = json.loads(response.data)
+    #         self.assertTrue("is a required property" in resp_obj['detail'])
+    # endregion account post

--- a/microsetta_private_api/api/tests/test_api_yaml.py
+++ b/microsetta_private_api/api/tests/test_api_yaml.py
@@ -162,20 +162,19 @@ class IntegrationTests(TestCase):
                                                        content_dict,
                                                        self.lang_query_dict)
 
-    def test_account_get_without_required_fields(self):
-        """Not providing any required field returns validation fail code"""
-
-        content_dict = {}
-
-        dicts_to_test = {QUERY_KEY: self.lang_query_dict,
-                         CONTENT_KEY: content_dict}
-
-        url = "/api/account/{0}".format(ACCT_ID)
-        self.run_query_and_content_required_field_test(url,
-                                                       dicts_to_test,
-                                                       content_dict,
-                                                       self.lang_query_dict)
-
+    # def test_account_get_without_required_fields(self):
+    #     """Not providing any required field returns validation fail code"""
+    #
+    #     content_dict = {}
+    #
+    #     dicts_to_test = {QUERY_KEY: self.lang_query_dict,
+    #                      CONTENT_KEY: content_dict}
+    #
+    #     url = "/api/account/{0}".format(ACCT_ID)
+    #     self.run_query_and_content_required_field_test(url,
+    #                                                    dicts_to_test,
+    #                                                    content_dict,
+    #                                                    self.lang_query_dict)
 
     # def test_accounts_post_with_extra_fields(self):
     #     """Providing any field not in api returns validation fail code"""

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -298,9 +298,12 @@ class IntegrationTests(TestCase):
             (ACCT_ID, env['source_id']))
         env_surveys = json.loads(resp.data)
 
-        self.assertListEqual(bobo_surveys, [1, 3, 4, 5])
-        self.assertListEqual(doggy_surveys, [2])
-        self.assertListEqual(env_surveys, [])
+        self.assertListEqual([x["survey_template_id"] for x in bobo_surveys],
+                             [1, 3, 4, 5])
+        self.assertListEqual([x["survey_template_id"] for x in doggy_surveys],
+                             [2])
+        self.assertListEqual([x["survey_template_id"] for x in env_surveys],
+                             [])
 
     def test_bobo_takes_a_survey(self):
         """
@@ -321,14 +324,14 @@ class IntegrationTests(TestCase):
             '/api/accounts/%s/sources/%s/survey_templates?language_tag=en-US' %
             (ACCT_ID, bobo['source_id']))
         bobo_surveys = json.loads(resp.data)
-        chosen_survey = bobo_surveys[0]
+        chosen_survey = bobo_surveys[0]["survey_template_id"]
         resp = self.client.get(
             '/api/accounts/%s/sources/%s/survey_templates/%s'
             '?language_tag=en-US' %
             (ACCT_ID, bobo['source_id'], chosen_survey))
         check_response(resp)
 
-        model = fuzz_form(json.loads(resp.data))
+        model = fuzz_form(json.loads(resp.data)["survey_template_text"])
         resp = self.client.post(
             '/api/accounts/%s/sources/%s/surveys?language_tag=en-US'
             % (ACCT_ID, bobo['source_id']),
@@ -349,7 +352,7 @@ class IntegrationTests(TestCase):
         resp = self.client.get(loc + "?language_tag=en-US")
         check_response(resp)
         retrieved_survey = json.loads(resp.data)
-        self.assertDictEqual(retrieved_survey, model)
+        self.assertDictEqual(retrieved_survey["survey_text"], model)
 
         # Clean up after the new survey
         with Transaction() as t:
@@ -950,6 +953,8 @@ class IntegrationTests(TestCase):
         check_response(resp)
         form_gb = json.loads(resp.data)
 
+        form_us = form_us["survey_template_text"]
+        form_gb = form_gb["survey_template_text"]
         # Responses should differ by locale
         self.assertEqual(form_us['groups'][0]['fields'][0]['id'], '107',
                          "Survey question 107 moved, update the test!")

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -643,7 +643,7 @@ class IntegrationTests(TestCase):
             (ACCT_ID, HUMAN_ID, chosen_survey))
         check_response(resp)
 
-        model = fuzz_form(json.loads(resp.data))
+        model = fuzz_form(json.loads(resp.data)["survey_template_text"])
         resp = self.client.post(
             '/api/accounts/%s/sources/%s/surveys?language_tag=en-US'
             % (ACCT_ID, HUMAN_ID),

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -1083,6 +1083,10 @@ def _create_mock_kit(transaction):
                     "(ag_kit_barcode_id, ag_kit_id, barcode) "
                     "VALUES(%s, %s, %s)",
                     (MOCK_SAMPLE_ID, KIT_ID, BARCODE))
+        # Add the mock barcode to American Gut Project
+        cur.execute("INSERT INTO project_barcode "
+                    "(project_id, barcode) "
+                    "VALUES(%s, %s)", (1, BARCODE))
 
 
 def _remove_mock_kit(transaction):
@@ -1095,6 +1099,10 @@ def _remove_mock_kit(transaction):
 
         # Some tests may leak leftover surveys, wipe those out also
         cur.execute("DELETE FROM source_barcodes_surveys WHERE barcode = %s",
+                    (BARCODE,))
+
+        # Remove the mock barcode from any projects
+        cur.execute("DELETE FROM project_barcode WHERE barcode = %s",
                     (BARCODE,))
 
         cur.execute("DELETE FROM barcode WHERE barcode = %s",

--- a/microsetta_private_api/model/source.py
+++ b/microsetta_private_api/model/source.py
@@ -122,9 +122,7 @@ class Source(ModelBase):
                         "participant_email": self.source_data.email,
                         "parent_1_name": self.source_data.parent1_name,
                         "parent_2_name": self.source_data.parent2_name,
-                        "deceased_parent": (self.source_data.parent1_deceased
-                                            or
-                                            self.source_data.parent2_deceased),
+                        "deceased_parent": self.source_data.deceased_parent,
                         "obtainer_name": self.source_data.assent_obtainer
                     }
                 else:

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -10,6 +10,7 @@ from microsetta_private_api.model.survey_template_question import \
         SurveyTemplateQuestion
 from microsetta_private_api.model.survey_template_trigger import \
         SurveyTemplateTrigger
+import copy
 
 
 class SurveyTemplateRepo(BaseRepo):
@@ -58,7 +59,7 @@ class SurveyTemplateRepo(BaseRepo):
 
     @staticmethod
     def get_survey_template_link_info(survey_id):
-        return SurveyTemplateRepo.SURVEY_INFO[survey_id]
+        return copy.deepcopy(SurveyTemplateRepo.SURVEY_INFO[survey_id])
 
     def get_survey_template(self, survey_id, language_tag):
 

--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -23,7 +23,7 @@ def build_app():
     app = connexion.FlaskApp(__name__)
 
     # Read the microsetta api spec file to configure the endpoints
-    app.add_api('api/microsetta_private_api.yaml')
+    app.add_api('api/microsetta_private_api.yaml', validate_responses=True)
 
     # Set default json encoder
     # Note: app.app is the actual Flask application instance, so any Flask

--- a/microsetta_private_api/templates/new_participant.jinja2
+++ b/microsetta_private_api/templates/new_participant.jinja2
@@ -136,7 +136,7 @@
     <div class="" id="consent">
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-        <form method="post" id="0-6-form" name="consent_info" onsubmit="return validate06();" action="consent">
+        <form method="post" id="0-6-form" name="consent_info" onsubmit="return validate06();" action="consent?language_tag={{ lang_tag }}">
            <input type="hidden" name="age_range" value="0-6">
            <p><input value="Yes" type="checkbox" name="consent_parent" id="consent_parent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_PARENT'] |e}}</p>
     </div>
@@ -156,7 +156,7 @@
 </div>
     <div class="" id="consent">
         <hr>
-        <form method="post" id="7-12-form" name="consent_info" onsubmit="return validate712();" action="consent">
+        <form method="post" id="7-12-form" name="consent_info" onsubmit="return validate712();" action="consent?language_tag={{ lang_tag }}">
         <input type="hidden" name="age_range" value="7-12">
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_SIMPLIFIED'] |e}}</p>
     </div>
@@ -197,7 +197,7 @@
 </div>
     <div class="" id="consent">
         <hr>
-        <form method="post" id="13-17-form" name="consent_info" onsubmit="return validate1317();" action="consent">
+        <form method="post" id="13-17-form" name="consent_info" onsubmit="return validate1317();" action="consent?language_tag={{ lang_tag }}">
            <input type="hidden" name="age_range" value="13-17">
            <p><input value="Yes" type="checkbox" name="consent_child" id="consent_child" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
     </div>
@@ -234,7 +234,7 @@
 <div class="" id="consent">
         <hr>
         <a href="http://oag.ca.gov/sites/all/files/agweb/pdfs/research/bill_of_rights.pdf" target="_blank">{{ tl['BILL_OF_RIGHTS']|e}}</a><br/>
-        <form method="post" id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="consent">
+        <form method="post" id="18-form" name="consent_info" onsubmit="return min_validation('18-form');" action="consent?language_tag={{ lang_tag }}">
         <input type="hidden" name="age_range" value="18-plus">
            <p><input value="Yes" type="checkbox" name="consent" id="consent" required data-rule-required="true"> {{ tl['TEXT_I_HAVE_READ_1'] |e}}</p>
     </div>


### PR DESCRIPTION
This PR 
* fixes #74 : replaces the earlier 403 error with a 404 
* fixes #79 : adds missing language tag to consent post
* fixes a bug in Source.to_api that was still expecting deceased info on two parents
* adds response validation from connexion and fixes a number of implementation/api inconsistencies uncovered that way
* starts but does not finish the work of issue 18, locking down required fields in api

@dhakim87  did lots of work on this PR too!

(edited to add GH links to the issues; should auto close them when this is merged)