### PR TITLE
Allow for tracking which kit ID an account was created using

### DIFF
--- a/microsetta_private_api/admin/tests/test_admin.py
+++ b/microsetta_private_api/admin/tests/test_admin.py
@@ -40,7 +40,8 @@ class AdminTests(TestCase):
                               "CA",
                               12345,
                               "US"
-                          ))
+                          ),
+                          "fakekit")
             acct_repo.create_account(acc)
 
             acc = Account(ADMIN_ACCT_ID,
@@ -56,7 +57,8 @@ class AdminTests(TestCase):
                               "CA",
                               12345,
                               "US"
-                          ))
+                          ),
+                          "fakekit")
             acct_repo.create_account(acc)
             t.commit()
 

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -158,7 +158,6 @@ def update_account(account_id, body, token_info):
             body['address']['post_code'],
             body['address']['country_code']
         )
-        acc.created_with_kit_name = body.get('kit_name')
 
         # 422 handling is done inside acct_repo
         acct_repo.update_account(acc)

--- a/microsetta_private_api/api/implementation.py
+++ b/microsetta_private_api/api/implementation.py
@@ -70,6 +70,7 @@ def find_accounts_for_login(token_info):
 
         if acct is None:
             return jsonify([]), 200
+
         return jsonify([acct.to_api()]), 200
 
 
@@ -157,6 +158,7 @@ def update_account(account_id, body, token_info):
             body['address']['post_code'],
             body['address']['country_code']
         )
+        acc.created_with_kit_name = body.get('kit_name')
 
         # 422 handling is done inside acct_repo
         acct_repo.update_account(acc)
@@ -687,7 +689,6 @@ def _validate_account_access(token_info, account_id):
         token_associated_account = account_repo.find_linked_account(
             token_info['iss'],
             token_info['sub'])
-
         account = account_repo.get_account(account_id)
         if account is None:
             raise NotFound(ACCT_NOT_FOUND_MSG)

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -366,7 +366,6 @@ class ApiTests(TestCase):
                 else:
                     raise ValueError(format("unexpect request action: ",
                                             action))
-
                 self.assertEqual(400, response.status_code)
                 resp_obj = json.loads(response.data)
                 self.assertTrue(curr_expected_msg in resp_obj['detail'])
@@ -395,12 +394,6 @@ class ApiTests(TestCase):
         # check all input fields/values appear in response body EXCEPT kit_name
         # plus additional fields
         expected_dict = copy.deepcopy(dummy_acct_dict)
-        try:
-            expected_dict.pop(KIT_NAME_KEY)
-        except KeyError:
-            # is ok if input did not have a kit name, as this is
-            # provided on account create but not account update
-            pass
         expected_dict[ACCT_ID_KEY] = real_acct_id_from_body
         expected_dict[ACCT_TYPE_KEY] = ACCT_TYPE_VAL
         expected_dict[CREATION_TIME_KEY] = real_creation_time
@@ -641,9 +634,11 @@ class AccountTests(ApiTests):
 
     # region account update/put tests
     @staticmethod
-    def make_updated_acct_dict():
+    def make_updated_acct_dict(keep_kit_name=False):
         result = copy.deepcopy(DUMMY_ACCT_INFO)
-        result.pop(KIT_NAME_KEY)
+
+        if not keep_kit_name:
+            result.pop(KIT_NAME_KEY)
 
         result["address"] = {
             "city": "Oakland",
@@ -659,7 +654,7 @@ class AccountTests(ApiTests):
         """Successfully update existing account"""
         dummy_acct_id = create_dummy_acct()
 
-        changed_acct_dict = self.make_updated_acct_dict()
+        changed_acct_dict = self.make_updated_acct_dict(keep_kit_name=True)
 
         # create post input json
         input_json = json.dumps(changed_acct_dict)

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -163,7 +163,8 @@ class IntegrationTests(TestCase):
                               "CA",
                               12345,
                               "US"
-                          ))
+                          ),
+                          "fakekit")
             acct_repo.create_account(acc)
 
             source_repo.create_source(Source(
@@ -504,7 +505,8 @@ class IntegrationTests(TestCase):
                 },
                 "email": "foo@baz.com",
                 "first_name": "Dan",
-                "last_name": "H"
+                "last_name": "H",
+                "kit_name": "fakekit"
             }
 
         # Hard to guess these two, so let's pop em out
@@ -514,12 +516,14 @@ class IntegrationTests(TestCase):
 
         regular_data.pop("account_id")
 
