### PR TITLE
Sample locked override

### DIFF
--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -11,6 +11,7 @@ from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.util.util import fromisotime
+from microsetta_private_api.admin.admin_impl import token_grants_admin_access
 
 
 def read_sample_associations(account_id, source_id, token_info):
@@ -101,7 +102,10 @@ def update_sample_association(account_id, source_id, sample_id, body,
             body["sample_notes"]
         )
 
-        sample_repo.update_info(account_id, source_id, sample_info)
+        is_admin = token_grants_admin_access(token_info)
+        sample_repo.update_info(account_id, source_id, sample_info,
+                                override_locked=is_admin)
+
         final_sample = sample_repo.get_sample(account_id, source_id, sample_id)
         t.commit()
     return jsonify(final_sample), 200
@@ -120,7 +124,9 @@ def dissociate_sample(account_id, source_id, sample_id, token_info):
                 account_id, source_id, sample_id, curr_answered_survey_id)
 
         sample_repo = SampleRepo(t)
-        sample_repo.dissociate_sample(account_id, source_id, sample_id)
+        is_admin = token_grants_admin_access(token_info)
+        sample_repo.dissociate_sample(account_id, source_id, sample_id,
+                                      override_locked=is_admin)
 
         t.commit()
 

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -282,7 +282,8 @@ def delete_dummy_accts():
                 # Now dissociate all the samples from this source
                 for curr_sample_id in sample_ids:
                     sample_repo.dissociate_sample(curr_acct_id, curr_source.id,
-                                                  curr_sample_id)
+                                                  curr_sample_id,
+                                                  override_locked=True)
 
                 # Finally, delete the source
                 source_repo.delete_source(curr_acct_id, curr_source.id)
@@ -1464,14 +1465,6 @@ class SampleTests(ApiTests):
         )
         self.assertEqual(200, get_resp.status_code)
         self.assertEqual(get_resp.json['sample_site'], 'Saliva')
-
-        # delete as admin so that tearDown doesn't require admin
-        delete_resp = self.client.delete(
-            '%s?%s' % (sample_url, self.default_lang_querystring),
-            headers=make_headers(FAKE_TOKEN_ADMIN))
-
-        # verify the delete was successful
-        self.assertEqual(204, delete_resp.status_code)
 
     def test_dissociate_sample_from_source_success(self):
         dummy_acct_id, dummy_source_id = create_dummy_source(

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -70,10 +70,11 @@ class SampleRepo(BaseRepo):
     #  Having multiple pathways to link in the db is a recipe for badness.
     #  Should something be done with the source_barcodes_surveys table? (which
     #  itself is required for linking samples to surveys!)
-    def _update_sample_association(self, sample_id, source_id):
+    def _update_sample_association(self, sample_id, source_id,
+                                   override_locked=False):
         with self._transaction.cursor() as cur:
             existing_sample = self._get_sample_by_id(sample_id)
-            if existing_sample.is_locked:
+            if existing_sample.is_locked and not override_locked:
                 raise RepoException(
                     "Sample edits locked: Sample already received")
 
@@ -135,7 +136,8 @@ class SampleRepo(BaseRepo):
             sample_row = cur.fetchone()
             return self._create_sample_obj(sample_row)
 
-    def update_info(self, account_id, source_id, sample_info):
+    def update_info(self, account_id, source_id, sample_info,
+                    override_locked=False):
         """
         Updates end user writable information about a sample that is assigned
         to a source.
@@ -146,7 +148,7 @@ class SampleRepo(BaseRepo):
             raise werkzeug.exceptions.NotFound("No sample ID: %s" %
                                                sample_info.id)
 
-        if existing_sample.is_locked:
+        if existing_sample.is_locked and not override_locked:
             raise RepoException("Sample edits locked: Sample already received")
 
         sample_date = None
@@ -203,20 +205,25 @@ class SampleRepo(BaseRepo):
                     raise RepoException("Sample is already assigned")
             else:
                 # This is the case where the sample is not yet assigned
+                # NOTE: we are not passing override_locked here as a sample
+                # that is not yet assigned cannot be locked.
                 self._update_sample_association(sample_id, source_id)
 
-    def dissociate_sample(self, account_id, source_id, sample_id):
+    def dissociate_sample(self, account_id, source_id, sample_id,
+                          override_locked=False):
         existing_sample = self.get_sample(account_id, source_id, sample_id)
         if existing_sample is None:
             raise werkzeug.exceptions.NotFound("No sample ID: %s" %
                                                sample_id)
-        if existing_sample.is_locked:
+        if existing_sample.is_locked and not override_locked:
             raise RepoException(
                 "Sample edits locked: Sample already received")
 
         # Wipe any user entered fields from the sample:
         self.update_info(account_id, source_id,
-                         SampleInfo(sample_id, None, None, None))
+                         SampleInfo(sample_id, None, None, None),
+                         override_locked=override_locked)
 
         # And detach the sample from the source
-        self._update_sample_association(sample_id, None)
+        self._update_sample_association(sample_id, None,
+                                        override_locked=override_locked)


### PR DESCRIPTION
Fixes #238 

This pull request adds in the ability to override modification of a locked sample. No API changes were necessary: the override is implicit for administrative users. As a caveat, this assumes the administrator knows what they are doing which is reasonable given the powers they wield in other areas. 

One awkward item though is that this PR does introduce the concept of admin into the primary API module. 