### PR TITLE
Minimal interface: installation items identified during RC testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ before_script:
 script:
   - make lint
   - make test-cov
+  - make test-install
 
 after_success:
   - coveralls

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,13 @@ lint:
 
 test: all
 	py.test
+	
+	# ensure the package is installed and the app is buildable. this test
+	# is a passive verification that non-py essential files are part of the
+	# installed entity.
+	pushd /
+	python -c "from microsetta_private_api import server; server.build_app()"
+	popd
 
 test-cov: all
 	py.test --cov=microsetta_private_api

--- a/Makefile
+++ b/Makefile
@@ -10,13 +10,13 @@ lint:
 
 test: all
 	py.test
-	
+
+test-install: all
 	# ensure the package is installed and the app is buildable. this test
 	# is a passive verification that non-py essential files are part of the
 	# installed entity.
-	pushd /
+	cd /  # go somewhere to avoid relative imports
 	python -c "from microsetta_private_api import server; server.build_app()"
-	popd
 
 test-cov: all
 	py.test --cov=microsetta_private_api

--- a/microsetta_private_api/LEGACY/build_db.py
+++ b/microsetta_private_api/LEGACY/build_db.py
@@ -1,6 +1,5 @@
 from microsetta_private_api.LEGACY.env_management import (
-    create_database, build, initialize, make_settings_table, patch_db,
-    populate_test_db)
+    create_database, initialize, patch_db, populate_test_db)
 
 DB = 'test'
 FORCE = True

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -450,11 +450,11 @@ def post_check_acct_inputs(body):
             params=ApiRequest.build_params({KIT_NAME_KEY: kit_name}))
 
         if response.status_code == 404:
-            response_info = "The provided kit id is not valid or has already " \
-                            "been used; please re-check your entry."
+            response_info = ("The provided kit id is not valid or has "
+                             "already been used; please re-check your entry.")
         elif response.status_code > 200:
             response_info = unable_to_validate_msg
-    except:
+    except:  # noqa
         response_info = unable_to_validate_msg
     finally:
         return json.dumps(response_info)

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ setup(
                   [
                      'db/*.*',
                      'db/patches/*.sql',
+                     'microsetta_private_api/api/microsetta_private_api.yaml',
+                     'microsetta_private_api/example/client.yaml',
                      'server_config.json',
                      'authrocket.pubkey'
                   ]},

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ setup(
                   [
                      'db/*.*',
                      'db/patches/*.sql',
-                     'microsetta_private_api/api/microsetta_private_api.yaml',
-                     'microsetta_private_api/example/client.yaml',
+                     'api/microsetta_private_api.yaml',
+                     'example/client.yaml',
                      'server_config.json',
                      'authrocket.pubkey'
                   ]},


### PR DESCRIPTION
Adds non-python files that were not being included on install

Adds a test to verify the app can be imported and built from the installed entity 

Adds a missing `__init__.py` file to ensure items from `microsetta_private_api.model.vue` can be imported
 