### PR TITLE
Endpoint for creating kits

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -36,10 +36,13 @@ def create_kits(body, token_info):
 
     with Transaction() as t:
         admin_repo = AdminRepo(t)
-        kits = admin_repo.create_kits(number_of_kits, number_of_samples,
-                                      kit_prefix, projects)
 
-        if kits:
+        try:
+            kits = admin_repo.create_kits(number_of_kits, number_of_samples,
+                                          kit_prefix, projects)
+        except KeyError:
+            return jsonify(code=422, message="Unable to create kits"), 422
+        else:
             t.commit()
 
     return jsonify(kits), 201

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -24,3 +24,22 @@ def validate_admin_access(token_info):
                                                    token_info['sub'])
         if account is None or account.account_type != 'admin':
             raise Unauthorized()
+
+
+def create_kits(body, token_info):
+    validate_admin_access(token_info)
+
+    number_of_kits = body['number_of_kits']
+    number_of_samples = body['number_of_samples']
+    kit_prefix = body.get('kit_prefix', None)
+    projects = body['projects']
+
+    with Transaction() as t:
+        admin_repo = AdminRepo(t)
+        kits = admin_repo.create_kits(number_of_kits, number_of_samples,
+                                      kit_prefix, projects)
+
+        if kits:
+            t.commit()
+
+    return jsonify(kits), 201

