### PR TITLE
Survey creation tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A private microservice to support The Microsetta Initiative
 ## Installation
 Create a new `conda` environment containing `flask` and other necessary packages:
 
-`conda create -n microsetta-private-api flask psycopg2 natsort`
+`conda create -n microsetta-private-api flask psycopg2 natsort pycryptodome`
 
 Once the conda environment is created, activate it:
 

--- a/microsetta_private_api/LEGACY/make_test_kits.py
+++ b/microsetta_private_api/LEGACY/make_test_kits.py
@@ -10,12 +10,6 @@ from microsetta_private_api.api.tests.test_integration import \
 def make_test_kits(output_filename=None, num_kits=100,
                    samples_lower_limit=1, samples_upper_limit=5):
 
-    # Ugh, imports are here inside this function because transaction
-    # (and thus test_integration, which depends on transaction)
-    # requires that an ag_test db *already* exist. Thus we can't
-    # import it without an error until after the rest of the code
-    # (outside this function) actually creates that database ...
-
     if output_filename is None:
         output_filename = "test_kit_ids_" + datetime.datetime.now().strftime(
             "%Y%m%d%H%M%S") + ".csv"

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -601,11 +601,6 @@ def read_kit(kit_name):
 def render_consent_doc(account_id, language_tag, consent_post_url, token_info):
     _validate_account_access(token_info, account_id)
 
-    # return render_template("new_participant.jinja2",
-    #                        message=MockJinja("message"),
-    #                        media_locale=MockJinja("media_locale"),
-    #                        tl=MockJinja("tl"))
-
     # NB: Do NOT need to explicitly pass account_id into template for
     # integration into form submission URL because form submit URL builds on
     # the base of the URL that called it (which includes account_id)

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -1073,22 +1073,3 @@ class SurveyTests(ApiTests):
             "survey_text": expected_model
         }
         self.assertEqual(expected_output, get_resp_obj)
-
-    # def test_source_create_fail_422(self):
-    #     """Return 422 if try to create a source with age_range 'legacy'"""
-    #     dummy_acct_id = create_dummy_acct(create_dummy_1=True)
-    #
-    #     bad_dummy_src_info = copy.deepcopy(DUMMY_HUMAN_SOURCE)
-    #     bad_dummy_src_info['consent']['age_range'] = 'legacy'
-    #
-    #     response = self.client.post(
-    #         '/api/accounts/%s/sources?%s' %
-    #         (dummy_acct_id, self.default_lang_querystring),
-    #         content_type='application/json',
-    #         data=json.dumps(bad_dummy_src_info),
-    #         headers=self.dummy_auth
-    #     )
-    #
-    #     # check response code
-    #     self.assertEqual(422, response.status_code)
-    # endregion source create/post

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -39,7 +39,8 @@ class SampleRepo(BaseRepo):
                 "ON ag_kit_barcodes.source_id = source.id "
                 "WHERE "
                 "source.account_id = %s AND "
-                "source.id = %s",
+                "source.id = %s "
+                "ORDER BY barcode.barcode asc",
                 (account_id, source_id)
             )
 


### PR DESCRIPTION
Adds some new unit tests that exercise creation of an answered survey and demonstrate it now succeeds (and we can read it back) even when the user provides no answers.  Also adds sample ordering by barcode, deletes some outdated comments, and adds pycryptodome to the install instructions.

Note these survey unit tests aren't quite as unitary as I'd like ... unlike, e.g., account post or source post, survey post doesn't return the object it creates, so I have to do an explicit subsequent get in order to round-trip the survey answers and find out if what I get back from the api is the same as what I put into the api :-/  Open to suggestions for improvement.