### PR TITLE
WIP: sending email via celery

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ In the activated conda environment, initialize a test database:
 
 `python microsetta_private_api/LEGACY/build_db.py`
 
+Then we'll initiate a Celery worker:
+
+`celery -A celery_worker.celery worker --loglevel=info`
+
 Next, start the microservice using flask's built-in server by running, e.g., 
 
 `python ./microsetta_private_api/server.py`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ Install the JSON Web Tokens library with cryptography support:
 
 `pip install pyjwt[crypto]`
 
+Install Redis and Celery with Redis support for out-of-band compute:
+
+`conda install redis`
+`pip install celery[redis]`
+
 Then install the microsetta-private-api in editable mode:
 
 `pip install -e .`

--- a/celery_worker.py
+++ b/celery_worker.py
@@ -1,0 +1,3 @@
+from microsetta_private_api.server import build_app
+from microsetta_private_api.celery_utils import celery  # noqa
+app = build_app()

--- a/celery_worker.py
+++ b/celery_worker.py
@@ -1,3 +1,3 @@
-from microsetta_private_api.server import build_app
-from microsetta_private_api.celery_utils import celery  # noqa
-app = build_app()
+from microsetta_private_api.server import app
+from microsetta_private_api.celery_utils import celery, init_celery
+init_celery(celery, app.app)

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 coveralls
 pycountry
 python-dateutil
+celery[redis]

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -6,3 +6,4 @@ coveralls
 pycountry
 python-dateutil
 celery[redis]