-        # Don't fuzz the email--changing the email in the accounts table
-        # without changing the email in the authorization causes
+        # Don't fuzz the email or kit_name -- changing the email in the
+        # accounts table without changing the email in the authorization causes
         # authorization errors (as it should)
         the_email = regular_data["email"]
+        kit_name = regular_data['kit_name']
         fuzzy_data = fuzz(regular_data)
         fuzzy_data['email'] = the_email
+        fuzzy_data['kit_name'] = kit_name
 
         # submit an invalid account type
         fuzzy_data['account_type'] = "Voldemort"
@@ -563,6 +567,7 @@ class IntegrationTests(TestCase):
         check_response(response)
 
         acc = json.loads(response.data)
+
         acc.pop('creation_time')
         acc.pop('update_time')
         regular_data['account_type'] = 'standard'

--- a/microsetta_private_api/db/patches/0063.sql
+++ b/microsetta_private_api/db/patches/0063.sql
@@ -1,0 +1,41 @@
+-- create a column that can be used to record what kit was used 
+-- when the account was created. 
+ALTER TABLE ag.account ADD COLUMN created_with_kit_id VARCHAR;
+
+-- from existing accounts, recover a kit that is associated with
+-- the account. if someone has a single kit, then that kit is used
+-- and has to be what was registered with. If they have multiple
+-- kits, then we'll just pick one of them as in the old system,
+-- users would have had to register with each kit individually.
+-- This should be suitable for newly created accounts where 
+-- people have assigned samples.
+UPDATE ag.account a SET created_with_kit_id = ss.kit_id
+    FROM (SELECT s.account_id, (array_agg(supplied_kit_id))[1] AS kit_id 
+          FROM ag.ag_kit ak 
+             JOIN ag.ag_kit_barcodes akb USING (ag_kit_id) 
+             INNER JOIN ag.source s ON (akb.source_id=s.id) 
+          GROUP BY s.account_id) ss
+    WHERE a.id = ss.account_id;
+
+-- a large number of kits have samples that were never assigned, 
+-- which resulted in them not being linked to the "source" table
+-- during migration. to handle this, let's use the older links in 
+-- the database.
+UPDATE ag.account SET created_with_kit_id=subquery.kit_id
+    FROM (SELECT ag_login_id, (array_agg(supplied_kit_id))[1] AS kit_id
+          FROM ag.account a
+              JOIN ag.ag_kit ak ON a.id=ak.ag_login_id
+              JOIN ag.ag_kit_barcodes USING(ag_kit_id)
+          WHERE created_with_kit_id IS NULL 
+          GROUP BY ag_login_id) AS subquery
+    WHERE id=subquery.ag_login_id;
+
+-- finally, there are a handful where the created_with_kit_id remains null.
+-- on inspection, this appears to happen in the new system when someone
+-- has created an account but hasn't yet claimed samples from a kit. We'll 
+-- set those to the empty string so that we can make created_with_kit_id
+-- not null
+UPDATE ag.account SET created_with_kit_id=''
+    WHERE created_with_kit_id IS NULL;
+
+ALTER TABLE ag.account ALTER COLUMN created_with_kit_id SET NOT NULL;

--- a/microsetta_private_api/model/account.py
+++ b/microsetta_private_api/model/account.py
@@ -28,15 +28,16 @@ class Account(ModelBase):
                 input_dict['address']['city'],
                 input_dict['address']['state'],
                 input_dict['address']['post_code'],
-                input_dict['address']['country_code'],
-            )
+                input_dict['address']['country_code']
+            ),
+            input_dict['kit_name']
         )
         return result
 
     def __init__(self, account_id, email,
                  account_type, auth_issuer, auth_sub,
                  first_name, last_name,
-                 address,
+                 address, created_with_kit_id,
                  creation_time=None, update_time=None):
         self.id = account_id
         self.email = email
@@ -46,6 +47,7 @@ class Account(ModelBase):
         self.first_name = first_name
         self.last_name = last_name
         self.address = address
+        self.created_with_kit_id = created_with_kit_id
         self.creation_time = creation_time
         self.update_time = update_time
 
@@ -59,7 +61,8 @@ class Account(ModelBase):
             "address": self.address.to_api(),
             "account_type": self.account_type,
             "creation_time": self.creation_time,
