### PR TITLE
ajax survey post

### DIFF
--- a/microsetta_private_api/example/client.yaml
+++ b/microsetta_private_api/example/client.yaml
@@ -218,6 +218,20 @@ paths:
         '302':
           description: Redirecting to necessary action
 
+  '/error':
+    get:
+      operationId: microsetta_private_api.example.client_impl.generate_error_page
+      description: Neatly display error messages sent from the front-end (only)
+      parameters:
+        - $ref: '#/components/parameters/error_msg'
+      responses:
+        '200':
+          description: Error report
+          content:
+            text/html:
+              schema:
+                type: string
+
   '/accounts/{account_id}/sources/{source_id}':
     get:
       operationId: microsetta_private_api.example.client_impl.get_source
@@ -334,6 +348,12 @@ components:
       schema:
         $ref: '#/components/schemas/source_id'
       required: true
+    error_msg:
+      name: error_msg
+      in: query
+      description: Error message provided by front-end
+      schema:
+        $ref: '#/components/schemas/error_msg'
   schemas:
     # account section
     account_id:
@@ -351,3 +371,6 @@ components:
     survey_template_id:
       type: integer
       example: 3
+    error_msg:
+      type: string
+      example: "%7B%0A%20%20%22detail%22%3A%20%22The%20browser%20(or%20proxy)%20sent%20a%20request%20that%20this%20server%20could%20not%20understand.%22%2C%0A%20%20%22status%22%3A%20400%2C%0A%20%20%22title%22%3A%20%22Bad%20Request%22%2C%0A%20%20%22type%22%3A%20%22about%3Ablank%22%0A%7D%0A"

--- a/microsetta_private_api/example/client.yaml
+++ b/microsetta_private_api/example/client.yaml
@@ -157,9 +157,11 @@ paths:
         '302':
           description: Redirecting to necessary action
 
-  '/workflow_take_primary_survey':
+  '/workflow_take_survey':
     get:
-      operationId: microsetta_private_api.example.client_impl.get_workflow_fill_primary_survey
+      operationId: microsetta_private_api.example.client_impl.get_workflow_fill_survey
+      parameters:
+        - $ref: '#/components/parameters/survey_template_id'
       responses:
         '200':
           description: Primary Survey
@@ -169,7 +171,14 @@ paths:
                 type: string
 
     post:
-      operationId: microsetta_private_api.example.client_impl.post_workflow_fill_primary_survey
+      operationId: microsetta_private_api.example.client_impl.post_workflow_fill_survey
+      parameters:
+        - $ref: '#/components/parameters/survey_template_id'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
       responses:
         '200':
           description: Error report
@@ -311,13 +320,13 @@ components:
 #      schema:
 #        $ref: '#/components/schemas/survey_id'
 #      required: true
-#    survey_template_id:
-#      name: survey_template_id
-#      in: path
-#      description: Unique internal id specifying a particular survey template
-#      schema:
-#        $ref: '#/components/schemas/survey_template_id'
-#      required: true
+    survey_template_id:
+      name: survey_template_id
+      in: query
+      description: Unique internal id specifying a particular survey template
+      schema:
+        $ref: '#/components/schemas/survey_template_id'
+      required: true
     source_id:
       name: source_id
       in: path
@@ -339,3 +348,6 @@ components:
       type: string
       readOnly: true # sent in GET, not in POST/PUT/PATCH
       example: "dae21127-27bb-4f52-9fd3-a2aa5eb5b86f"
+    survey_template_id:
+      type: integer
+      example: 3

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -538,6 +538,19 @@ def post_check_acct_inputs(body):
         return json.dumps(response_info)
 
 
+def generate_error_page(error_msg):
+    # output is general error page
+    error_txt = quote(error_msg)
+    mailto_url = "mailto:{0}?subject={1}&body={2}".format(
+        HELP_EMAIL, quote("minimal interface error"), error_txt)
+
+    output = render_template('error.jinja2',
+                             mailto_url=mailto_url,
+                             error_msg=error_msg)
+
+    return output
+
+
 class BearerAuth(AuthBase):
     def __init__(self, token):
         self.token = token
@@ -572,13 +585,7 @@ class ApiRequest:
             output = redirect("/home")
         elif response.status_code >= 400:
             # output is general error page
