### PR TITLE
Admin Barcode Search Cleanup

### DIFF
--- a/microsetta_private_api/admin/tests/test_admin.py
+++ b/microsetta_private_api/admin/tests/test_admin.py
@@ -104,23 +104,19 @@ class AdminTests(TestCase):
             self.assertIsNone(diag['account'])
             self.assertIsNone(diag['source'])
             self.assertIsNotNone(diag['sample'])
-            self.assertGreater(len(diag['barcode_info']), 0)
+            self.assertGreater(len(diag['barcode_info']['projects']), 0)
 
             diag = admin_repo.retrieve_diagnostics_by_barcode('000033903')
             self.assertIsNotNone(diag['barcode'])
             self.assertIsNone(diag['account'])
             self.assertIsNone(diag['source'])
             self.assertIsNone(diag['sample'])
-            self.assertGreater(len(diag['barcode_info']), 0)
+            self.assertGreater(len(diag['barcode_info']['projects']), 0)
 
             # Uhh, should this return a 404 not found or just an empty
             # diagnostic object...?
             diag = admin_repo.retrieve_diagnostics_by_barcode('NotABarcode :D')
-            self.assertIsNotNone(diag['barcode'])
-            self.assertIsNone(diag['account'])
-            self.assertIsNone(diag['source'])
-            self.assertIsNone(diag['sample'])
-            self.assertEqual(len(diag['barcode_info']), 0)
+            self.assertIsNone(diag)
 
     def test_create_kits(self):
         with Transaction() as t:
@@ -203,7 +199,7 @@ class AdminTests(TestCase):
             admin_repo = AdminRepo(t)
 
             diag = admin_repo.retrieve_diagnostics_by_barcode(TEST_BARCODE)
-            prestatus = diag['barcode_info'][0]['status']
+            prestatus = diag['barcode_info']['status']
 
             admin_repo.scan_barcode(
                 TEST_BARCODE,
@@ -214,11 +210,11 @@ class AdminTests(TestCase):
             )
 
             diag = admin_repo.retrieve_diagnostics_by_barcode(TEST_BARCODE)
-            self.assertEqual(diag['barcode_info'][0]['technician_notes'],
+            self.assertEqual(diag['barcode_info']['technician_notes'],
                              TEST_NOTES)
-            self.assertEqual(diag['barcode_info'][0]['sample_status'],
+            self.assertEqual(diag['barcode_info']['sample_status'],
                              TEST_STATUS)
-            self.assertEqual(diag['barcode_info'][0]['status'],
+            self.assertEqual(diag['barcode_info']['status'],
                              prestatus)
 
             with self.assertRaises(NotFound):

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -89,6 +89,29 @@ class AdminRepo(BaseRepo):
             # How to unwrap a psycopg2 DictRow.  I feel dirty.
             barcode_info = [{k: v for k, v in x.items()}
                             for x in barcode_info]  # Get Inceptioned!!
+
+            # Collapse info from joined project_barcode and project tables
+            # into array within barcode_info
+            if barcode_info:
+                first = barcode_info[0]
+                first['projects'] = [
+                    {
+                        'project_id': r['project_id'],
+                        'project': r['project']
+                    }
+                    for r in barcode_info]
+                del first['project_id']
+                del first['project']
+                barcode_info = first
+            else:
+                barcode_info = None
+
+            if account is None and \
+                    source is None and \
+                    sample is None and \
+                    barcode_info is None:
+                return None
+
             diagnostic = {
                 "barcode": sample_barcode,
                 "account": account,


### PR DESCRIPTION
Minor changes to the behavior in Admin Barcode Search.  Now pushes all the projects inside one barcode_info rather than duplicating whole records.  Now returns 404 when no information about a barcode can be found.  