-            "update_time": self.update_time
+            "update_time": self.update_time,
+            "kit_name": self.created_with_kit_id
         }
 
     def account_matches_auth(self, email, auth_issuer, auth_sub):

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -14,12 +14,13 @@ class AccountRepo(BaseRepo):
                 "account_type, auth_issuer, auth_sub, " \
                 "first_name, last_name, " \
                 "street, city, state, post_code, country_code, " \
-                "creation_time, update_time, created_with_kit_id"
+                "created_with_kit_id, creation_time, update_time"
 
     write_cols = "id, email, " \
                  "account_type, auth_issuer, auth_sub, " \
-                 "first_name, last_name, created_with_kit_id, " \
-                 "street, city, state, post_code, country_code"
+                 "first_name, last_name, " \
+                 "street, city, state, post_code, country_code, " \
+                 "created_with_kit_id"
 
     @staticmethod
     def _row_to_addr(r):
@@ -48,8 +49,9 @@ class AccountRepo(BaseRepo):
     def _account_to_row(a):
         return (a.id, a.email,
                 a.account_type, a.auth_issuer, a.auth_sub,
-                a.first_name, a.last_name, a.created_with_kit_id) + \
-                AccountRepo._addr_to_row(a.address)
+                a.first_name, a.last_name) + \
+                AccountRepo._addr_to_row(a.address) + \
+                (a.created_with_kit_id, )
 
     def claim_legacy_account(self, email, auth_iss, auth_sub):
         # Returns now-claimed legacy account if an unclaimed legacy account
@@ -146,12 +148,12 @@ class AccountRepo(BaseRepo):
                             "auth_sub = %s, "
                             "first_name = %s, "
                             "last_name = %s, "
-                            "created_with_kit_id = %s, "
                             "street = %s, "
                             "city = %s, "
                             "state = %s, "
                             "post_code = %s, "
-                            "country_code = %s "
+                            "country_code = %s, "
+                            "created_with_kit_id = %s "
                             "WHERE "
                             "account.id = %s",
                             final_row

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -14,11 +14,11 @@ class AccountRepo(BaseRepo):
                 "account_type, auth_issuer, auth_sub, " \
                 "first_name, last_name, " \
                 "street, city, state, post_code, country_code, " \
-                "creation_time, update_time"
+                "creation_time, update_time, created_with_kit_id"
 
     write_cols = "id, email, " \
                  "account_type, auth_issuer, auth_sub, " \
-                 "first_name, last_name, " \
+                 "first_name, last_name, created_with_kit_id, " \
                  "street, city, state, post_code, country_code"
 
     @staticmethod
@@ -41,14 +41,15 @@ class AccountRepo(BaseRepo):
             r['account_type'], r['auth_issuer'], r['auth_sub'],
             r['first_name'], r['last_name'],
             AccountRepo._row_to_addr(r),
+            r['created_with_kit_id'],
             r['creation_time'], r['update_time'])
 
     @staticmethod
     def _account_to_row(a):
         return (a.id, a.email,
                 a.account_type, a.auth_issuer, a.auth_sub,
-                a.first_name, a.last_name) + \
-               AccountRepo._addr_to_row(a.address)
+                a.first_name, a.last_name, a.created_with_kit_id) + \
+                AccountRepo._addr_to_row(a.address)
 
     def claim_legacy_account(self, email, auth_iss, auth_sub):
         # Returns now-claimed legacy account if an unclaimed legacy account
@@ -136,7 +137,6 @@ class AccountRepo(BaseRepo):
             row_id = row[0:1]
             row_email_to_cc = row[1:]
             final_row = row_email_to_cc + row_id
-
             try:
                 cur.execute("UPDATE account "
                             "SET "
@@ -146,6 +146,7 @@ class AccountRepo(BaseRepo):
                             "auth_sub = %s, "
                             "first_name = %s, "
                             "last_name = %s, "
+                            "created_with_kit_id = %s, "
                             "street = %s, "
                             "city = %s, "
                             "state = %s, "
@@ -177,7 +178,7 @@ class AccountRepo(BaseRepo):
                             "%s, %s, "
                             "%s, %s, %s, "
                             "%s, %s, "
-                            "%s, %s, %s, %s, %s)",
+                            "%s, %s, %s, %s, %s, %s)",
                             AccountRepo._account_to_row(account))
                 return cur.rowcount == 1
         except psycopg2.errors.UniqueViolation as e:


### PR DESCRIPTION
In brief: modify account table, recover kit IDs from old accounts, and modify the model/repo code to allow for getting a kit name in and out from the `accounts` table.