### PR TITLE
Support to fix admin issue 42

### DIFF
--- a/microsetta_private_api/admin/tests/test_admin.py
+++ b/microsetta_private_api/admin/tests/test_admin.py
@@ -114,13 +114,17 @@ class AdminTests(TestCase):
         except Unauthorized:
             pass
 
+    # TODO FIXME HACK:  Need to build mock barcodes rather than using
+    #  these fixed ones
     def test_retrieve_diagnostics_by_barcode_w_scans(self):
         def make_tz_datetime(y, m, d):
             return datetime.datetime(y, m, d, 0, 0,
                                      tzinfo=psycopg2.tz.FixedOffsetTimezone(
                                          offset=-420, name=None))
 
-        test_barcode = '000044481'  # non-AGP barcode--no acct, source, etc
+        # Non-AGP barcode so no acct, source, or sample;
+        # also no preexisting scans in test db
+        test_barcode = '000004531'
         first_scan_id = 'f7fd3022-3a9c-4f79-b92c-5cebd83cba38'
         second_scan_id = '76aec821-aa28-4dea-a796-2cfd1276f78c'
 
@@ -144,8 +148,6 @@ class AdminTests(TestCase):
             add_dummy_scan(second_scan)
 
             with Transaction() as t:
-                # TODO FIXME HACK: Build mock barcodes rather than using
-                #  these fixed ones
                 admin_repo = AdminRepo(t)
                 diag = admin_repo.retrieve_diagnostics_by_barcode(test_barcode)
                 self.assertIsNotNone(diag['barcode_info'])
@@ -164,8 +166,6 @@ class AdminTests(TestCase):
 
     def test_retrieve_diagnostics_by_barcode_wo_scans(self):
         with Transaction() as t:
-            # TODO FIXME HACK:  Need to build mock barcodes rather than using
-            #  these fixed ones
             admin_repo = AdminRepo(t)
             diag = admin_repo.retrieve_diagnostics_by_barcode('000033903')
             self.assertIsNotNone(diag['barcode_info'])
@@ -177,8 +177,6 @@ class AdminTests(TestCase):
 
     def test_retrieve_diagnostics_by_barcode_nonexistent(self):
         with Transaction() as t:
-            # TODO FIXME HACK:  Need to build mock barcodes rather than using
-            #  these fixed ones
             admin_repo = AdminRepo(t)
             # Uhh, should this return a 404 not found or just an empty
             # diagnostic object...?
@@ -228,7 +226,6 @@ class AdminTests(TestCase):
             self.assertIsNone(diag['sample'])
             self.assertGreater(len(diag['scans_info']), 0)
             self.assertGreater(len(diag['projects_info']), 0)
-
 
     def test_create_project(self):
         with Transaction() as t:

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -12,7 +12,7 @@
 -- a sample (whereas, e.g., environmental sources don't require
 -- site_sampled, etc).
 UPDATE barcodes.barcode
-SET sample_status = 'valid'
+SET sample_status = 'sample-is-valid'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
 AND ag_kit_barcodes.source_id = ag.source.id 

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -17,15 +17,11 @@ FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
 AND ag_kit_barcodes.source_id = ag.source.id 
 AND ag.source.account_id = account.id
-AND site_sampled IS NOT null
+AND sample_date IS NOT null
 AND sample_status IS null AND scan_date IS NOT null;
 
 -- case 2: barcode is part of AGP and linked to an account
 -- by way of a source but is missing (at least some) collection info.
--- NB sample collection date is used as the bellwether for the whole
--- set of sample collection info because it is relevant to all
--- kinds of samples (whereas previously used field, sample site, is not
--- filled when environmental samples are returned).
 UPDATE barcodes.barcode
 SET sample_status = 'no-collection-info'
 FROM ag.ag_kit_barcodes, ag.source, ag.account

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -15,7 +15,7 @@ UPDATE barcodes.barcode
 SET sample_status = 'valid'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
-AND ag_kit_barcodes.source_id = ag.source.id
+AND ag_kit_barcodes.source_id = ag.source.id 
 AND ag.source.account_id = account.id
 AND site_sampled IS NOT null
 AND sample_status IS null AND scan_date IS NOT null;
