### PR TITLE
Sources list

### DIFF
--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -608,8 +608,6 @@ def render_consent_doc(account_id, language_tag, consent_post_url, token_info):
     localization_info = localization.LANG_SUPPORT[language_tag]
     consent_html = render_template(
         "new_participant.jinja2",
-        page_title="Consent",
-        show_breadcrumbs=True,
         tl=localization_info[localization.NEW_PARTICIPANT_KEY],
         lang_tag=language_tag,
         post_url=consent_post_url

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -729,9 +729,6 @@ def generate_error_page(error_msg):
 
 def render_faq():
     output = render_template('faq.jinja2',
-                             page_title="Frequently Asked Questions",
-                             show_breadcrumbs=True,
-                             show_logout=False,
                              authrocket_url=SERVER_CONFIG["authrocket_url"],
                              endpoint=SERVER_CONFIG["endpoint"])
     return output

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -207,17 +207,6 @@ def determine_workflow_state():
     if not has_covid:
         return NEEDS_COVID_SURVEY, current_state
 
-    # Does the human source have any samples? NO-> kit_sample_association.html
-    needs_reroute, samples_output, _ = ApiRequest.get(
-        "/accounts/{0}/sources/{1}/samples".format(acct_id, source_id))
-    if needs_reroute:
-        current_state["reroute"] = surveys_output
-        return NEEDS_REROUTE, current_state
-    if len(samples_output) == 0:
-        return NEEDS_SAMPLE, current_state
-
-    current_state['sample_objs'] = samples_output
-
     return ALL_DONE, current_state
 
 
@@ -243,14 +232,11 @@ def workflow():
     elif next_state == NEEDS_COVID_SURVEY:
         return redirect("/workflow_take_survey?survey_template_id=" +
                         NEEDS_COVID_SURVEY.replace(_NEEDS_SURVEY_PREFIX, ""))
-    elif next_state == NEEDS_SAMPLE:
-        return redirect("/workflow_claim_kit_samples")
     elif next_state == ALL_DONE:
-        # redirect to the page showing all the samples for this source
-        samples_url = "/accounts/{account_id}/sources/{source_id}".format(
-            account_id=current_state["account_id"],
-            source_id=current_state["human_source_id"])
-        return redirect(samples_url)
+        # redirect to the account page (showing all the sources)
+        acct_url = "/accounts/{account_id}".format(
+            account_id=current_state["account_id"])
+        return redirect(acct_url)
 
 
 def get_workflow_create_account():
@@ -471,12 +457,14 @@ def post_workflow_fill_survey(survey_template_id, body):
 
 
 def get_account(account_id):
-    if TOKEN_KEY_NAME not in session:
+    next_state, current_state = determine_workflow_state()
+    if next_state != ALL_DONE:
         return redirect(WORKFLOW_URL)
 
     do_return, sources, _ = ApiRequest.get('/accounts/%s/sources' % account_id)
     if do_return:
         return sources
+
     return render_template('account.jinja2',
                            acct_id=account_id,
                            sources=sources)

--- a/microsetta_private_api/static/kit_check.js
+++ b/microsetta_private_api/static/kit_check.js
@@ -23,5 +23,5 @@ function verify_kit_claim(form_name) {
             }
         });
     };
-};
+}
 

--- a/microsetta_private_api/templates/account.jinja2
+++ b/microsetta_private_api/templates/account.jinja2
@@ -1,0 +1,20 @@
+{% extends "sitebase.jinja2" %}
+{% set page_title = "Sources" %}
+{% set show_breadcrumbs = True %}
+{% block head %}
+{% endblock %}
+{% block content %}
+        <div class="container">
+            {%  if sources|length > 0 %}
+            Sources:
+            <div class="list-group">
+                {% for source in sources %}
+                <a href="/accounts/{{acct_id}}/sources/{{ source.source_id }}"
+                   class="list-group-item list-group-item-action {{loop.cycle('odd', 'even') }}">
+                    {{ source.source_name }}
+                </a>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+{% endblock %}

--- a/microsetta_private_api/templates/faq.jinja2
+++ b/microsetta_private_api/templates/faq.jinja2
@@ -1,6 +1,6 @@
 {% extends "sitebase.jinja2" %}
