### PR TITLE
Kiss fix for no survey answers

### DIFF
--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -596,7 +596,9 @@ def generate_error_page(error_msg):
 
     output = render_template('error.jinja2',
                              mailto_url=mailto_url,
-                             error_msg=error_msg)
+                             error_msg=error_msg,
+                             endpoint=SERVER_CONFIG["endpoint"],
+                             authrocket_url=SERVER_CONFIG["authrocket_url"])
 
     return output
 

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -178,13 +178,25 @@ class SurveyAnswersRepo(BaseRepo):
             for survey_template_group in survey_template.groups:
                 for survey_question in survey_template_group.questions:
                     survey_question_id = survey_question.id
+                    q_type = survey_question.response_type
+
+                    # TODO FIXME HACK: Modify DB to make this unnecessary!
+                    # We MUST record at least ONE answer for each survey
+                    # (even if the user answered nothing)
+                    #  or we can't properly track the survey template id later.
+                    # Therefore, if the user answered NOTHING, store an empty
+                    # string for the first string or text question in the
+                    # survey, just so something is recorded.
+                    if len(survey_model) == 0 and \
+                            (q_type == "STRING" or q_type == "TEXT"):
+                        survey_model[str(survey_question_id)] = ""
+
                     if str(survey_question_id) not in survey_model:
                         # TODO: Is this supposed to leave the question blank
                         #  or write Unspecified?
                         continue
                     answer = survey_model[str(survey_question_id)]
 
-                    q_type = survey_question.response_type
                     if q_type == "SINGLE":
                         # Normalize localized answer
                         normalized_answer = self._unlocalize(answer,
@@ -230,6 +242,19 @@ class SurveyAnswersRepo(BaseRepo):
                                     (survey_answers_id,
                                      survey_question_id,
                                      answer))
+
+        if len(survey_model) == 0:
+            # we should not have gotten to the end without recording at least
+            # ONE answer (even an empty one) ... but it could happen if this
+            # survey template includes NO text or string questions AND the
+            # user doesn't answer any of the questions it does include. Not
+            # worth making the code robust to this case, as this whole "include
+            # one empty answer is a temporary hack", but at least ensure we
+            # know this problem occurred if it ever does
+            raise RepoException("No answers provided for survey template %s "
+                                "and not able to add an empty string default" %
+                                survey_template_id)
+
         return survey_answers_id
 
     def delete_answered_survey(self, acct_id, survey_id):

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -249,7 +249,7 @@ class SurveyAnswersRepo(BaseRepo):
             # survey template includes NO text or string questions AND the
             # user doesn't answer any of the questions it does include. Not
             # worth making the code robust to this case, as this whole "include
-            # one empty answer is a temporary hack", but at least ensure we
+            # one empty answer" is a temporary hack, but at least ensure we
             # know this problem occurred if it ever does
             raise RepoException("No answers provided for survey template %s "
                                 "and not able to add an empty string default" %

--- a/microsetta_private_api/templates/error.jinja2
+++ b/microsetta_private_api/templates/error.jinja2
@@ -22,6 +22,9 @@
             <li class="breadcrumb-item"><a href="/home">Home</a></li>
           </ol>
         </nav>
+        <div>
+            <a href="{{authrocket_url}}/logout?redirect_uri={{endpoint}}/logout">Log Out</a>
+        </div>
         <div class="container">
             <p>
                 An error seemed to have occurred (see below). It is most likely our fault.
@@ -38,7 +41,6 @@
             <pre>{{ error_msg }}</pre>
         </div>
     </div>
-
     <div>
         <br />
         <p>


### PR DESCRIPTION
Record at least ONE answer to each survey (or, failing even that, error in a way that explicitly describes the problem).  Also, show logout link on error page.