-            error_txt = quote(response.text)
-            mailto_url = "mailto:{0}?subject={1}&body={2}".format(
-                HELP_EMAIL, quote("minimal interface error"), error_txt)
-
-            output = render_template('error.jinja2',
-                                     mailto_url=mailto_url,
-                                     error_msg=response.text)
+            output = generate_error_page(response.text)
         else:
             error_code = 0  # there is a response code but no *error* code
             if response.text:

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -50,6 +50,8 @@ ACCT_ADDR_KEY = "address"
 ACCT_WRITEABLE_KEYS = [ACCT_FNAME_KEY, ACCT_LNAME_KEY, ACCT_EMAIL_KEY,
                        ACCT_ADDR_KEY]
 
+_NEEDS_SURVEY_PREFIX = "NeedsSurvey"
+
 # States
 NEEDS_REROUTE = "NeedsReroute"
 NEEDS_LOGIN = "NeedsLogin"
@@ -58,7 +60,7 @@ NEEDS_EMAIL_CHECK = "NeedsEmailCheck"
 NEEDS_HUMAN_SOURCE = "NeedsHumanSource"
 TOO_MANY_HUMAN_SOURCES = "TooManyHumanSources"
 NEEDS_SAMPLE = "NeedsSample"
-NEEDS_PRIMARY_SURVEY = "NeedsPrimarySurvey"
+NEEDS_PRIMARY_SURVEY = _NEEDS_SURVEY_PREFIX + "1"
 ALL_DONE = "AllDone"
 
 
@@ -224,7 +226,8 @@ def workflow():
     elif next_state == NEEDS_HUMAN_SOURCE:
         return redirect("/workflow_create_human_source")
     elif next_state == NEEDS_PRIMARY_SURVEY:
-        return redirect("/workflow_take_primary_survey")
+        return redirect("/workflow_take_survey?survey_template_id=" +
+                        NEEDS_PRIMARY_SURVEY.replace(_NEEDS_SURVEY_PREFIX, ""))
     elif next_state == NEEDS_SAMPLE:
         return redirect("/workflow_claim_kit_samples")
     elif next_state == ALL_DONE:
@@ -392,40 +395,37 @@ def post_workflow_claim_kit_samples(body):
     return redirect(WORKFLOW_URL)
 
 
-def get_workflow_fill_primary_survey():
+def get_workflow_fill_survey(survey_template_id):
     next_state, current_state = determine_workflow_state()
-    if next_state != NEEDS_PRIMARY_SURVEY:
+    if next_state != _NEEDS_SURVEY_PREFIX + str(survey_template_id):
         return redirect(WORKFLOW_URL)
 
     acct_id = current_state["account_id"]
     source_id = current_state["human_source_id"]
-    primary_survey = 1
     do_return, survey_output = ApiRequest.get(
         '/accounts/%s/sources/%s/survey_templates/%s' %
-        (acct_id, source_id, primary_survey))
+        (acct_id, source_id, survey_template_id))
     if do_return:
         return survey_output
 
     return render_template("survey.jinja2",
+                           endpoint=SERVER_CONFIG["endpoint"],
+                           survey_template_id=survey_template_id,
                            survey_schema=survey_output[
                                'survey_template_text'])
 
 
-def post_workflow_fill_primary_survey():
+def post_workflow_fill_survey(survey_template_id, body):
     next_state, current_state = determine_workflow_state()
-    if next_state == NEEDS_PRIMARY_SURVEY:
+    if next_state == _NEEDS_SURVEY_PREFIX + str(survey_template_id):
         acct_id = current_state["account_id"]
         source_id = current_state["human_source_id"]
-
-        model = {}
-        for x in flask.request.form:
-            model[x] = flask.request.form[x]
 
         do_return, surveys_output = ApiRequest.post(
             "/accounts/%s/sources/%s/surveys" % (acct_id, source_id),
             json={
-                "survey_template_id": 1,
-                "survey_text": model
+                "survey_template_id": survey_template_id,
+                "survey_text": body
             }
         )
 

--- a/microsetta_private_api/templates/survey.jinja2
+++ b/microsetta_private_api/templates/survey.jinja2
@@ -11,6 +11,7 @@
     <link rel="stylesheet" href="/static/css/minimal_interface.css" />
     <script>
         var result_txt = "";
