### PR TITLE
No implicit form submission

### DIFF
--- a/microsetta_private_api/static/input_util.js
+++ b/microsetta_private_api/static/input_util.js
@@ -1,10 +1,32 @@
-
-function preclude_whitespace(selector)
-{
-    <!--https://stackoverflow.com/questions/12010275/strip-white-spaces-on-input-->
+function preclude_whitespace(selector) {
+    // https://stackoverflow.com/questions/12010275/strip-white-spaces-on-input
     $(selector).bind('input', function(){
         $(this).val(function(_, v){
             return v.replace(/\s+/g, '');
+        });
+    });
+}
+
+// Disable implicit submission for the form with the input name (NOT id).
+// While implicit submission is strongly recommended by the HTML
+// standards for accessibility purposes, it is causing confusion
+// and premature form submission for our user base
+function preventImplicitSubmission(form_name){
+    let implicit_sub_input_types = ["text", "search", "url", "tel", "email", "password", "date", "month", "week", "time",
+        "datetime-local", "number"];
+    let partial_selector = 'form[name ="' + form_name + '"] input[type="';
+    $.each(implicit_sub_input_types, function(index, value) {
+        let input_elements = $(partial_selector + value + '"]');
+
+        // for each input element of the given type in form, disable submit on pressing Enter
+        // by making the keydown event return false on presses of that key
+        input_elements.each(function() {
+            $(this).keydown(function (e) {
+                if (e.keyCode === 13) {
+                    e.preventDefault();
+                    return false;
+                }
+            });
         });
     });
 }

--- a/microsetta_private_api/static/vue_survey_form.js
+++ b/microsetta_private_api/static/vue_survey_form.js
@@ -40,3 +40,7 @@ var vm = new Vue({
         }
     },
 });
+
+// This CANNOT be done in $(document).ready() on the page containing the vue form because
+// the vue form is not created until after point :(
+preventImplicitSubmission("survey_form");

--- a/microsetta_private_api/templates/account_details.jinja2
+++ b/microsetta_private_api/templates/account_details.jinja2
@@ -4,13 +4,14 @@
 {% set show_logout = True %}
 {% block head %}
     <script>
