### PR TITLE
WIP - Vioscreen Report PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,15 @@ In the activated conda environment, initialize a test database:
 
 `python microsetta_private_api/LEGACY/build_db.py`
 
-Then we'll initiate a Celery worker:
+Then we'll initiate a Celery worker (Example shown is with embedded Celery Beat scheduler):
 
-`celery -A microsetta_private_api.celery_worker.celery worker --loglevel=info`
+`celery -A microsetta_private_api.celery_worker.celery worker -B --loglevel=info`
+
+*** OR (Allowing for multiple workers)***
+
+`celery -A microsetta_private_api.celery_worker.celery worker --loglevel=info` (Start 1 worker)
+`celery -A microsetta_private_api.celery_worker.celery beat --loglevel=info` (Start the Celery Beat scheduler)
+
 
 Next, start the microservice using flask's built-in server by running, e.g., 
 

--- a/microsetta_private_api/api/__init__.py
+++ b/microsetta_private_api/api/__init__.py
@@ -12,7 +12,7 @@ from ._source import (
 from ._survey import (
     read_survey_template, read_survey_templates, read_answered_survey,
     read_answered_surveys, submit_answered_survey,
-    read_answered_survey_associations,
+    read_answered_survey_associations, top_food_report,
 )
 from ._sample import (
     read_sample_association, associate_sample, read_sample_associations,

--- a/microsetta_private_api/api/__init__.py
+++ b/microsetta_private_api/api/__init__.py
@@ -39,6 +39,7 @@ __all__ = [
     'read_answered_survey',
     'read_answered_surveys',
     'read_answered_survey_associations',
+    'top_food_report',
     'read_sample_association',
     'associate_sample',
     'read_sample_associations',

--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -10,6 +10,7 @@ from microsetta_private_api.repo.sample_repo import SampleRepo
 from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.transaction import Transaction
+from microsetta_private_api.repo.vioscreen_repo import VioscreenRepo
 from microsetta_private_api.util.util import fromisotime
 from microsetta_private_api.admin.admin_impl import token_grants_admin_access
 

--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -10,7 +10,6 @@ from microsetta_private_api.repo.sample_repo import SampleRepo
 from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.transaction import Transaction
-from microsetta_private_api.repo.vioscreen_repo import VioscreenRepo
 from microsetta_private_api.util.util import fromisotime
 from microsetta_private_api.admin.admin_impl import token_grants_admin_access
 

--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -1,7 +1,5 @@
-import io
-
 import flask
-from flask import jsonify, make_response, send_file
+from flask import jsonify, make_response
 from werkzeug.exceptions import NotFound
 
 from microsetta_private_api.api._account import \
@@ -239,7 +237,9 @@ def top_food_report(account_id, source_id, survey_id, token_info):
         vioscreen_repo = VioscreenRepo(t)
 
         # Vioscreen username is our survey_id
-        status = vioscreen_repo.get_vioscreen_status(account_id, source_id, survey_id)
+        status = vioscreen_repo.get_vioscreen_status(account_id,
+                                                     source_id,
+                                                     survey_id)
         if status != 3:
             # Oops, we don't have results available for this one
             raise NotFound("No such survey recorded")

--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -1,5 +1,8 @@
+import io
+
 import flask
-from flask import jsonify
+from flask import jsonify, make_response, send_file
+from werkzeug.exceptions import NotFound
 
 from microsetta_private_api.api._account import \
     _validate_account_access
@@ -10,6 +13,7 @@ from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.vioscreen_repo import VioscreenRepo
 from microsetta_private_api.util import vioscreen, vue_adapter
+from microsetta_private_api.util.vioscreen import VioscreenAdminAPI
 
 
 def read_survey_templates(account_id, source_id, language_tag, token_info):
@@ -226,3 +230,31 @@ def _submit_vioscreen_status(account_id, source_id, info_str):
                                     source_id,
                                     vio_info["username"])
     return response
+
+
+def top_food_report(account_id, source_id, survey_id, token_info):
+    _validate_account_access(token_info, account_id)
+
+    with Transaction() as t:
+        vioscreen_repo = VioscreenRepo(t)
+
+        # Vioscreen username is our survey_id
+        status = vioscreen_repo.get_vioscreen_status(account_id, source_id, survey_id)
+        if status != 3:
+            # Oops, we don't have results available for this one
+            raise NotFound("No such survey recorded")
+
+        vio = VioscreenAdminAPI()
+        sessions = vio.sessions(survey_id)
+        # Looks like vioscreen supports multiple sessions per user, do we care?
+        session_id = sessions[0]['sessionId']
+        report = vio.top_food_report(session_id)
+
+        response = make_response(report)
+        response.headers.set("Content-Type", "application/pdf")
+        # TODO: Do we want it to download a file or be embedded in the html?
+        # response.headers.set('Content-Disposition',
+        #                      'attachment',
+        #                      filename='top-food-report.pdf')
+
+        return response

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -681,6 +681,32 @@ paths:
     # NB: NO "put"--you shouldn't update an answered survey, but instead should take a new one
     # NB: Currently no delete ... can dissociate a survey from a sample but not delete the survey itself
 
+  '/accounts/{account_id}/sources/{source_id}/surveys/{survey_id}/reports/topfoodreport':
+    # Attempts to generate the vioscreen top food report pdf from this vioscreen survey
+    get:
+      # TODO: Unsure if this should be get or post- it's post on vioscreen, but
+      # we can't easily embed the pdf if the link is a post.  May need to post
+      # and cache results so we can make it a get for embedding.
+      operationId: microsetta_private_api.api.top_food_report
+      tags:
+        - Survey
+      summary: Generate vioscreen top food report
+      description:  Generate vioscreen top food report
+      parameters:
+        - $ref: '#/components/parameters/account_id'
+        - $ref: '#/components/parameters/source_id'
+        - $ref: '#/components/parameters/survey_id'
+        - $ref: '#/components/parameters/language_tag'
+      responses:
+        '200':
+          description: Top Food Report pdf
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
   '/accounts/{account_id}/sources/{source_id}/samples':
     get:
       operationId: microsetta_private_api.api.read_sample_associations

--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -22,6 +22,15 @@ def init_celery(celery, app):
     celery.Task = ContextTask
     celery.autodiscover_tasks([PACKAGE])
 
+    # Set up "Celery Beat", events that run on a fixed time interval
+    celery.conf.beat_schedule = {
+        # Vioscreen tokens are good for an hour, refresh every 55 minutes
+        "refresh_vioscreen_token": {
+            "task": "microsetta_private_api.util.vioscreen.refresh_headers",
+            "schedule": 55 * 60
+        }
+    }
+
 
 def make_celery(app_name):
     celery_backend = SERVER_CONFIG[CELERY_BACKEND_URI]

--- a/microsetta_private_api/celery_worker.py
+++ b/microsetta_private_api/celery_worker.py
@@ -1,3 +1,7 @@
 from microsetta_private_api.server import app
 from microsetta_private_api.celery_utils import celery, init_celery
+from microsetta_private_api.util.vioscreen import refresh_headers
 init_celery(celery, app.app)
+
+# Run any celery tasks that require initialization on worker start
+refresh_headers.delay()  # Initialize the vioscreen task with a token

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -49,18 +49,19 @@ class SurveyAnswersRepo(BaseRepo):
             #  in dev builds)
             # TODO:  It's even worse than I feared.  Some of our primary
             #  surveys are ALSO vioscreen surveys with the same key. wtf.
-            # if len(rows) == 0:
-            vioscreen_repo = VioscreenRepo(self._transaction)
-            status = vioscreen_repo._get_vioscreen_status(survey_answers_id)
-            if status is not None:
-                return SurveyTemplateRepo.VIOSCREEN_ID
-            else:
-                return None
-                # TODO: Maybe this should throw an exception, but doing so
-                #  locks the end user out of the minimal implementation
-                #  if they submit an empty survey response.
-                # raise RepoException("No answers in survey: %s" %
-                #                     survey_answers_id)
+            if len(rows) == 0:
+                vioscreen_repo = VioscreenRepo(self._transaction)
+                status = vioscreen_repo._get_vioscreen_status(
+                    survey_answers_id)
+                if status is not None:
+                    return SurveyTemplateRepo.VIOSCREEN_ID
+                else:
+                    return None
+                    # TODO: Maybe this should throw an exception, but doing so
+                    #  locks the end user out of the minimal implementation
+                    #  if they submit an empty survey response.
+                    # raise RepoException("No answers in survey: %s" %
+                    #                     survey_answers_id)
 
             arbitrary_question_id = rows[0][1]
             cur.execute("SELECT surveys.survey_id FROM "

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -44,18 +44,23 @@ class SurveyAnswersRepo(BaseRepo):
                         (survey_answers_id,))
             rows += cur.fetchall()
 
-            if len(rows) == 0:
-                vioscreen_repo = VioscreenRepo(self._transaction)
-                status = vioscreen_repo.get_vioscreen_status(survey_answers_id)
-                if status is not None:
-                    return SurveyTemplateRepo.VIOSCREEN_ID
-                else:
-                    return None
-                    # TODO: Maybe this should throw an exception, but doing so
-                    #  locks the end user out of the minimal implementation
-                    #  if they submit an empty survey response.
-                    # raise RepoException("No answers in survey: %s" %
-                    #                     survey_answers_id)
+            # TODO:  We probably can't merge the PR with this change, need
+            #  a policy to resolve these survey ids (unless they only happen
+            #  in dev builds)
+            # TODO:  It's even worse than I feared.  Some of our primary
+            #  surveys are ALSO vioscreen surveys with the same key. wtf.
+            # if len(rows) == 0:
+            vioscreen_repo = VioscreenRepo(self._transaction)
+            status = vioscreen_repo._get_vioscreen_status(survey_answers_id)
+            if status is not None:
+                return SurveyTemplateRepo.VIOSCREEN_ID
+            else:
+                return None
+                # TODO: Maybe this should throw an exception, but doing so
+                #  locks the end user out of the minimal implementation
+                #  if they submit an empty survey response.
+                # raise RepoException("No answers in survey: %s" %
+                #                     survey_answers_id)
 
             arbitrary_question_id = rows[0][1]
             cur.execute("SELECT surveys.survey_id FROM "

--- a/microsetta_private_api/repo/vioscreen_repo.py
+++ b/microsetta_private_api/repo/vioscreen_repo.py
@@ -3,9 +3,6 @@ from werkzeug.exceptions import NotFound
 
 
 # This was ported from the american_gut_project's ag_data_access.py.
-from microsetta_private_api.repo.source_repo import SourceRepo
-
-
 class VioscreenRepo(BaseRepo):
     def __init__(self, transaction):
         super().__init__(transaction)

--- a/microsetta_private_api/server_config.json
+++ b/microsetta_private_api/server_config.json
@@ -12,5 +12,7 @@
   "FLASK_SECRET_KEY": null,
   "vioscreen_endpoint": "https://demo.vioscreen.com",
   "vioscreen_regcode": "regcode",
-  "vioscreen_cryptokey": "1234567891011121"
+  "vioscreen_cryptokey": "1234567891011121",
+  "vioscreen_admin_username": "",
+  "vioscreen_admin_password": ""
 }

--- a/microsetta_private_api/util/vioscreen.py
+++ b/microsetta_private_api/util/vioscreen.py
@@ -241,7 +241,8 @@ class VioscreenAdminAPI:
         return self._get_session_data(id_, 'eatingpatterns').get('data')
 
     def foodconsumption(self, id_):
-        return self._get_session_data(id_, 'foodconsumption').get('foodConsumption')
+        return self._get_session_data(id_, 'foodconsumption')\
+            .get('foodConsumption')
 
     def dietaryscore(self, id_):
         return self._get_session_data(id_, 'dietaryscore').get('dietaryScore')


### PR DESCRIPTION
Adds support for talking to vioscreen using RPC through celery.  Have to worry about both the RPC channel only allowing jsonifiable data, handling async correctly, and dealing with content types and pdf embedding, but it all works as a prototype.  Note that the initial vioscreen login handshake takes about 35 seconds (as presumably does any token refresh), but once logged in the pdf generation time is near instant.  Must check if vioscreen meters our pdf generation and we're forced to cache results.

Uncovered a potential issue where survey ids in developer builds are referring to both valid vioscreen data and primary survey data, which is not supported by our model classes/repos.  