### PR TITLE
Prep for ui email verification and legacy acct support

### DIFF
--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -89,9 +89,9 @@ def claim_legacy_acct(token_info):
         t.commit()
 
         if acct is None:
-            return jsonify(code=404, message=ACCT_NOT_FOUND_MSG), 404
+            return jsonify([]), 200
 
-        return jsonify(acct.to_api()), 200
+        return jsonify([acct.to_api()]), 200
 
 
 def register_account(body, token_info):

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -610,7 +610,7 @@ def create_human_source_from_consent(account_id, body, token_info):
 
 
 def verify_authrocket(token):
-    email_verification_key = 'email_verification'
+    email_verification_key = 'email_verified'
 
     try:
         token_info = jwt.decode(token,

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -74,23 +74,23 @@ paths:
       operationId: microsetta_private_api.api.implementation.claim_legacy_acct
       tags:
         - Account
-      summary: Claim any matching legacy account for this user
-      description: Claim any matching legacy account for this user
+      summary: Claim any legacy accounts for this user's email and return an array of them
+      description: Claim any legacy accounts for this user's email and return an array of them
       parameters:
         - $ref: '#/components/parameters/language_tag'
       responses:
         '200':
-          description: Successfully claimed legacy account
+          description: Successfully claimed legacy account(s)
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/account'
+                type: array
+                items:
+                  $ref: '#/components/schemas/account'
         '401':
           $ref: '#/components/responses/401Unauthorized'
         '403':
           $ref: '#/components/responses/403Forbidden'
-        '404':
-          $ref: '#/components/responses/404NotFound'
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 

--- a/microsetta_private_api/api/tests/test_auth.py
+++ b/microsetta_private_api/api/tests/test_auth.py
@@ -68,7 +68,7 @@ FAKE_TOKEN_NO_EMAIL_VERIFY = "noemailver"
 def decode_fake_token(fake_token, pubkey, algorithms, verify, issuer):
     result = {
         'email': 'a@test.com',
-        'email_verification': True,
+        'email_verified': True,
         'iss': 'anissuer',
         'sub': 'asub'
     }
@@ -79,7 +79,7 @@ def decode_fake_token(fake_token, pubkey, algorithms, verify, issuer):
     elif fake_token == FAKE_TOKEN_NO_EMAIL:
         result.pop('email')
     elif fake_token == FAKE_TOKEN_NO_EMAIL_VERIFY:
-        result.pop('email_verification')
+        result.pop('email_verified')
     else:
         raise ValueError("Unrecognized fake token")
 

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -49,14 +49,14 @@ def mock_verify_func(token):
     if token == "boogabooga":
         return {
             "email": "foo@baz.com",
-            'email_verification': True,
+            'email_verified': True,
             "iss": "https://MOCKUNITTEST.com",
             "sub": "1234ThisIsNotARealSub",
         }
     elif token == "woogawooga":
         return {
             "email": FAKE_EMAIL,
-            'email_verification': True,
+            'email_verified': True,
             "iss": "https://MOCKUNITTEST.com",
             "sub": "ThisIsAlsoNotARealSub",
         }


### PR DESCRIPTION
While implementing the client changes for requiring email verification and letting users claim legacy accounts, I ran across a couple of things that I wanted/needed to change.  First of all, although AuthRocket's documentation said they will send back a claim named 'email_verification', actually they send back one called 'email_verified' ... ok.  Second, in the interface code it is convenient to have the interface for finding a legacy account (by email) be of the same structure as the interface for finding an account by login info; therefore, I modified POST /accounts/legacies to return an array--empty if it found (and claimed) no legacy account, filled with a single account if it did find and claim one.  Just as for `find_accounts_for_login`, the *api* structure supports returning more than one account, but the underlying code in `implementation.py` is not actually capable of returning more than one account at a time.