### PR TITLE
Very simple CLI to start server

### DIFF
--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -56,10 +56,7 @@ def build_app():
     return app
 
 
-# If we're running in stand alone mode, run the application
-if __name__ == '__main__':
-    app = build_app()
-
+def run(app):
     if SERVER_CONFIG["ssl_cert_path"] and SERVER_CONFIG["ssl_key_path"]:
         ssl_context = (
             SERVER_CONFIG["ssl_cert_path"], SERVER_CONFIG["ssl_key_path"]
@@ -72,3 +69,9 @@ if __name__ == '__main__':
         debug=SERVER_CONFIG['debug'],
         ssl_context=ssl_context
     )
+
+
+# If we're running in stand alone mode, run the application
+if __name__ == '__main__':
+    app = build_app()
+    run(app)

--- a/mpa_cli.py
+++ b/mpa_cli.py
@@ -1,0 +1,8 @@
+import click
+from microsetta_private_api.server import build_app, run
+
+
+@click.command()
+def cli():
+    app = build_app()
+    run(app)

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     packages=find_packages(),
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
+    py_modules=['mpa-cli'],
     url="https://github.com/biocore/microsetta-private-api",
     description="A RESTful API to support The Microsetta Initiative",
     license='BSD-3-Clause',
@@ -41,4 +42,8 @@ setup(
                      'static/vendor/bootstrap-3.3.7-dist/fonts/*',
                      'authrocket.pubkey'
                   ]},
+    entry_points='''
+        [console_scripts]
+        mpa-cli=mpa_cli:cli
+    '''
 )


### PR DESCRIPTION
This is helpful when spinning up a test server in travis, in support of the microsetta-admin project, which needs to interact with a test instance of the API. If microsetta-private-api is pip installed, then the exact path of `server.py` to execute is buried somewhere in the system. With a little work you can determine that, or just run `mpa-cli`:

```bash
$ mpa-cli
WARNING: FLASK_SECRET_KEY must be set to run with gUnicorn
 * Serving Flask app "microsetta_private_api.server" (lazy loading)
 * Environment: production
   WARNING: This is a development server. Do not use it in a production deployment.
   Use a production WSGI server instead.
 * Debug mode: on
 * Running on http://0.0.0.0:8082/ (Press CTRL+C to quit)
 * Restarting with stat
WARNING: FLASK_SECRET_KEY must be set to run with gUnicorn
 * Debugger is active!
 * Debugger PIN: 118-114-262
```