### PR TITLE
Return account and source IDs with Sample

### DIFF
--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1558,8 +1558,10 @@ components:
           $ref: '#/components/schemas/sample_projects'
         source_id:
           $ref: '#/components/schemas/source_id'
+          nullable: true
         account_id:
           $ref: '#/components/schemas/account_id'
+          nullable: true
 
     # source section
     source_id:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1402,6 +1402,11 @@ components:
       type: string
       readOnly: true
       example: "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff"
+    account_id_nullable:
+      type: string
+      readOnly: true
+      example: "aaaaaaaa-bbbb-cccc-dddd-eeeeffffffff"
+      nullable: true
     account_type: # e.g., regular user or admin--room to grow
       type: string
       readOnly: true
@@ -1557,17 +1562,20 @@ components:
         sample_projects:
           $ref: '#/components/schemas/sample_projects'
         source_id:
-          $ref: '#/components/schemas/source_id'
-          nullable: true
+          $ref: '#/components/schemas/source_id_nullable'
         account_id:
-          $ref: '#/components/schemas/account_id'
-          nullable: true
+          $ref: '#/components/schemas/account_id_nullable'
 
     # source section
     source_id:
       type: string
       readOnly: true # sent in GET, not in POST/PUT/PATCH
       example: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0"
+    source_id_nullable:
+      type: string
+      readOnly: true # sent in GET, not in POST/PUT/PATCH
+      example: "b0b0b0b0-b0b0-b0b0-b0b0-b0b0b0b0b0b0"
+      nullable: true
     source_name:
       type: string
     source_type:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1556,6 +1556,10 @@ components:
           $ref: '#/components/schemas/sample_notes'
         sample_projects:
           $ref: '#/components/schemas/sample_projects'
+        source_id:
+          $ref: '#/components/schemas/source_id'
+        account_id:
+          $ref: '#/components/schemas/account_id'
 
     # source section
     source_id:

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -1266,12 +1266,13 @@ class SurveyTests(ApiTests):
 
 @pytest.mark.usefixtures("client")
 class SampleTests(ApiTests):
-    def test_get_unclaimed_samples(self):
+    def test_kits_get_fail_missing(self):
         get_resp = self.client.get('/api/kits/?language_tag=en_US&'
                                    'kit_name=%s' % MISSING_KIT_NAME,
                                    headers=self.dummy_auth)
         self.assertEqual(get_resp.status_code, 404)
 
+    def test_kits_get_fail_all_samples_assigned(self):
         get_resp = self.client.get('/api/kits/?language_tag=en_US&'
                                    'kit_name=%s' % EXISTING_KIT_NAME,
                                    headers=self.dummy_auth)
@@ -1279,11 +1280,11 @@ class SampleTests(ApiTests):
         # valid kit but all samples are assigned
         self.assertEqual(get_resp.status_code, 404)
 
+    def test_kits_get_success(self):
         get_resp = self.client.get('/api/kits/?language_tag=en_US&'
                                    'kit_name=%s' % EXISTING_KIT_NAME_2,
                                    headers=self.dummy_auth)
 
-        # valid kit but all samples are assigned
         self.assertEqual(get_resp.status_code, 200)
         get_resp_obj = json.loads(get_resp.data)
         self.assertEqual(len(get_resp_obj), 1)

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -1266,6 +1266,31 @@ class SurveyTests(ApiTests):
 
 @pytest.mark.usefixtures("client")
 class SampleTests(ApiTests):