@@ -25,7 +25,7 @@ AND sample_status IS null AND scan_date IS NOT null;
 UPDATE barcodes.barcode
 SET sample_status = 'no-collection-info'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
-WHERE barcode.barcode = ag_kit_barcodes.barcode
+WHERE barcode.barcode = ag_kit_barcodes.barcode 
 AND ag_kit_barcodes.source_id = ag.source.id
 AND ag.source.account_id = account.id
 AND site_sampled IS null

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -21,14 +21,18 @@ AND site_sampled IS NOT null
 AND sample_status IS null AND scan_date IS NOT null;
 
 -- case 2: barcode is part of AGP and linked to an account
--- by way of a source but is missing (at least some) collection info
+-- by way of a source but is missing (at least some) collection info.
+-- NB sample collection date is used as the bellwether for the whole
+-- set of sample collection info because it is relevant to all
+-- kinds of samples (whereas previously used field, sample site, is not
+-- filled when environmental samples are returned).
 UPDATE barcodes.barcode
 SET sample_status = 'no-collection-info'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
 AND ag_kit_barcodes.source_id = ag.source.id 
 AND ag.source.account_id = account.id
-AND site_sampled IS null
+AND sample_date IS null
 AND sample_status IS null AND scan_date IS NOT null;
 
 -- case 3: barcode is part of AGP and is linked to an account

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -12,23 +12,23 @@
 -- a sample (whereas, e.g., environmental sources don't require
 -- site_sampled, etc).
 UPDATE barcodes.barcode
-SET sample_status = 'sample-is-valid'
+SET sample_status = 'valid'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
-AND ag_kit_barcodes.source_id = ag.source.id 
+AND ag_kit_barcodes.source_id = ag.source.id
 AND ag.source.account_id = account.id
-AND sample_date IS NOT null
+AND site_sampled IS NOT null
 AND sample_status IS null AND scan_date IS NOT null;
 
 -- case 2: barcode is part of AGP and linked to an account
--- by way of a source but is missing (at least some) collection info.
+-- by way of a source but is missing (at least some) collection info
 UPDATE barcodes.barcode
 SET sample_status = 'no-collection-info'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
 WHERE barcode.barcode = ag_kit_barcodes.barcode
-AND ag_kit_barcodes.source_id = ag.source.id 
+AND ag_kit_barcodes.source_id = ag.source.id
 AND ag.source.account_id = account.id
-AND sample_date IS null
+AND site_sampled IS null
 AND sample_status IS null AND scan_date IS NOT null;
 
 -- case 3: barcode is part of AGP and is linked to an account

--- a/microsetta_private_api/db/patches/0067.sql
+++ b/microsetta_private_api/db/patches/0067.sql
@@ -25,8 +25,8 @@ AND sample_status IS null AND scan_date IS NOT null;
 UPDATE barcodes.barcode
 SET sample_status = 'no-collection-info'
 FROM ag.ag_kit_barcodes, ag.source, ag.account
-WHERE barcode.barcode = ag_kit_barcodes.barcode 
-AND ag_kit_barcodes.source_id = ag.source.id
+WHERE barcode.barcode = ag_kit_barcodes.barcode
+AND ag_kit_barcodes.source_id = ag.source.id 
 AND ag.source.account_id = account.id
 AND site_sampled IS null
 AND sample_status IS null AND scan_date IS NOT null;

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -23,6 +23,10 @@ class AdminRepo(BaseRepo):
 
     def _get_ids_relevant_to_barcode(self, sample_barcode):
         with self._transaction.dict_cursor() as cur:
+            # First, look for this barcode in the set of barcodes
+            # associated with AGP kits; if it is there, get its kit id and
+            # follow the source id associated with that AGP barcode to its
+            # source and account ids.
             cur.execute(
                 "SELECT "
                 "ag_kit_barcodes.ag_kit_barcode_id as sample_id, "
@@ -31,18 +35,45 @@ class AdminRepo(BaseRepo):
                 "ag_kit_barcodes.ag_kit_id as kit_id "
                 "FROM "
                 "ag.ag_kit_barcodes "
-                "LEFT OUTER JOIN "
+                "INNER JOIN "
                 "source "
                 "ON "
                 "ag_kit_barcodes.source_id = source.id "
-                "LEFT OUTER JOIN "
+                "INNER JOIN "
                 "account "
                 "ON "
                 "account.id = source.account_id "
                 "WHERE "
                 "ag_kit_barcodes.barcode = %s",
                 (sample_barcode,))
