### PR TITLE
Email verification

### DIFF
--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -147,6 +147,34 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
+  '/accounts/{account_id}/email_match':
+    get:
+      operationId: microsetta_private_api.api.implementation.check_email_match
+      tags:
+        - Account
+      summary: Check if email on microsetta account matches email on authentication account
+      description: Check if email on microsetta account matches email on authentication account
+      parameters:
+        - $ref: '#/components/parameters/account_id'
+        - $ref: '#/components/parameters/language_tag'
+      responses:
+        '200':
+          description: Successfully returned email match status
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  email_match:
+                    type: boolean
+                    example: true
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
   '/accounts/{account_id}/consent':
     get:
       operationId: microsetta_private_api.api.implementation.render_consent_doc

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -26,6 +26,8 @@ paths:
                   $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
     post:
       operationId: microsetta_private_api.api.implementation.register_account
       tags:
@@ -60,6 +62,8 @@ paths:
                 $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -83,6 +87,8 @@ paths:
                 $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -107,6 +113,8 @@ paths:
                 $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     put:
@@ -132,6 +140,8 @@ paths:
                 $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -161,6 +171,8 @@ paths:
                     example: "<html><body>Consent form here</body></html>"
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
     post:
       operationId: microsetta_private_api.api.implementation.create_human_source_from_consent
       tags:
@@ -214,6 +226,8 @@ paths:
                   $ref: '#/components/examples/human_child_source_w_id'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -261,6 +275,8 @@ paths:
                       obtainer_name: "Hades Doe"
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     post:
@@ -308,6 +324,8 @@ paths:
                   $ref: '#/components/examples/nonhuman_source_w_id'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -342,6 +360,8 @@ paths:
                   $ref: '#/components/examples/nonhuman_source_w_id'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     put:
@@ -386,6 +406,8 @@ paths:
                   $ref: '#/components/examples/nonhuman_source_w_id'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -405,6 +427,8 @@ paths:
           description: Successfully deleted source
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -433,6 +457,8 @@ paths:
                   $ref: '#/components/schemas/thin_survey_template_info'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     # NB: No delete, put, or post for survey templates--can maybe expand to that for admin user in future
@@ -466,6 +492,8 @@ paths:
 
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     # NB: No delete, put, or post for a particular survey template--can maybe expand to that for admin user in future
@@ -501,6 +529,8 @@ paths:
                         - survey_id
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     post:
@@ -532,6 +562,8 @@ paths:
                 type: string
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
@@ -566,6 +598,8 @@ paths:
                       - survey_text
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     # NB: NO "put"--you shouldn't update an answered survey, but instead should take a new one
@@ -593,6 +627,8 @@ paths:
                   $ref: '#/components/schemas/sample'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     post:
@@ -629,6 +665,8 @@ paths:
                 type: string
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -657,6 +695,8 @@ paths:
                 $ref: '#/components/schemas/sample'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     put:
@@ -684,6 +724,8 @@ paths:
                 $ref: '#/components/schemas/sample'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -705,6 +747,8 @@ paths:
           description: Sample was dissociated from source
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -754,6 +798,8 @@ paths:
                   survey_template_type: local
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
     post:
@@ -784,6 +830,8 @@ paths:
                 type: string
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -808,6 +856,8 @@ paths:
           description: Answered survey was dissociated from sample
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -832,6 +882,8 @@ paths:
                   $ref: '#/components/schemas/sample'
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
         '422':
@@ -983,6 +1035,8 @@ paths:
                 type: object
         '401':
           $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
         '404':
           $ref: '#/components/responses/404NotFound'
 
@@ -1117,6 +1171,8 @@ components:
   responses:
     401Unauthorized:   # Can be referenced as '#/components/responses/401Unauthorized'
       description: Invalid or missing token.
+    403Forbidden:   # Can be referenced as '#/components/responses/403Forbidden'
+      description: Authorization refused.
     404NotFound:       # Can be referenced as '#/components/responses/404NotFound'
       description: The specified resource was not found.
     422UnprocessableEntity:

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -61,30 +61,25 @@ ACCT_MOCK_ISS = "MrUnitTest.go"
 ACCT_MOCK_SUB = "NotARealSub"
 ACCT_MOCK_ISS_2 = "NewPhone"
 ACCT_MOCK_SUB_2 = "WhoDis"
-MOCK_HEADERS = {"Authorization": "Bearer BoogaBooga"}
-MOCK_HEADERS_2 = {"Authorization": "Bearer WoogaWooga"}
-MOCK_HEADERS_IMPOSTOR = {"Authorization": "Bearer FoogaFooga"}
+MOCK_HEADERS = {"Authorization": "Bearer mockone"}
+MOCK_HEADERS_IMPOSTOR = {"Authorization": "Bearer mockimpostor"}
 
 
 def mock_verify(token):
-    if token == "BoogaBooga":
+    if token == "mockone":
         return {
             'email': TEST_EMAIL,
             'iss': ACCT_MOCK_ISS,
             'sub': ACCT_MOCK_SUB
         }
-    elif token == "WoogaWooga":
-        return {
-            'email': TEST_EMAIL_2,
-            'iss': ACCT_MOCK_ISS_2,
-            'sub': ACCT_MOCK_SUB_2
-        }
-    else:
+    elif token == "mockimpostor":
         return {
             'email': 'impostor@test.com',
             'iss': 'impostor',
             'sub': 'animpostor'
         }
+    else:
+        raise ValueError("Unrecognized mock token")
 
 
 CREATION_TIME_KEY = "creation_time"

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -49,12 +49,14 @@ def mock_verify_func(token):
     if token == "boogabooga":
         return {
             "email": "foo@baz.com",
+            'email_verification': True,
             "iss": "https://MOCKUNITTEST.com",
             "sub": "1234ThisIsNotARealSub",
         }
     elif token == "woogawooga":
         return {
             "email": FAKE_EMAIL,
+            'email_verification': True,
             "iss": "https://MOCKUNITTEST.com",
             "sub": "ThisIsAlsoNotARealSub",
         }


### PR DESCRIPTION
Per @wasade, any user of the private API must have validated their email (with the authentication provider, AuthRocket) before they are allowed to perform any actions on the API.

Note that since it has been requested that the minimalInterface inform users who do not have a verified email that they need to go do that, it was also necessary to differentiate between a user who just isn't authenticated and one who is but who still needs to verify their email.  I have set this up via a 403 forbidden http response code (Forbidden) for the authenticated-but-email-not-verified case, but if this sparks disagreement, let me know.