+        var error_txt = "";
 
         function postSurvey() {
             $.ajax({
@@ -21,15 +22,26 @@
                     result_txt = data;
                 },
                 error: function (jqXHR, textStatus, errorThrown) {
-                    result_txt = jqXHR.responseText;
+                    error_txt = jqXHR.responseText;
                 },
                 complete: function (data, textStatus, output_obj) {
+                    // Replace the html on this page with the html successfully received from the ajax call.
+                    // Note that the html we successfully received MAY be an html page reporting an error
+                    // captured in the back end :)
                     if (result_txt !== ""){
                         document.open();
                         document.write(result_txt);
                         document.close();
                     } else {
-                        alert(textStatus);
+                        // I can't imagine how we could get here, but just in case, at least the
+                        // user sees *something* ...
+                        if (error_txt === ""){
+                            error_txt = textStatus;
+                        }
+                        let queryParam = encodeURIComponent(error_txt);
+                        // Get customized error page that will show whatever error message we captured
+                        // here in the front end
+                        window.location.replace("{{ endpoint }}/error?error_msg=" + queryParam);
                     }
                 },
                 dataType: "html",
@@ -60,7 +72,7 @@
         <div class="container" id="app">
             <div class="panel panel-default">
                 <div class="panel-body">
-                    <form id="survey_form" onsubmit="return postAccount(this);">
+                    <form id="survey_form">
                         <vue-form-generator :schema="schema" :model="model" :options="formOptions"></vue-form-generator>
                     </form>
                 </div>

--- a/microsetta_private_api/templates/survey.jinja2
+++ b/microsetta_private_api/templates/survey.jinja2
@@ -2,12 +2,44 @@
 <html>
 <head>
     <title>Microsetta Participant Survey</title>
+    <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
     <script type="text/javascript" src="/static/vendor/js/vue-2.5.17.min.js"></script>
     <link rel="stylesheet" href="/static/vendor/bootstrap-4.4.1-dist/css/bootstrap.min.css" />
     <script type="text/javascript" src="/static/vendor/vue-form-generator-2.3.4/vfg.js"></script>
     <link rel="stylesheet" type="text/css" href="/static/vendor/vue-form-generator-2.3.4/vfg.css">
 
     <link rel="stylesheet" href="/static/css/minimal_interface.css" />
+    <script>
+        var result_txt = "";
+
+        function postSurvey() {
+            $.ajax({
+                type: "POST",
+                url: "{{ endpoint }}/workflow_take_survey?survey_template_id={{ survey_template_id }}",
+                data: JSON.stringify(survey_model),
+                success: function (data, textStatus, jqXHR) {
+                    result_txt = data;
+                },
+                error: function (jqXHR, textStatus, errorThrown) {
+                    result_txt = jqXHR.responseText;
+                },
+                complete: function (data, textStatus, output_obj) {
+                    if (result_txt !== ""){
+                        document.open();
+                        document.write(result_txt);
+                        document.close();
+                    } else {
+                        alert(textStatus);
+                    }
+                },
+                dataType: "html",
+                contentType: "application/json"
+            });
+
+            // always return false, preventing a traditional post of the form
+            return false;
+        }
+    </script>
 </head>
 <body>
     <a href="https://microsetta.ucsd.edu" title="microsetta.ucsd.edu">
@@ -28,7 +60,7 @@
         <div class="container" id="app">
             <div class="panel panel-default">
                 <div class="panel-body">
-                    <form method="post" id="survey_form">
+                    <form id="survey_form" onsubmit="return postAccount(this);">
                         <vue-form-generator :schema="schema" :model="model" :options="formOptions"></vue-form-generator>
                     </form>
                 </div>
@@ -60,7 +92,7 @@
         type: "submit",
         validateBeforeSubmit: true,
         onSubmit: function(){
-          document.getElementById("survey_form").submit();
+            return postSurvey();
         }
       });
     </script>


### PR DESCRIPTION
To accommodate vue-form-generator library limitations, change survey.jinja behavior to post form data via an ajax call rather than via a traditional form post.  Modify back-end to handle multiple surveys through the same jinja page by distinguishing survey template id.