+    def test_get_unclaimed_samples(self):
+        get_resp = self.client.get('/api/kits/?language_tag=en_US&'
+                                   'kit_name=%s' % MISSING_KIT_NAME,
+                                   headers=self.dummy_auth)
+        self.assertEqual(get_resp.status_code, 404)
+
+        get_resp = self.client.get('/api/kits/?language_tag=en_US&'
+                                   'kit_name=%s' % EXISTING_KIT_NAME,
+                                   headers=self.dummy_auth)
+
+        # valid kit but all samples are assigned
+        self.assertEqual(get_resp.status_code, 404)
+
+        get_resp = self.client.get('/api/kits/?language_tag=en_US&'
+                                   'kit_name=%s' % EXISTING_KIT_NAME_2,
+                                   headers=self.dummy_auth)
+
+        # valid kit but all samples are assigned
+        self.assertEqual(get_resp.status_code, 200)
+        get_resp_obj = json.loads(get_resp.data)
+        self.assertEqual(len(get_resp_obj), 1)
+        self.assertEqual(get_resp_obj[0]['source_id'], None)
+        self.assertEqual(get_resp_obj[0]['account_id'], None)
+        self.assertEqual(get_resp_obj[0]['sample_barcode'], '000014119')
+
     def test_associate_sample_to_source_success(self):
         dummy_acct_id, dummy_source_id = create_dummy_source(
             "Bo", Source.SOURCE_TYPE_HUMAN, DUMMY_HUMAN_SOURCE,

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -119,6 +119,8 @@ DUMMY_EMPTY_SAMPLE_INFO = {
     'sample_locked': False,
     'sample_notes': None,
     'sample_projects': ['American Gut Project'],
+    'account_id': None,
+    'source_id': None,
     'sample_site': None}
 
 DUMMY_FILLED_SAMPLE_INFO = {
@@ -128,6 +130,8 @@ DUMMY_FILLED_SAMPLE_INFO = {
     'sample_locked': False,
     'sample_notes': "Oops, I dropped it",
     'sample_projects': ['American Gut Project'],
+    'account_id': 'foobar',
+    'source_id': 'foobarbaz',
     'sample_site': 'Saliva'}
 
 ACCT_ID_KEY = "account_id"
@@ -472,6 +476,8 @@ def create_dummy_sample_objects(filled=False):
                     info_dict["sample_notes"],
                     info_dict["sample_barcode"],
                     None,
+                    info_dict['source_id'],
+                    info_dict['account_id'],
                     info_dict["sample_projects"])
 
     return sample_info, sample
@@ -1297,7 +1303,12 @@ class SampleTests(ApiTests):
         # ensure there is precisely one sample associated with this source
         # (that is empty of collection info)
         get_resp_obj = json.loads(get_response.data)
-        self.assertEqual(get_resp_obj, [DUMMY_EMPTY_SAMPLE_INFO])
+
+        exp = DUMMY_EMPTY_SAMPLE_INFO.copy()
+        exp['source_id'] = SOURCE_ID_1
+        exp['account_id'] = ACCT_ID_1
+
+        self.assertEqual(get_resp_obj, [exp])
 
         # TODO: We should also have tests of associating a sample to a source
         #  that fail with with a 401 (sample not found) and a 422 (sample

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -936,7 +936,8 @@ class IntegrationTests(TestCase):
         # Many fields are not writable, each should individually cause failure.
         readonly_fields = [
             'sample_id', 'sample_barcode',
-            'sample_locked', 'sample_projects'
+            'sample_locked', 'sample_projects',
+            'source_id', 'account_id'
         ]
 
         for readonly_field in readonly_fields:

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -4,7 +4,8 @@ from microsetta_private_api.model.model_base import ModelBase
 
 class Sample(ModelBase):
     def __init__(self, sample_id, datetime_collected, site, notes, barcode,
-                 latest_scan_timestamp, sample_projects):
+                 latest_scan_timestamp, source_id, account_id,
+                 sample_projects):
         self.id = sample_id
         # NB: datetime_collected may be None if sample not yet used
         self.datetime_collected = datetime_collected
@@ -17,6 +18,9 @@ class Sample(ModelBase):
         self._latest_scan_timestamp = latest_scan_timestamp
         self.sample_projects = sample_projects
 
+        self.source_id = source_id
+        self.account_id = account_id
+
     @property
     def is_locked(self):
         # If a sample has been scanned into the system, that means its
@@ -25,7 +29,8 @@ class Sample(ModelBase):
 
     @classmethod
     def from_db(cls, sample_id, date_collected, time_collected,
-                site, notes, barcode, latest_scan_timestamp, sample_projects):
+                site, notes, barcode, latest_scan_timestamp,
+                source_id, account_id, sample_projects):
         datetime_collected = None
         # NB a sample may NOT have date and time collected if it has been sent
         # out but not yet used
@@ -33,7 +38,8 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                   latest_scan_timestamp, sample_projects)
+                   latest_scan_timestamp, source_id, account_id,
+                   sample_projects)
 
     def to_api(self):
         return {
@@ -43,6 +49,8 @@ class Sample(ModelBase):
             "sample_locked": self.is_locked,
             "sample_datetime": self.datetime_collected,
             "sample_notes": self.notes,
+            "source_id": self.source_id,
+            "account_id": self.account_id,
             "sample_projects": list(self.sample_projects)
         }
 

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -17,7 +17,9 @@ class SampleRepo(BaseRepo):
         ag.ag_kit_barcodes.site_sampled,
         ag.ag_kit_barcodes.notes,
         ag.ag_kit_barcodes.barcode,
-        latest_scan.scan_timestamp
+        latest_scan.scan_timestamp,
+        ag.source.id,
+        ag.source.account_id
         FROM ag.ag_kit_barcodes
         LEFT JOIN (
             SELECT barcode, max(scan_timestamp) AS scan_timestamp


### PR DESCRIPTION
`SampleRepo` and `Sample` now return the samples source ID and account ID. This is useful for diagnostics when examining a full kit as a there may be multiple sources or accounts. 