### PR TITLE
Obtain account information based on the created_with_kit_id field

### DIFF
--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -351,6 +351,9 @@ class AdminRepo(BaseRepo):
         acct_repo = AccountRepo(self._transaction)
         ids = acct_repo.get_account_ids_by_email(email)
 
+        if len(ids) == 0:
+            return None
+
         accts = [acct_repo.get_account(acct_id) for acct_id in ids]
         diagnostic = {
             "accounts": accts

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -319,7 +319,24 @@ class AdminRepo(BaseRepo):
             # account info associated with it
             pre_microsetta_acct = acct_repo.get_account(row['account_id'])
 
+        # obtain information on any accounts created using the kit ID
+        with self._transaction.dict_cursor() as cur:
+            cur.execute(
+                "SELECT id as account_id "
+                "FROM "
+                "account "
+                "WHERE "
+                "created_with_kit_id = %s",
+                (supplied_kit_id, ))
+            rows = cur.fetchall()
+
+        accounts_created = None
+        if len(rows) > 0:
+            accounts_created = [acct_repo.get_account(row['account_id'])
+                                for row in rows]
+
         diagnostic = {
+            'accounts_created': accounts_created,
             'kit_id': kit.id,
             'supplied_kit_id': supplied_kit_id,
             'kit': kit,


### PR DESCRIPTION
The `created_with_kit_id` field is available under `account`, however it was not hooked up to the diagnostics when searching by kit ID. 