+redis

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -256,8 +256,7 @@ def send_email(body, token_info):
         template_args['resolution_url'] = resolution_url
         template_args['contact_name'] = contact_name
         celery_send_email.apply_async(args=[email, template_name,
-                                            template_args],
-                                      ignore_result=True)
+                                            template_args])
 
         # Add an event to the log that we sent this email successfully
         event = LogEvent(

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -255,7 +255,7 @@ def send_email(body, token_info):
         template_args = dict(body['template_args'])
         template_args['resolution_url'] = resolution_url
         template_args['contact_name'] = contact_name
-        celery_send_email.apply_async(args=[email, template_name, 
+        celery_send_email.apply_async(args=[email, template_name,
                                             template_args],
                                       ignore_result=True)
 

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -255,8 +255,9 @@ def send_email(body, token_info):
         template_args = dict(body['template_args'])
         template_args['resolution_url'] = resolution_url
         template_args['contact_name'] = contact_name
-        celery_send_email.delay(email, template_name, template_args,
-                                ignore_result=True)
+        celery_send_email.apply_async(args=[email, template_name, 
+                                            template_args],
+                                      ignore_result=True)
 
         # Add an event to the log that we sent this email successfully
         event = LogEvent(

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -2,7 +2,6 @@ import uuid
 from flask import jsonify
 import datetime
 
-from microsetta_private_api.admin.email_templates import EmailMessage
 from microsetta_private_api.config_manager import SERVER_CONFIG
 from microsetta_private_api.model.log_event import LogEvent
 from microsetta_private_api.exceptions import RepoException
@@ -10,7 +9,8 @@ from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.event_log_repo import EventLogRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.admin_repo import AdminRepo
-from microsetta_private_api.util.email import SendEmail
+from microsetta_private_api.tasks import send_email as celery_send_email
+from microsetta_private_api.admin.email_templates import EmailMessage
 from microsetta_private_api.util.redirects import build_login_redirect
 from werkzeug.exceptions import Unauthorized, BadRequest
 
@@ -249,13 +249,13 @@ def send_email(body, token_info):
 
         # Determine what template must be sent, and build the template args
         # from whatever is in the body and the resolution url we determined
-        template = EmailMessage[body['template']]
+        template_name = body['template']
+        template = EmailMessage[template_name]
+
         template_args = dict(body['template_args'])
         template_args['resolution_url'] = resolution_url
         template_args['contact_name'] = contact_name
-
-        # Send the email
-        SendEmail.send(email, template, template_args)
+        celery_send_email.delay(email, template_name, template_args)
 
         # Add an event to the log that we sent this email successfully
         event = LogEvent(

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -255,7 +255,8 @@ def send_email(body, token_info):
         template_args = dict(body['template_args'])
         template_args['resolution_url'] = resolution_url
         template_args['contact_name'] = contact_name
-        celery_send_email.delay(email, template_name, template_args)
+        celery_send_email.delay(email, template_name, template_args,
+                                ignore_result=True)
 
         # Add an event to the log that we sent this email successfully
         event = LogEvent(

--- a/microsetta_private_api/celery_tests.py
+++ b/microsetta_private_api/celery_tests.py
@@ -1,10 +1,8 @@
 from unittest.mock import patch
-from unittest import TestCase
 from microsetta_private_api.tasks import send_email
 
 
-class CeleryTaskTests(TestCase):
-    def test_send_email(self):
-        with patch('microsetta_private_api.util.email.SendEmail.send'):
-            obs = send_email('foobar', 'incorrect_sample_type', {})
-            assert obs is None
+def test_task_send_email():
+    with patch('microsetta_private_api.util.email.SendEmail.send') as p:
+        send_email.apply(args=['foo', 'incorrect_sample_type', 'baz'])
+        assert p.called

--- a/microsetta_private_api/celery_tests.py
+++ b/microsetta_private_api/celery_tests.py
@@ -1,0 +1,10 @@
+from unittest.mock import patch
+from unittest import TestCase
+from microsetta_private_api.tasks import send_email
+
+
+class CeleryTaskTests(TestCase):
+    def test_send_email(self):
+        with patch('microsetta_private_api.util.email.SendEmail.send'):
+            obs = send_email('foobar', 'incorrect_sample_type', {})
+            assert obs is None

--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -1,0 +1,28 @@
+from celery import Celery
+
+from microsetta_private_api.config_manager import SERVER_CONFIG
+
+
+# derived from
+# https://medium.com/@frassetto.stefano/flask-celery-howto-d106958a15fe
+
+
+def init_celery(celery, app):
+    celery.conf.update(app.config)
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+
+
+def make_celery(app_name):
+    celery_backend = SERVER_CONFIG['celery_backend_uri']
+    celery_broker = SERVER_CONFIG['celery_broker_uri']
+    return Celery(app_name, backend=celery_backend, broker=celery_broker)
+
+
+celery = make_celery(__name__.split('.')[0])

--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -11,6 +11,7 @@ CELERY_BROKER_URI = 'celery_broker_uri'
 # https://medium.com/@frassetto.stefano/flask-celery-howto-d106958a15fe
 def init_celery(celery, app):
     celery.conf.update(app.config)
+    celery.conf.task_default_queue = 'microsetta-private-api'
     TaskBase = celery.Task
 
     class ContextTask(TaskBase):

--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -2,11 +2,13 @@ from celery import Celery
 
 from microsetta_private_api.config_manager import SERVER_CONFIG
 
+PACKAGE = __name__.split('.')[0]
+CELERY_BACKEND_URI = 'celery_backend_uri'
+CELERY_BROKER_URI = 'celery_broker_uri'
+
 
 # derived from
 # https://medium.com/@frassetto.stefano/flask-celery-howto-d106958a15fe
-
-
 def init_celery(celery, app):
     celery.conf.update(app.config)
     TaskBase = celery.Task
@@ -17,12 +19,13 @@ def init_celery(celery, app):
                 return TaskBase.__call__(self, *args, **kwargs)
 
     celery.Task = ContextTask
+    celery.autodiscover_tasks([PACKAGE])
 
 
 def make_celery(app_name):
-    celery_backend = SERVER_CONFIG['celery_backend_uri']
-    celery_broker = SERVER_CONFIG['celery_broker_uri']
+    celery_backend = SERVER_CONFIG[CELERY_BACKEND_URI]
+    celery_broker = SERVER_CONFIG[CELERY_BROKER_URI]
     return Celery(app_name, backend=celery_backend, broker=celery_broker)
 
 
-celery = make_celery(__name__.split('.')[0])
+celery = make_celery(PACKAGE)

--- a/microsetta_private_api/conftest.py
+++ b/microsetta_private_api/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+
+@pytest.fixture(scope='session')
+def celery_config():
+    return {
+        'broker_url': 'memory://',
+        'result_backend': 'cache+memory://'
+    }

--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -71,6 +71,7 @@ def build_app():
         app.app.logger.setLevel(gunicorn_logger.level)
 
     init_celery(celery, app.app)
+    celery.autodiscover_tasks([__name__.split('.')[0]])
 
     return app
 

--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -71,7 +71,6 @@ def build_app():
         app.app.logger.setLevel(gunicorn_logger.level)
 
     init_celery(celery, app.app)
-    celery.autodiscover_tasks([__name__.split('.')[0]])
 
     return app
 
@@ -91,7 +90,9 @@ def run(app):
     )
 
 
+app = build_app()
+
+
 # If we're running in stand alone mode, run the application
 if __name__ == '__main__':
-    app = build_app()
     run(app)

--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -6,6 +6,8 @@ from microsetta_private_api.config_manager import SERVER_CONFIG
 from flask import jsonify
 
 from microsetta_private_api.exceptions import RepoException
+from microsetta_private_api.celery_utils import celery, init_celery
+
 
 """
 Basic flask/connexion-based web application
@@ -67,6 +69,8 @@ def build_app():
         gunicorn_logger = logging.getLogger('gunicorn.error')
         app.app.logger.handlers = gunicorn_logger.handlers
         app.app.logger.setLevel(gunicorn_logger.level)
+
+    init_celery(celery, app.app)
 
     return app
 

--- a/microsetta_private_api/server_config.json
+++ b/microsetta_private_api/server_config.json
@@ -7,6 +7,8 @@
   "ssl_key_path": null,
   "CAfile": null,
   "authrocket_url": "https://jubilant-smoke-a54b.e2.loginrocket.com",
+  "celery_backend_uri": "redis://localhost:6379",
+  "celery_broker_uri": "redis://localhost:6379",
   "FLASK_SECRET_KEY": null,
   "vioscreen_endpoint": "https://demo.vioscreen.com",
   "vioscreen_regcode": "regcode",

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -3,7 +3,7 @@ from microsetta_private_api.util.email import SendEmail
 from microsetta_private_api.admin.email_templates import EmailMessage
 
 
-@celery.task()
+@celery.task(ignore_result=True)
 def send_email(email, template_name, template_args):
     template = EmailMessage[template_name]
     SendEmail.send(email, template, template_args)

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -6,7 +6,4 @@ from microsetta_private_api.admin.email_templates import EmailMessage
 @celery.task()
 def send_email(email, template_name, template_args):
     template = EmailMessage[template_name]
-    #SendEmail.send(email, template, template_args)
-    f = open('/tmp/coolcool', 'a')
-    f.write(str(email))
-    f.close()
+    SendEmail.send(email, template, template_args)

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -1,0 +1,12 @@
+from microsetta_private_api.celery_utils import celery
+from microsetta_private_api.util.email import SendEmail
+from microsetta_private_api.admin.email_templates import EmailMessage
+
+
+@celery.task()
+def send_email(email, template_name, template_args):
+    template = EmailMessage[template_name]
+    #SendEmail.send(email, template, template_args)
+    f = open('/tmp/coolcool', 'a')
+    f.write(str(email))
+    f.close()


### PR DESCRIPTION
This PR adds in a broker-based async compute framework to offload long running tasks to separate processes. As a proof-of-concept, the send email functionality is now through a separate worker. The ability to run tasks like this is related to #260 in that it would be nice if (a) a cronjob could tickle the API to do something such as pull information from vioscreen and (b) to not block a web server process for something that may take many minutes or longer to run.

What's nice about celery is it's possible to just call the function like a regular Python function. So right now, the test implemented here is not relying on the async methods (as we're implicitly assuming celery does that stuff correctly).

Nothing here is set in stone. This is one way we can offload long running compute, and we can explore alternatives that is the consensus. 