-            return cur.fetchone()
+            result = cur.fetchone()
+
+            if result is not None:
+                return result
+
+            # else if the barcode is not associated with a source id, it may
+            # still be (more tenuously) associated with an account if it in
+            # the set of barcodes associated with AGP kits and the kit it is
+            # in has been used to open an AGP account; in this case, we can get
+            # an account id and a kit id but NOT a source id.
+            # Even if there is no such account association, we can still get
+            # the (official, UUID) kit id if this is an AGP kit
+            cur.execute(
+                "SELECT ag_kit_barcodes.ag_kit_barcode_id as sample_id, "
+                "ag_kit_barcodes.ag_kit_id as kit_id, "
+                "ag.account.id as account_id "
+                "FROM ag.ag_kit_barcodes "
+                "INNER JOIN barcodes.barcode "
+                "ON ag_kit_barcodes.barcode = barcode.barcode "
+                "LEFT OUTER JOIN ag.account "
+                "ON barcodes.barcode.kit_id = ag.account.created_with_kit_id "
+                "WHERE ag_kit_barcodes.barcode = %s;",
+                (sample_barcode,))
+            result = cur.fetchone()
+            # NB: if still nothing, this is not an AGP-associated barcode so
+            # we can't collect any useful ids
+
+            return result
 
     def retrieve_diagnostics_by_barcode(self, sample_barcode, grab_kit=True):
         def _rows_to_dicts_list(rows):
@@ -52,34 +83,37 @@ class AdminRepo(BaseRepo):
             ids = self._get_ids_relevant_to_barcode(sample_barcode)
 
             if ids is None:
-                sample_id = None
-                source_id = None
-                account_id = None
-                kit_id = None
-            else:
-                sample_id = ids["sample_id"]
-                source_id = ids["source_id"]
-                account_id = ids["account_id"]
-                kit_id = ids["kit_id"]
+                ids = {}
+
+            # default for not found is None
+            sample_id = ids.get("sample_id")
+            source_id = ids.get("source_id")
+            account_id = ids.get("account_id")
+            # NB: this is the true UUID kit id (the primary key of
+            # ag.ag_kit), NOT the kit's participant-facing string "id"
+            kit_id = ids.get("kit_id")
 
             account = None
             source = None
             sample = None
             kit = None
 
-            # get sample object for this barcode
+            # get sample object for this barcode, if any
             if sample_id is not None:
                 sample_repo = SampleRepo(self._transaction)
                 sample = sample_repo._get_sample_by_id(sample_id)
 
-            # get account and source objects for this barcode
-            if source_id is not None and account_id is not None:
+            # get account object for this barcode, if any
+            if account_id is not None:
                 account_repo = AccountRepo(self._transaction)
-                source_repo = SourceRepo(self._transaction)
                 account = account_repo.get_account(account_id)
+
+            # and source object for this barcode, if any
+            if source_id is not None:
+                source_repo = SourceRepo(self._transaction)
                 source = source_repo.get_source(account_id, source_id)
 
-            # get projects_info list for this barcode
+            # get (partial) projects_info list for this barcode
             cur.execute("SELECT project, is_microsetta, "
                         "bank_samples, plating_start_date "
                         "FROM barcodes.project "
@@ -454,9 +488,9 @@ class AdminRepo(BaseRepo):
         if ids is None:
             raise NotFound("No such barcode")
 
-        account_id = ids['account_id']
-        source_id = ids['source_id']
-        sample_id = ids['sample_id']
+        account_id = ids.get('account_id')
+        source_id = ids.get('source_id')
+        sample_id = ids.get('sample_id')
 
         account = None
         source = None


### PR DESCRIPTION
Primarily extends admin_repo.py's _get_ids_relevant_to_barcode to identify cases where barcode is not attached to a source but IS associated with an account in the sense that it is part of a kit that has been used to set up an account; this case will get (only) the 'no-associated-source' warning in admin interface as part of forthcoming issue 42 fix.  Extends tests to separately exercise each of the cases that will lead to different warnings in admin interface.