### PR TITLE
A patch for 199 showing kwargs only decorator

### DIFF
--- a/microsetta_private_api/util/decorator_util.py
+++ b/microsetta_private_api/util/decorator_util.py
@@ -7,34 +7,3 @@ def has_non_keyword_arguments(func):
     for p in params:
         if params[p].kind != inspect.Parameter.KEYWORD_ONLY:
             return True
-
-
-def build_param_map(func, param_names):
-    sig = inspect.signature(func)
-    params = sig.parameters
-
-    desired_set = set(param_names)
-
-    # Argh.  OrderedDict doesn't know how to find the indexes of its keys.
-    output = {}
-    for idx, (key, value) in enumerate(params.items()):
-        if key in desired_set:
-            output[key] = (idx, value.default)
-    return output
-
-
-def bind_param_map(param_map, parameter_overrides, func_args, func_kwargs):
-    output = {}
-    for key in param_map:
-        idx, default = param_map[key]
-        if idx < len(func_args):
-            output[key] = func_args[idx]
-        else:
-            output[key] = func_kwargs.get(key, default)
-
-    # TODO: We only use this to set survey_template_id on vioscreen callback
-    #  would we prefer defaults instead of overrides?
-    if parameter_overrides is not None:
-        for key in parameter_overrides:
-            output[key] = parameter_overrides[key]
-    return output

--- a/microsetta_private_api/util/decorator_util.py
+++ b/microsetta_private_api/util/decorator_util.py
@@ -1,6 +1,14 @@
 import inspect
 
 
+def has_non_keyword_arguments(func):
+    sig = inspect.signature(func)
+    params = sig.parameters
+    for p in params:
+        if params[p].kind != inspect.Parameter.KEYWORD_ONLY:
+            return True
+
+
 def build_param_map(func, param_names):
     sig = inspect.signature(func)
     params = sig.parameters

--- a/microsetta_private_api/util/tests/test_decorator_util.py
+++ b/microsetta_private_api/util/tests/test_decorator_util.py
@@ -1,52 +1,21 @@
-from microsetta_private_api.util.decorator_util import build_param_map, \
-    bind_param_map
+from microsetta_private_api.util.decorator_util import \
+    has_non_keyword_arguments
 
 
-def my_test_decorator(func):
-    pmap = build_param_map(func, ['x', 'y', 'z', 'override'])
+def test_non_keyword_args():
+    def func1(x, y, z):
+        pass
 
-    def wrapper(*args, **kwargs):
-        bound_params = bind_param_map(pmap,
-                                      {'override': "Fig Newton"},
-                                      args,
-                                      kwargs)
-        return bound_params.get('x'), \
-            bound_params.get('y'), \
-            bound_params.get('z'), \
-            bound_params.get('override')
+    def func2(x=1, y=2, z=3):
+        pass
 
-    return wrapper
+    def func3(*, x=1, y=2, z=3):
+        pass
 
+    def func4(a, b, c, *, x=1, y=2, z=3):
+        pass
 
-def test_1():
-    @my_test_decorator
-    def func1(z, a, b, x=7, d=4, y=None):
-        assert False
-
-    assert func1("z", "a", "b", "x", "d", "y") == ("x", "y", "z", "Fig Newton")
-    assert func1("zz2", "a", "b", d=27, y="foobar") == \
-        (7, "foobar", "zz2", "Fig Newton")
-
-    # Hah, you'd think this wouldn't compile, and it would throw a TypeError
-    # if the wrapper method ever called into func1, but the wrapper itself
-    # has no idea what the args and kwargs are, and doesn't care if they
-    # overlap.  Bound params happens to prefer args over kwargs arbitrarily.
-    assert func1("z", "a", "b", "x", x=15) == ("x", None, "z", "Fig Newton")
-
-
-def test_2():
-    @my_test_decorator
-    def func2(x=29):
-        assert False
-
-    assert func2(15) == (15, None, None, "Fig Newton")
-    assert func2(y="Can'tSeeThis") == (29, None, None, "Fig Newton")
-    assert func2(override="OrThis") == (29, None, None, "Fig Newton")
-
-
-def test_3():
-    @my_test_decorator
-    def func3(override):
-        assert False
-
-    assert func3("Nope") == (None, None, None, "Fig Newton")
+    assert has_non_keyword_arguments(func1)
+    assert has_non_keyword_arguments(func2)
+    assert not has_non_keyword_arguments(func3)
+    assert has_non_keyword_arguments(func4)


### PR DESCRIPTION
Implementation restricting decorator to kwargs only functions.  It cleans up the decorator, but I feel it significantly increases the barrier to entry of client_impl for devs who are new to python (like me).  It's here as an option, but I prefer the decorator_util bound mappings version