### PR TITLE
Admin override for associate sample

### DIFF
--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -28,12 +28,15 @@ def read_sample_associations(account_id, source_id, token_info):
 def associate_sample(account_id, source_id, body, token_info):
     _validate_account_access(token_info, account_id)
 
+    is_admin = token_grants_admin_access(token_info)
     with Transaction() as t:
         sample_repo = SampleRepo(t)
         sample_repo.associate_sample(account_id,
                                      source_id,
-                                     body['sample_id'])
+                                     body['sample_id'],
+                                     override_locked=is_admin)
         t.commit()
+
     response = flask.Response()
     response.status_code = 201
     response.headers['Location'] = '/api/accounts/%s/sources/%s/samples/%s' % \

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -434,7 +434,7 @@ def create_dummy_answered_survey(dummy_acct_id, dummy_source_id,
     return survey_answers_id
 
 
-def create_dummy_kit(account_id=None, source_id=None):
+def create_dummy_kit(account_id=None, source_id=None, associate_sample=True):
     with Transaction() as t:
         _create_mock_kit(t, barcodes=[BARCODE],
                          mock_sample_ids=[MOCK_SAMPLE_ID])
@@ -445,8 +445,11 @@ def create_dummy_kit(account_id=None, source_id=None):
 
             sample_info, _ = create_dummy_sample_objects(True)
             sample_repo = SampleRepo(t)
-            sample_repo.associate_sample(account_id, source_id, MOCK_SAMPLE_ID)
-            sample_repo.update_info(account_id, source_id, sample_info)
+
+            if associate_sample:
+                sample_repo.associate_sample(account_id, source_id,
+                                             MOCK_SAMPLE_ID)
+                sample_repo.update_info(account_id, source_id, sample_info)
 
         t.commit()
 
@@ -1356,13 +1359,13 @@ class SampleTests(ApiTests):
             "Bo", Source.SOURCE_TYPE_HUMAN, DUMMY_HUMAN_SOURCE,
             create_dummy_1=True)
 
-        create_dummy_kit(dummy_acct_id, dummy_source_id)
+        create_dummy_kit(dummy_acct_id, dummy_source_id,
+                         associate_sample=False)
         _ = create_dummy_answered_survey(
             dummy_acct_id, dummy_source_id)
 
         base_url = '/api/accounts/{0}/sources/{1}/samples'.format(
             dummy_acct_id, dummy_source_id)
-        sample_url = "{0}/{1}".format(base_url, MOCK_SAMPLE_ID)
 
         # "scan" the sample in
         _ = create_dummy_acct(create_dummy_1=True,

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -176,7 +176,8 @@ class SampleRepo(BaseRepo):
                             sample_info.id
                         ))
 
-    def associate_sample(self, account_id, source_id, sample_id):
+    def associate_sample(self, account_id, source_id, sample_id,
+                         override_locked=False):
         with self._transaction.cursor() as cur:
             cur.execute("SELECT "
                         "ag_kit_barcode_id, "
@@ -193,7 +194,6 @@ class SampleRepo(BaseRepo):
             if row is None:
                 raise werkzeug.exceptions.NotFound("No sample ID: %s" %
                                                    sample_id)
-
             if row[2] is not None:
                 if row[1] != account_id:
                     # This is the case where the sample is already assigned in
@@ -205,9 +205,8 @@ class SampleRepo(BaseRepo):
                     raise RepoException("Sample is already assigned")
             else:
                 # This is the case where the sample is not yet assigned
-                # NOTE: we are not passing override_locked here as a sample
-                # that is not yet assigned cannot be locked.
-                self._update_sample_association(sample_id, source_id)
+                self._update_sample_association(sample_id, source_id,
+                                                override_locked=override_locked)  # noqa
 
     def dissociate_sample(self, account_id, source_id, sample_id,
                           override_locked=False):


### PR DESCRIPTION
Fixes #248 

The code path used for claiming a sample did not get the lockout override added in. This PR addresses that. 