-{% set page_title="Frequently Asked Questions" %}
-{% set show_breadcrumbs=True %}
+{% set page_title = "Frequently Asked Questions" %}
+{% set show_breadcrumbs = True %}
 {% block head %}
     <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
     <script>

--- a/microsetta_private_api/templates/faq.jinja2
+++ b/microsetta_private_api/templates/faq.jinja2
@@ -1,4 +1,6 @@
 {% extends "sitebase.jinja2" %}
+{% set page_title="Frequently Asked Questions" %}
+{% set show_breadcrumbs=True %}
 {% block head %}
     <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
     <script>

--- a/microsetta_private_api/templates/new_participant.jinja2
+++ b/microsetta_private_api/templates/new_participant.jinja2
@@ -1,4 +1,6 @@
 {% extends "sitebase.jinja2" %}
+{% set page_title="Consent" %}
+{% set show_breadcrumbs=True %}
 {% block head %}
 <script src="/static/vendor/js/jquery-1.11.1.min.js"></script>
 <script src="/static/vendor/js/jquery-ui-1.10.1.custom.min.js"></script>

--- a/microsetta_private_api/templates/new_participant.jinja2
+++ b/microsetta_private_api/templates/new_participant.jinja2
@@ -1,6 +1,6 @@
 {% extends "sitebase.jinja2" %}
-{% set page_title="Consent" %}
-{% set show_breadcrumbs=True %}
+{% set page_title = "Consent" %}
+{% set show_breadcrumbs = True %}
 {% block head %}
 <script src="/static/vendor/js/jquery-1.11.1.min.js"></script>
 <script src="/static/vendor/js/jquery-ui-1.10.1.custom.min.js"></script>

--- a/microsetta_private_api/templates/sample.jinja2
+++ b/microsetta_private_api/templates/sample.jinja2
@@ -48,9 +48,9 @@
     </div>
 
     <script type="text/javascript">
