### PR TITLE
Update sample_is_valid.jinja2

### DIFF
--- a/microsetta_private_api/templates/email/sample_is_valid.jinja2
+++ b/microsetta_private_api/templates/email/sample_is_valid.jinja2
@@ -10,7 +10,7 @@
 </p>
 <p class="c1"><span class="c0">&nbsp;</span></p>
 <p class="c8 c9">
-    <span class="c0">We recently received the following sample from you and noticed that the sample type may have been incorrectly assigned. To view the sample type, please click on the link below.</span>
+    <span class="c0">Thank you for your interest and participation in The Microsetta Initiative. We have received your sample, and it is now in the processing queue.</span>
 </p>
 <p class="c1"><span class="c0">&nbsp;</span></p>
 <p class="c1">


### PR DESCRIPTION
Participants have been receiving the incorrect email template when their sample is received by our lab and is marked as "sample-is-valid" upon being scanned in.

@dhakim87  @wasade