### PR TITLE
Allow Redirects On Login

### DIFF
--- a/microsetta_private_api/example/client.yaml
+++ b/microsetta_private_api/example/client.yaml
@@ -70,6 +70,11 @@ paths:
           name: token
           schema:
             type: string
+        - in: query
+          name: redirect_uri
+          schema:
+            type: string
+            nullable: true
       responses:
         '200':
           description: Error report

--- a/microsetta_private_api/example/client_impl.py
+++ b/microsetta_private_api/example/client_impl.py
@@ -6,6 +6,7 @@ from requests.auth import AuthBase
 from urllib.parse import quote
 from os import path
 from datetime import datetime
+import base64
 
 # Authrocket uses RS256 public keys, so you can validate anywhere and safely
 # store the key in code. Obviously using this mechanism, we'd have to push code
@@ -406,7 +407,7 @@ def get_rootpath():
     return redirect(HOME_URL)
 
 
-def get_authrocket_callback(token):
+def get_authrocket_callback(token, redirect_uri=None):
     session[TOKEN_KEY_NAME] = token
     do_return, accts_output, _ = ApiRequest.get('/accounts')
     if do_return:
@@ -417,6 +418,10 @@ def get_authrocket_callback(token):
         session[ADMIN_MODE_KEY] = accts_output[0]['account_type'] == 'admin'
     else:
         session[ADMIN_MODE_KEY] = False
+
+    if redirect_uri:
+        uri = base64.urlsafe_b64decode(redirect_uri).decode()
+        return redirect(uri)
 
     return redirect(HOME_URL)
 

--- a/microsetta_private_api/util/redirects.py
+++ b/microsetta_private_api/util/redirects.py
@@ -1,0 +1,38 @@
+import base64
+from microsetta_private_api.config_manager import SERVER_CONFIG
+
+
+def build_login_redirect(redirect_uri):
+    # If a user is externally directed to perform some action, (via email for
+    #  example) or is mid action when forced to login, it may be pleasant to
+    #  redirect them to a particular page upon successful login.  This is
+    #  possible by passing a urlsafe_base64decode'd parameter into the
+    #  authrocket login route, which will cause the user to login, register
+    #  their token within their active session with our system (and discard the
+    #  token so it will not be sent to redirects), then redirect the user to a
+    #  to a specified url
+
+    # Because these redirects are GETs they should not be used to perform
+    #  actions directly.
+
+    # Example: Redirect to "hello"
+    # "aGVsbG8=" == base64.urlsafe_base64encode("hello".encode()).decode()
+    # "{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback%3Fredirect_uri%3DaGVsbG8=" # noqa
+
+    # Example: Redirect to "https://google.com"
+    # "aGVsbG8=" == base64.urlsafe_base64encode("hello".encode()).decode()
+    # "{{authrocket_url}}/login?redirect_uri={{endpoint}}/authrocket_callback%3Fredirect_uri%3DaHR0cHM6Ly9nb29nbGUuY29t" # noqa
+
+    endpoint = SERVER_CONFIG["endpoint"]
+    authrocket_url = SERVER_CONFIG["authrocket_url"]
+    inside_url = base64.urlsafe_b64encode(redirect_uri.encode()).decode()
+
+    return authrocket_url + \
+        "/login?redirect_uri=" + endpoint + \
+        "/authrocket_callback%3Fredirect_uri%3D" + inside_url
+
+
+if __name__ == "__main__":
+    print("Build Login Redirect!")
+    url = input("Desired URL: ")
+    print(build_login_redirect(url))


### PR DESCRIPTION
Added parameter to /authrocket_callback allowing redirect after login.  This enables generation of links that send users/admins to specific pages via email or external tools.  Added redirects.py utility for generating such links.  This script can be used standalone to generate a link of your choice (note that its output is only useful for the server where you run it, dev/staging/production).  Only GETs can use this set of operations

We will need to remember that any links we send out to end users form a loose contract with that user that we will not change our urls (or we will invalidate those links).  Depending on our requirements, we can layer complexity onto this mechanism to allow signing of links with specific tokens, link expiration, etc.  