-      var survey_model={{sample|tojson}}
-      var survey_schema={{schema|tojson}}
-      last_group = survey_schema.groups[survey_schema.groups.length-1]
+      var survey_model={{sample|tojson}};
+      var survey_schema={{schema|tojson}};
+      last_group = survey_schema.groups[survey_schema.groups.length-1];
       last_group.fields.push(
       {
         buttonText: "Update",

--- a/microsetta_private_api/templates/sample.jinja2
+++ b/microsetta_private_api/templates/sample.jinja2
@@ -31,6 +31,7 @@
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/home">Home</a></li>
+            <li class="breadcrumb-item"><a href="/accounts/{{acct_id}}">Sources</a></li>
             <li class="breadcrumb-item"><a href="/accounts/{{acct_id}}/sources/{{source_id}}">Samples</a></li>
           </ol>
         </nav>

--- a/microsetta_private_api/templates/source.jinja2
+++ b/microsetta_private_api/templates/source.jinja2
@@ -28,67 +28,73 @@
         <nav aria-label="breadcrumb">
           <ol class="breadcrumb">
             <li class="breadcrumb-item"><a href="/home">Home</a></li>
+            <li class="breadcrumb-item"><a href="/accounts/{{acct_id}}">Sources</a></li>
           </ol>
         </nav>
         <div class="container">
-            Samples:
-            {% if samples|length > 1 %}
-            <p><i>If collecting all samples on the same day, please only complete a single Food Frequency Questionnaire.</i></p>
-            {% endif %}
-            <div class="list-group">
-                {% for sample in samples %}
-                <div class="container list-group-item {{loop.cycle('odd', 'even') }}">
-                  <div class="row">
-                    <div class="col-sm">
-                      <a href="/accounts/{{acct_id}}/sources/{{source_id}}/samples/{{sample.sample_id}}">{{sample.sample_barcode |e}}</a>
+            {% if samples|length > 0 %}
+                Samples:
+                {% if samples|length > 1 %}
+                <p><i>If collecting all samples on the same day, please only complete a single Food Frequency Questionnaire.</i></p>
+                {% endif %}
+                <div class="list-group">
+                    {% for sample in samples %}
+                    <div class="container list-group-item {{loop.cycle('odd', 'even') }}">
+                      <div class="row">
+                        <div class="col-sm">
+                          <a href="/accounts/{{acct_id}}/sources/{{source_id}}/samples/{{sample.sample_id}}">{{sample.sample_barcode |e}}</a>
+                        </div>
+                        <div class="col-sm">
+                          {{sample.sample_datetime |e}}
+                        </div>
+                        <div class="col-sm">
+                          {{sample.sample_site |e}}
+                        </div>
+                        <div class="col-sm">
+                          {% if sample.ffq %}
+                            Food Frequency Questionnaire<span class="fa fa-check"/>
+                          {% else %}
+                            <a href="/accounts/{{acct_id}}/sources/{{source_id}}/samples/{{sample.sample_id}}/survey_templates/{{vioscreen_id}}">Food Frequency Questionnaire</a><span class="fa fa-unchecked"/>
+                          {% endif %}
+                        </div>
+                      </div>
                     </div>
-                    <div class="col-sm">
-                      {{sample.sample_datetime |e}}
-                    </div>
-                    <div class="col-sm">
-                      {{sample.sample_site |e}}
-                    </div>
-                    <div class="col-sm">
-                      {% if sample.ffq %}
-                        Food Frequency Questionnaire<span class="fa fa-check"/>
-                      {% else %}
-                        <a href="/accounts/{{acct_id}}/sources/{{source_id}}/samples/{{sample.sample_id}}/survey_templates/{{vioscreen_id}}">Food Frequency Questionnaire</a><span class="fa fa-unchecked"/>
-                      {% endif %}
-                    </div>
-                  </div>
-                </div>
-                {% endfor %}
+                    {% endfor %}
+                {% endif %}
             </div>
         </div>
         <div class="container">
             <form method="post" name="kit_claim_form" action="/claim_additional_kit">
                 <div class="form-group">
-                    <label for="kit_name" name="kit_name_label">Have another kit with more samples? Please enter the kit ID here:</label>
+                    <label for="kit_name" name="kit_name_label">To add samples, please enter a kit ID here:</label>
                     <input id="kit_name" name="kit_name" class="form-control" type="text"/>
                  </div>
                 <input type="submit" class="btn btn-primary" value="Add samples"/>
             </form>
         </div>
+        <p></p>
         <div class="container">
-            <p>Surveys taken:</p>
-            <div class="list-group">
-                {% for survey in surveys %}
-                <div class="container list-group-item {{loop.cycle('odd', 'even') }}">
-                  <div class="row">
-                    <div class="col-sm">
-                      {{survey.survey_template_title |e}}
+            {% if surveys|length > 0 %}
+                <p>Surveys taken:</p>
+                <div class="list-group">
+                    {% for survey in surveys %}
+                    <div class="container list-group-item {{loop.cycle('odd', 'even') }}">
+                      <div class="row">
+                        <div class="col-sm">
+                          {{survey.survey_template_title |e}}
+                        </div>
+                        <div class="col-sm">
+                            {% if survey.answered %}
+                            <span class="fa fa-check"/>
+                            {% else %}
+                            <span class="fa fa-unchecked"/>
+                            {% endif %}
+                        </div>
+                      </div>
                     </div>
-                    <div class="col-sm">
-                        {% if survey.answered %}
-                        <span class="fa fa-check"/>
-                        {% else %}
-                        <span class="fa fa-unchecked"/>
-                        {% endif %}
-                    </div>
-                  </div>
-                </div>
-                </a>
-                {% endfor %}
+                    </a>
+                    {% endfor %}
+                {% endif %}
             </div>
         </div>
     </div>

--- a/microsetta_private_api/templates/update_email.jinja2
+++ b/microsetta_private_api/templates/update_email.jinja2
@@ -34,7 +34,7 @@
             you logged in with.  Would you like us to update your email in our records?
             <br />
             <br />
-            <form method="post" name="kit_claim_form" action="/workflow_update_email">
+            <form method="post" name="update_email_form" action="/workflow_update_email">
                 <input type="hidden" id="do_update" name = "do_update" value="Yes" />
                 <button type="submit" class="btn btn-light" onclick="cancelEmailUpdate();">
                     No, skip and continue


### PR DESCRIPTION
Main changes: Change workflow so that it ends at list of sources, not list of samples. Expand breadcrumbs so show this extra level where needed. Add logic to prevent printing list header (e.g. "Samples") when list is empty.


Minor changes: move some hard-coded settings used by sitebase into extension templates, add semicolons at end of javascript statements, replace a copy-pasted form name with relevant one.
