### PR TITLE
NameError on acct_repo depending on code path taken

### DIFF
--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -332,6 +332,7 @@ class AdminRepo(BaseRepo):
 
         accounts_created = None
         if len(rows) > 0:
+            acct_repo = AccountRepo(self._transaction)
             accounts_created = [acct_repo.get_account(row['account_id'])
                                 for row in rows]
 


### PR DESCRIPTION
It's possible to take a code path through `AdminRepo.retrieve_diagnostics_by_email` which would trigger a `NameError`. Issue fixed here. 