-        // Wait for the DOM to be ready
-        $(function() {
-            preclude_whitespace("#kit_name")
+        $(document).ready(function(){
+            let form_name = 'acct_form';
+            preventImplicitSubmission(form_name);
+            preclude_whitespace("#kit_name");
 
             // Initialize form validation on the registration form.
             // It has the name attribute "registration"
-            $("form[name='acct_form']").validate({
+            $("form[name='" + form_name + "']").validate({
                 // Specify validation rules
                 rules: {
                     // The key name on the left side is the name attribute

--- a/microsetta_private_api/templates/account_details.jinja2
+++ b/microsetta_private_api/templates/account_details.jinja2
@@ -3,8 +3,6 @@
 {% set show_breadcrumbs = True %}
 {% set show_logout = True %}
 {% block head %}
-    <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
-    <script src="/static/vendor/js/jquery.validate.min.js"></script>
     <script>
         // Wait for the DOM to be ready
         $(function() {

--- a/microsetta_private_api/templates/account_overview.jinja2
+++ b/microsetta_private_api/templates/account_overview.jinja2
@@ -5,23 +5,6 @@
 {% block head %}
     <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
     <script src="/static/vendor/js/jquery.validate.min.js"></script>
-    <script>
-        $(document).ready(function() {
-            // Initialize form validation
-            $("form[name='new_source_form']").validate({
-                // Specify validation rules
-                rules: {
-                    // The key name on the left side is the name attribute
-                    // of an input field. Validation rules are defined
-                    // on the right side
-
-                    // TODO: Nothing here keeps someone from e.g. naming all their sources "Bob", etc
-                    source_name: "required",
-                    source_type: "required"
-                }
-            });
-        });
-    </script>
 {% endblock %}
 {% block breadcrumb %}
     <li class="breadcrumb-item active" aria-current="page">Account</li>

--- a/microsetta_private_api/templates/create_nonhuman_source.jinja2
+++ b/microsetta_private_api/templates/create_nonhuman_source.jinja2
@@ -2,7 +2,11 @@
 {% set page_title = "Create Non-human Source" %}
 {% set show_breadcrumbs = True %}
 {% block head %}
-
+    <script>
+        $(document).ready(function(){
+            preventImplicitSubmission("new_source_form");
+        });
+    </script>
 {% endblock %}
 {% block content %}
     <div class="container">

--- a/microsetta_private_api/templates/sample.jinja2
+++ b/microsetta_private_api/templates/sample.jinja2
@@ -11,30 +11,34 @@
     <script type="text/javascript" src="/static/vendor/js/jquery.timepicker.min.js"></script>
 
     <script>
-    $( function() {
-      $( "#sample_date" ).datepicker({
-          onClose: function() {
-            $(this).valid();
-            }});
+        $(document).ready(function(){
+            let form_name = 'sample_form';
+            preventImplicitSubmission(form_name);
 
-      $( "#sample_time" ).timepicker({
-          timeFormat: 'h:mm p',
-          interval: 30,
-          {% if sample.sample_time == "" %}
-          defaultTime: 'now',
-          {% else %}
-          defaultTime: '{{ sample.sample_time }}',
-          {% endif %}
-          startTime: '8',
-          dynamic: false,
-          dropdown: true,
-          scrollbar: true,
-          change: function() {
-            $(this).valid();
-            }
-      });
+            $("#sample_date" ).datepicker({
+                onClose: function() {
+                    $(this).valid();
+                }
+            });
 
-      $("form[name='sample_form']").validate({
+            $( "#sample_time" ).timepicker({
+                timeFormat: 'h:mm p',
+                interval: 30,
+                {% if sample.sample_time == "" %}
+                defaultTime: 'now',
+                {% else %}
+                defaultTime: '{{ sample.sample_time }}',
+                {% endif %}
+                startTime: '8',
+                dynamic: false,
+                dropdown: true,
+                scrollbar: true,
+                change: function() {
+                    $(this).valid();
+                }
+            });
+
+            $("form[name='" + form_name + "']").validate({
                 // don't automatically move into the Date field
                 // as that triggers the pop up and it's annoying
                 focusInvalid: false,
@@ -56,12 +60,12 @@
                 }
             });
 
-        {% if not is_environmental %}
-        // https://github.com/jquery-validation/jquery-validation/issues/1872#issuecomment-257874743
-        $('#sample_site').on('change', function(){
-            $("form[name='sample_form']").validate().element('select');
-        });
-        {% endif %}
+            {% if not is_environmental %}
+            // https://github.com/jquery-validation/jquery-validation/issues/1872#issuecomment-257874743
+            $('#sample_site').on('change', function(){
+                $("form[name='" + form_name + "']").validate().element('select');
+            });
+            {% endif %}
     });
     </script>
 {% endblock %}

--- a/microsetta_private_api/templates/sample.jinja2
+++ b/microsetta_private_api/templates/sample.jinja2
@@ -129,11 +129,11 @@
           {% endif %}
 
           <div class="form-group">
-            <label for="sample_notes" name="sample_notes_label">Notes</label>
+            <label for="sample_notes" id="sample_notes_label">Notes</label>
             <div class="col-sm-10">
                 <textarea class="form-control" id="sample_notes" name="sample_notes" rows=3>{{ sample.sample_notes |e}}</textarea>
-    </div>
-
+            </div>
+          </div>
          <button type="submit" class="btn btn-primary">Update</button>
       </form>
     </div>

--- a/microsetta_private_api/templates/sitebase.jinja2
+++ b/microsetta_private_api/templates/sitebase.jinja2
@@ -4,26 +4,25 @@
     <meta charset="utf-8"/>
     <title>Microsetta {{page_title}}</title>
 
+    <link rel="stylesheet" href="/static/vendor/bootstrap-4.4.1-dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="/static/css/minimal_interface.css" />
+    <style>
+        {% if admin_mode %}
+        body {
+            padding-top: 50px;
+            margin: 2%;
+        }
+        {% endif %}
+    </style>
+
     <!-- jquery must be enabled before bootstrap for collapsible functionality -->
     <script src="/static/vendor/js/jquery-3.4.1.min.js"></script>
     <script src="/static/vendor/js/jquery.validate.min.js"></script>
     <script src="/static/vendor/bootstrap-4.4.1-dist/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="/static/vendor/bootstrap-4.4.1-dist/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="/static/css/minimal_interface.css" />
     <script src="/static/input_util.js"></script>
 
     {%block head%}
     {%endblock%}
-
-
-    <style>
-    {% if admin_mode %}
-    body {
-        padding-top: 50px;
-        margin: 2%;
-    }
-    {% endif %}
-    </style>
 </head>
 <body>
     {% if admin_mode %}

--- a/microsetta_private_api/templates/source.jinja2
+++ b/microsetta_private_api/templates/source.jinja2
@@ -75,9 +75,11 @@
 
         // Wait for the DOM to be ready
         $(document).ready(function(){
-            preclude_whitespace('#kit_name')
+            let form_name = 'list_kit_form';
+            preventImplicitSubmission(form_name);
+            preclude_whitespace('#kit_name');
 
-            let kit_validation_setup_func = make_kit_validation_setup_func('list_kit_form', kitSubmitHandler);
+            let kit_validation_setup_func = make_kit_validation_setup_func(form_name, kitSubmitHandler);
             kit_validation_setup_func()
         });
     </script>

--- a/microsetta_private_api/templates/survey.jinja2
+++ b/microsetta_private_api/templates/survey.jinja2
@@ -49,16 +49,14 @@
             return false;
         }
 
-        function set_triggers(model, field)
-        {
-            if ('triggered_by' in field && field.triggered_by !== null && field.triggered_by.length > 0)
-            {
-                field.visible = function()
-                {
-                  visible = false
-                  for (var entry of field.triggered_by)
-                      visible |= (model[entry['q_id']] === entry['response'])
-                  return visible
+        function set_triggers(model, field) {
+            if ('triggered_by' in field && field.triggered_by !== null && field.triggered_by.length > 0) {
+                field.visible = function() {
+                    let visible = false;
+                    for (let entry of field.triggered_by) {
+                        visible |= (model[entry['q_id']] === entry['response']);
+                    }
+                    return visible;
                 }
             }
         }
@@ -70,37 +68,36 @@
 {% block content %}
     <div class="panel panel-default">
         <div class="panel-body">
-            <form id="survey_form">
+            <form id="survey_form" name="survey_form">
                 <vue-form-generator :schema="schema" :model="model" :options="formOptions"></vue-form-generator>
             </form>
         </div>
     </div>
 
     <script type="text/javascript">
-      var survey_model = {}
-      var survey_schema={{survey_schema|tojson}}
+        var survey_model = {};
+        var survey_schema= {{survey_schema|tojson}} ;
 
-      if (survey_schema.fields !== null)
-        for (var field of survey_schema.fields)
-        {
-          set_triggers(survey_model, field)
+        if (survey_schema.fields !== null) {
+            for (let field of survey_schema.fields) {
+                set_triggers(survey_model, field)
+            }
+            for (let group of survey_schema.groups) {
+                for (let field of group.fields) {
+                    set_triggers(survey_model, field)
+                }
+            }
         }
-        for (var group of survey_schema.groups)
-          for (var field of group.fields)
-          {
-            set_triggers(survey_model, field)
-          }
 
-      last_group = survey_schema.groups[survey_schema.groups.length-1]
-      last_group.fields.push(
-      {
-        buttonText: "Submit Survey",
-        type: "submit",
-        validateBeforeSubmit: true,
-        onSubmit: function(){
-            return postSurvey();
-        }
-      });
+        last_group = survey_schema.groups[survey_schema.groups.length-1];
+        last_group.fields.push({
+            buttonText: "Submit Survey",
+            type: "submit",
+            validateBeforeSubmit: true,
+            onSubmit: function(){
+                return postSurvey();
+            }
+        });
     </script>
     <script type="text/javascript" src="/static/vue_survey_form.js"></script>
 {% endblock %}


### PR DESCRIPTION
Fixes #189 Prevent survey submission when hitting enter in form (i.e., implicit submission).

Note that I have NOT prevented implicit submission on the admin email search form, because it has only one field (email input) and having the search happen when you hit return in that field is convenient, and because I figured admins could handle two ways to submit :)

However, I HAVE prevented implicit submission on the one-input-field form in source.jinja2 that retrieves samples in a kit when provided with a kit name, mostly because I was worried that end users would be confused if it acted differently than the other, more complicated forms.  I would be interested on opinions from the team on whether to keep this approach or let all one-field forms (but not others) do implicit submission.