### PR TITLE
Create incorrect_environmental.plain

### DIFF
--- a/microsetta_private_api/templates/email/incorrect_environmental.plain
+++ b/microsetta_private_api/templates/email/incorrect_environmental.plain
@@ -1,0 +1,21 @@
+Hello {{contact_name |e}},
+    Thank you for your interest and participation in The Microsetta Initiative. We are writing as we've encountered an issue processing your sample, and we would appreciate your assistance in helping resolve this matter.
+
+    Specifically, the following sample sent to the lab was associated as an environmental sample:
+        Barcode {{sample_barcode |e}}
+
+    Our lab noted that the above sample is a human sample, so we would need to ensure it is properly associated so we can accurately process this sample.   Please log back into the participant website by clicking or copying the following URL:
+    {{ account_url}}
+    
+    Check that you have a human source type set up in the "Sources" table.  
+    
+    If there is a human source set up, please email us back, specifying who the sample belongs to and if the below sample type is correct.
+    If there is not a human source, please add one for this sample's owner.  Once a source has been set up, please email us back, specifying who the sample belongs to and if the below sample type is correct.
+        Barcode {{sample_barcode |e}}: {{received_type |e}}
+       
+    If you have more details about this sample (such as the collection date or time), please communicate this to microsetta@ucsd.edu by replying to this email. We will then update your sample's information so it can be appropriately associated.
+
+    If you have any questions, please reply to us at microsetta@ucsd.edu.
+
+    Thank you,
+    The Microsetta Team

--- a/microsetta_private_api/templates/email/incorrect_environmental.plain
+++ b/microsetta_private_api/templates/email/incorrect_environmental.plain
@@ -1,21 +1,21 @@
 Hello {{contact_name |e}},
     Thank you for your interest and participation in The Microsetta Initiative. We are writing as we've encountered an issue processing your sample, and we would appreciate your assistance in helping resolve this matter.
 
-    Specifically, the following sample sent to the lab was associated as an environmental sample:
+    Specifically, the following sample received by our lab was described as being associated to an environmental source:
         Barcode {{sample_barcode |e}}
 
-    Our lab noted that the above sample is a human sample, so we would need to ensure it is properly associated so we can accurately process this sample.   Please log back into the participant website by clicking or copying the following URL:
+    Our lab noted that this sample appears to be a human associated sample. We need your help to ensure the sample is properly associated so it can be safely handled and processed correctly by our lab.   Please log back into the participant website by clicking or copying the following URL:
     {{ account_url}}
     
     Check that you have a human source type set up in the "Sources" table.  
-    
-    If there is a human source set up, please email us back, specifying who the sample belongs to and if the below sample type is correct.
-    If there is not a human source, please add one for this sample's owner.  Once a source has been set up, please email us back, specifying who the sample belongs to and if the below sample type is correct.
+    * If there is a human source set up, please reply to this email (microsetta@ucsd.edu), indicating who the sample belongs to, and verify the sample type (e.g. stool, saliva, etc.).
+    * If a human source has not been set up, please create one for the sample's owner. This step is required for our human subjects research requirements.  Once a source has been set up, please email us back, indicating who the sample belongs to and verify the sample type (e.g. stool, saliva, etc.).
+    * Below is a suggestion from our lab for the sample type.  If you believe it is correct, then please verify it with us.
         Barcode {{sample_barcode |e}}: {{received_type |e}}
        
-    If you have more details about this sample (such as the collection date or time), please communicate this to microsetta@ucsd.edu by replying to this email. We will then update your sample's information so it can be appropriately associated.
+    After verifying the sample type, we will then update your sample's information so it can be appropriately associated.
 
-    If you have any questions, please reply to us at microsetta@ucsd.edu.
+   Again, thank you for your interest and participation, and for your help in this correction. Please do not hesitate to reply to this email or send questions to microsetta@ucsd.edu.
 
     Thank you,
     The Microsetta Team


### PR DESCRIPTION
Email template for samples that are incorrectly associated as environmental samples, but should be human samples
- Included language to ensure that participants have a human source available to use for re-assignment