--- a/microsetta_private_api/admin/tests/test_admin.py
+++ b/microsetta_private_api/admin/tests/test_admin.py
@@ -125,10 +125,45 @@ class AdminTests(TestCase):
     def test_create_kits(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            kits = admin_repo.create_kits(5, 4, '', ['foo', 'bar'])
-            self.assertEqual(['created', ], list(kits.keys()))
-            self.assertEqual(len(kits['created']), 5)
-            for obj in kits['created']:
-                self.assertEqual(len(obj['sample_barcodes']), 4)
+
+            with self.assertRaisesRegex(KeyError, "does not exist"):
+                admin_repo.create_kits(5, 3, '', ['foo', 'bar'])
+
+            non_tmi = admin_repo.create_kits(5, 3, '',
+                                             ['Project - /J/xL_|Eãt'])
+            self.assertEqual(['created', ], list(non_tmi.keys()))
+            self.assertEqual(len(non_tmi['created']), 5)
+            for obj in non_tmi['created']:
+                self.assertEqual(len(obj['sample_barcodes']), 3)
                 self.assertEqual({'kit_id', 'kit_uuid', 'sample_barcodes'},
                                  set(obj))
+
+            # should not be present in the ag tables
+            non_tmi_kits = [k['kit_id'] for k in non_tmi['created']]
+            with t.cursor() as cur:
+                cur.execute("SELECT supplied_kit_id "
+                            "FROM ag.ag_kit "
+                            "WHERE supplied_kit_id IN %s",
+                            (tuple(non_tmi_kits), ))
+                observed = cur.fetchall()
+                self.assertEqual(len(observed), 0)
+
+            tmi = admin_repo.create_kits(4, 2, 'foo',
+                                         ['American Gut Project'])
+            self.assertEqual(['created', ], list(tmi.keys()))
+            self.assertEqual(len(tmi['created']), 4)
+            for obj in tmi['created']:
+                self.assertEqual(len(obj['sample_barcodes']), 2)
+                self.assertEqual({'kit_id', 'kit_uuid', 'sample_barcodes'},
+                                 set(obj))
+                self.assertTrue(obj['kit_id'].startswith('foo_'))
+
+            # should be present in the ag tables
+            tmi_kits = [k['kit_id'] for k in tmi['created']]
+            with t.cursor() as cur:
+                cur.execute("SELECT supplied_kit_id "
+                            "FROM ag.ag_kit "
+                            "WHERE supplied_kit_id IN %s",
+                            (tuple(tmi_kits), ))
+                observed = cur.fetchall()
+                self.assertEqual(len(observed), 4)

--- a/microsetta_private_api/admin/tests/test_admin.py
+++ b/microsetta_private_api/admin/tests/test_admin.py
@@ -121,3 +121,14 @@ class AdminTests(TestCase):
             self.assertIsNone(diag['source'])
             self.assertIsNone(diag['sample'])
             self.assertEqual(len(diag['barcode_info']), 0)
+
+    def test_create_kits(self):
+        with Transaction() as t:
+            admin_repo = AdminRepo(t)
+            kits = admin_repo.create_kits(5, 4, '', ['foo', 'bar'])
+            self.assertEqual(['created', ], list(kits.keys()))
+            self.assertEqual(len(kits['created']), 5)
+            for obj in kits['created']:
+                self.assertEqual(len(obj['sample_barcodes']), 4)
+                self.assertEqual({'kit_id', 'kit_uuid', 'sample_barcodes'},
+                                 set(obj))

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -875,6 +875,10 @@ paths:
 
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        
+        '422':
+          $ref: '#/components/responses/422UnprocessableEntity'
+
 
 components:
   parameters:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -813,6 +813,7 @@ paths:
           $ref: '#/components/responses/404NotFound'
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
+
   # START ADMINISTRATOR PATHS
   '/admin/search/sample/{sample_barcode}':
     get:
@@ -835,6 +836,45 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/admin/create/kits':
+    post:
+      operationId: microsetta_private_api.admin.admin_impl.create_kits
+      tags:
+        - Admin
+      summary: Create kit identifiers and associated sample barcodes
+      description: Create kit identifiers and associated sample barcodes
+      requestBody:
+        content:
+          application/json:
+            schema:
+                type: "object"
+                properties:
+                  number_of_kits:
+                    type: integer
+                  number_of_samples:
+                    type: integer
+                  kit_id_prefix:
+                    type: string
+                  projects:
+                    type: array
+                    items:
+                      type: string
+
+                required:
+                  - number_of_kits
+                  - number_of_samples
+                  - projects
+
+      responses:
+        '201':
+          description: Kit identifiers and associated samples were successfully created
+          content:
+            application/json:
+              schema:
+                type: object
+
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
 
 components:
   parameters:
@@ -989,6 +1029,7 @@ components:
         - last_name
         - email
         - address
+
     address:   # taken from https://opensource.zalando.com/restful-api-guidelines/#address-fields
       description:
         an address of a location/destination

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -1220,6 +1220,12 @@ def _create_mock_kit(transaction, barcodes=None, mock_sample_ids=None,
 
     with transaction.cursor() as cur:
         # create a record for the new kit in ag_kit table
+        cur.execute("INSERT INTO barcodes.kit "
+                    "(kit_id)"
+                    "VALUES(%s)",
+                    (supplied_kit_id, ))
+
+        # create a record for the new kit in ag_kit table
         cur.execute("INSERT INTO ag_kit "
                     "(ag_kit_id, "
                     "supplied_kit_id, swabs_per_kit) "
@@ -1286,6 +1292,15 @@ def _remove_mock_kit(transaction, barcodes=None, mock_sample_ids=None,
                         (barcode,))
         # next barcode/sample to delete
 
+        cur.execute("SELECT supplied_kit_id "
+                    "FROM ag_kit "
+                    "WHERE ag_kit_id=%s",
+                    (kit_id, ))
+        supplied_kit_id = cur.fetchone()
+
         # now delete the kit the barcode(s) were associated to
         cur.execute("DELETE FROM ag_kit WHERE ag_kit_id=%s",
                     (kit_id,))
+        if supplied_kit_id is not None:
+            cur.execute("DELETE FROM barcodes.kit WHERE kit_id=%s",
+                        (supplied_kit_id,))

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -1,0 +1,10 @@
+CREATE TABLE barcodes.kit (
+    kit_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    kit_id VARCHAR NOT NULL CONSTRAINT unq_kit_id UNIQUE,
+    fedex_tracking VARCHAR NULL,
+    address VARCHAR NULL
+);
+
+--ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;
+ALTER TABLE barcodes.barcode ADD CONSTRAINT fk_barcode_kit_id
+    FOREIGN KEY (kit_id) REFERENCES barcodes.kit (kit_id);

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -10,12 +10,12 @@
 -- With TMI kits, we are also now positioned to (for many kits) get fedex tracking 
 -- information, so lets us up for that...
 CREATE TABLE barcodes.kit (
-    kit_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    kit_uuid uuid DEFAULT uuid_generate_v4() NOT NULL,
     kit_id VARCHAR NOT NULL CONSTRAINT unq_kit_id UNIQUE,
     fedex_tracking VARCHAR NULL,
-    address VARCHAR NULL
+    address VARCHAR NULL,
+    CONSTRAINT kit_uuid_pkey PRIMARY KEY ( kit_uuid )
 );
-ALTER TABLE barcodes.kit ALTER COLUMN kit_uuid set default uuid_generate_v4();
 
 -- Now lets make sure the barcodes are associated to the kits
 ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -10,7 +10,7 @@
 -- With TMI kits, we are also now positioned to (for many kits) get fedex tracking 
 -- information, so lets us up for that...
 CREATE TABLE barcodes.kit (
-    kit_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+    kit_uuid uuid PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
     kit_id VARCHAR NOT NULL CONSTRAINT unq_kit_id UNIQUE,
     fedex_tracking VARCHAR NULL,
     address VARCHAR NULL

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -1,3 +1,14 @@
+-- Prior to the TMI collection kit, the concept of a kit was specific to the
+-- American Gut Project and its schema. The TMI kit though is physically a kit
+-- and reasonably will be used on non-TMI projects in the future. Therefore
+-- we are ensuring kit names can be reflected for all kits created, even if they
+-- are not part of the TMI/AGP. 
+
+-- A note on projects: previously, barcodes were associated with projects not
+-- kits. This was necessary as non-AGP projects did not have a notion of a kit.
+
+-- With TMI kits, we are also now positioned to (for many kits) get fedex tracking 
+-- information, so lets us up for that...
 CREATE TABLE barcodes.kit (
     kit_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     kit_id VARCHAR NOT NULL CONSTRAINT unq_kit_id UNIQUE,
@@ -5,6 +16,24 @@ CREATE TABLE barcodes.kit (
     address VARCHAR NULL
 );
 
+-- Now lets make sure the barcodes are associated to the kits
 ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;
 ALTER TABLE barcodes.barcode ADD CONSTRAINT fk_barcode_kit_id
     FOREIGN KEY (kit_id) REFERENCES barcodes.kit (kit_id);
+
+-- Let's make sure all existing kits are reflected in this 
+-- table
+DO $do$
+DECLARE
+    k varchar;
+BEGIN
+    FOR k IN
+        SELECT supplied_kit_id FROM ag.ag_kit
+    LOOP
+        INSERT INTO barcodes.kit (kit_id) VALUES (k);
+    END LOOP;
+END $do$;
+
+-- And finally, let's establish FK relationships
+ALTER TABLE ag.ag_kit ADD CONSTRAINT fk_barcode_schema_kit_id
+    FOREIGN KEY (supplied_kit_id) REFERENCES barcodes.kit (kit_id);

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -5,6 +5,6 @@ CREATE TABLE barcodes.kit (
     address VARCHAR NULL
 );
 
---ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;
+ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;
 ALTER TABLE barcodes.barcode ADD CONSTRAINT fk_barcode_kit_id
     FOREIGN KEY (kit_id) REFERENCES barcodes.kit (kit_id);

--- a/microsetta_private_api/db/patches/0055.sql
+++ b/microsetta_private_api/db/patches/0055.sql
@@ -10,11 +10,12 @@
 -- With TMI kits, we are also now positioned to (for many kits) get fedex tracking 
 -- information, so lets us up for that...
 CREATE TABLE barcodes.kit (
-    kit_uuid uuid PRIMARY KEY NOT NULL DEFAULT uuid_generate_v4(),
+    kit_uuid uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
     kit_id VARCHAR NOT NULL CONSTRAINT unq_kit_id UNIQUE,
     fedex_tracking VARCHAR NULL,
     address VARCHAR NULL
 );
+ALTER TABLE barcodes.kit ALTER COLUMN kit_uuid set default uuid_generate_v4();
 
 -- Now lets make sure the barcodes are associated to the kits
 ALTER TABLE barcodes.barcode ADD COLUMN kit_id VARCHAR;

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -82,10 +82,10 @@ class AdminRepo(BaseRepo):
 
     def _generate_random_kit_name(self, name_length, prefix):
         if prefix is None:
-            prefix = 'tmi_'
+            prefix = 'tmi'
 
-        # O, o, S and l removed to improve readability
-        chars = 'abcdefghjkmnpqrstuvwxyz' + 'ABCDEFGHJKMNPQRTUVWXYZ'
+        # O, o, S, I and l removed to improve readability
+        chars = 'abcdefghijkmnpqrstuvwxyz' + 'ABCDEFGHJKMNPQRTUVWXYZ'
         chars += string.digits
         rand_name = ''.join(random.choice(chars)
                             for i in range(name_length))

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1,7 +1,6 @@
 import uuid
 import string
 import random
-from itertools import groupby
 
 from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.base_repo import BaseRepo

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -75,3 +75,11 @@ class AdminRepo(BaseRepo):
             }
 
             return diagnostic
+
+    def create_kits(self, number_of_kits, number_of_samples, kit_prefix,
+                    projects):
+        import uuid
+        return {'created': [{'kit_id': 'mock_%d' % i,
+                             'sample_barcodes': ['a', 'b', 'c'],
+                             'kit_uuid': str(uuid.uuid4()),
+                             } for i in range(number_of_kits)]}

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1,3 +1,8 @@
+import uuid
+import string
+import random
+from itertools import groupby
+
 from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.repo.sample_repo import SampleRepo
@@ -76,10 +81,115 @@ class AdminRepo(BaseRepo):
 
             return diagnostic
 
+    def _generate_random_kit_name(self, name_length, prefix):
+        if prefix is None:
+            prefix = 'tmi_'
+
+        # O, o, S and l removed to improve readability
+        chars = 'abcdefghjkmnpqrstuvwxyz' + 'ABCDEFGHJKMNPQRTUVWXYZ'
+        chars += string.digits
+        rand_name = ''.join(random.choice(chars)
+                            for i in range(name_length))
+        return prefix + rand_name
+
     def create_kits(self, number_of_kits, number_of_samples, kit_prefix,
                     projects):
-        import uuid
-        return {'created': [{'kit_id': 'mock_%d' % i,
-                             'sample_barcodes': ['a', 'b', 'c'],
-                             'kit_uuid': str(uuid.uuid4()),
-                             } for i in range(number_of_kits)]}
+        with self._transaction.cursor() as cur:
+            # get existing projects
+            cur.execute("SELECT project, project_id "
+                        "FROM barcodes.project")
+            known_projects = {prj.lower(): id_ for prj, id_ in cur.fetchall()}
+            for name in projects:
+                if name.lower() not in known_projects:
+                    raise KeyError("%s does not exist" % name)
+
+            # get existing kits to test for conflicts
+            cur.execute("""SELECT kit_id FROM barcodes.kit""")
+            existing = set(cur.fetchall())
+            names = [self._generate_random_kit_name(8, kit_prefix)
+                     for i in range(number_of_kits)]
+
+            # if we observe ANY conflict, lets bail. This should be extremely
+            # rare, from googling seemed a easier than having postgres
+            # generate a unique identifier that was reasonably short, hard to
+            # guess
+            if len(set(names) - existing) != number_of_kits:
+                raise KeyError("Conflict in created names, kits not created")
+
+            # get the maximum observed barcode.
+            # historically, barcodes were of the format NNNNNNNNN where each
+            # position was a digit. this has created many problems on
+            # subsequent use as Excel and other tools naively assume these
+            # values are numeric. As of 16APR2020, barcodes will be of the
+            # format XNNNNNNNN where the first position is considered a
+            # control character that cannot safely be considered a digit.
+            # this is *safe* for all prior barcodes as the first character
+            # has always been the "0" character.
+            total_barcodes = number_of_kits * number_of_samples
+            cur.execute("SELECT max(right(barcode,8)::integer) "
+                        "FROM barcodes.barcode")
+            start_bc = cur.fetchone()[0] + 1
+            new_barcodes = ['X%0.8d' % (start_bc + i)
+                            for i in range(total_barcodes)]
+
+            # partition up barcodes and associate to kit names
+            kit_barcodes = []
+            barcode_offset = range(0, total_barcodes, number_of_samples)
+            for offset, name in zip(barcode_offset, names):
+                for i in range(number_of_samples):
+                    kit_barcodes.append((name, new_barcodes[offset + i]))
+
+            # create barcode project associations
+            barcode_projects = []
+            for barcode in new_barcodes:
+                for project in projects:
+                    prj_id = known_projects[project.lower()]
+                    barcode_projects.append((barcode, prj_id))
+
+            # create shipping IDs
+            cur.executemany("INSERT INTO barcodes.kit "
+                            "(kit_id) "
+                            "VALUES (%s)", [(n, ) for n in names])
+
+            # add a new barcode to barcode table
+            barcode_insertions = [(n, b, 'unassigned')
+                                  for n, b in kit_barcodes]
+            cur.executemany("INSERT INTO barcode (kit_id, barcode, status) "
+                            "VALUES (%s, %s, %s)",
+                            barcode_insertions)
+
+            # add project information
+            cur.executemany("INSERT INTO project_barcode "
+                            "(barcode, project_id) "
+                            "VALUES (%s, %s)", barcode_projects)
+
+            # create a record for the new kit in ag_kit table
+            ag_kit_insertions = [(str(uuid.uuid4()), name, number_of_samples)
+                                 for name in names]
+            cur.executemany("INSERT INTO ag.ag_kit "
+                            "(ag_kit_id, supplied_kit_id, swabs_per_kit) "
+                            "VALUES (%s, %s, %s)",
+                            ag_kit_insertions)
+
+            # associate the new barcode to a new sample id and
+            # to the new kit in the ag_kit_barcodes table
+            kit_id_to_ag_kit_id = {k: u for u, k, _ in ag_kit_insertions}
+            kit_barcodes_insert = [(kit_id_to_ag_kit_id[i], b)
+                                   for i, b in kit_barcodes]
+            cur.executemany("INSERT INTO ag_kit_barcodes "
+                            "(ag_kit_id, barcode) "
+                            "VALUES (%s, %s)",
+                            kit_barcodes_insert)
+
+        with self._transaction.dict_cursor() as cur:
+            cur.execute("SELECT kit_id, "
+                        "       kit_uuid, "
+                        "       array_agg(barcode) as sample_barcodes "
+                        "FROM barcodes.kit "
+                        "LEFT JOIN barcodes.barcode USING (kit_id)"
+                        "WHERE kit_id IN %s "
+                        "GROUP BY (kit_id, kit_uuid)", (tuple(names), ))
+            created = [{'kit_id': k, 'kit_uuid': u, 'sample_barcodes': b}
+                       for k, u, b in cur.fetchall()]
+
+        return {'created': created}

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1,13 +1,10 @@
-<<<<<<< HEAD
 import uuid
 import string
 import random
 
-=======
 from datetime import date
 
 from microsetta_private_api.exceptions import RepoException
->>>>>>> 139f2db7a5b77fe309c77f740460f47605a8c3f0
 from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.repo.kit_repo import KitRepo

--- a/setup.cfg
+++ b/setup.cfg
@@ -11,4 +11,5 @@ per-file-ignores =
     microsetta_private_api/LEGACY/locale_data/american_gut.py:E501
     microsetta_private_api/LEGACY/locale_data/british_gut.py:E501
     microsetta_private_api/LEGACY/locale_data/english_gut.py:E501
+    microsetta_private_api/LEGACY/locale_data/english_gut.py:W291
     microsetta_private_api/LEGACY/locale_data/spanish_gut.py:E501

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,5 @@ per-file-ignores =
     microsetta_private_api/LEGACY/locale_data/__init__.py:E501
     microsetta_private_api/LEGACY/locale_data/american_gut.py:E501
     microsetta_private_api/LEGACY/locale_data/british_gut.py:E501
-    microsetta_private_api/LEGACY/locale_data/english_gut.py:E501
-    microsetta_private_api/LEGACY/locale_data/english_gut.py:W291
+    microsetta_private_api/LEGACY/locale_data/english_gut.py:E501,W291
     microsetta_private_api/LEGACY/locale_data/spanish_gut.py:E501


### PR DESCRIPTION
Kit creation. This ended up more complex than initially intended. 

Previously, the notion of a "kit" was limited to the `ag` schema as only AGP projects had collections of samples. The TMI "box" is really a kit, and we intend to ship to other projects, which *may not* use our participant portal. We will also be receiving FedEx tracking information on kits shipped. SO, there is now a `kit`s table in `barcodes`. References updated, and existing kit names are backported. 

To facilitate tracking of shipments, our logistics partner is putting a QR code on the outside of the kits, which they will scan and send to us (exact mechanism of "sending to us" is not final). That code is `kit_uuid` in `barcodes.kit` right now. 

I do not think kits *need* to live in both `barcodes.kit` and `ag.ag_kit`, however I think adapting the database to address is a major refactor.

