### PR TITLE
Split Primary/Vioscreen Surveys Into Separate IDs

### DIFF
--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -373,7 +373,7 @@ class MigrationSupport:
                     linked_barcode = row[0]
                     TRN.add("INSERT INTO source_barcodes_surveys "
                             "(barcode, survey_id) "
-                            "VALUES(%s, %s)", linked_barcode, new_survey_id)
+                            "VALUES(%s, %s)", (linked_barcode, new_survey_id))
 
         # Check that we were successful - no offending ids should remain
         TRN.add("SELECT DISTINCT survey_id FROM ag_login_surveys "

--- a/microsetta_private_api/db/patches/0070.sql
+++ b/microsetta_private_api/db/patches/0070.sql
@@ -1,0 +1,5 @@
+-- Intentionally Left Blank.  See the corresponding python function in
+-- migration_support.py
+
+-- (Note that empty queries are not supported, so need a placeholder)
+SELECT 1;


### PR DESCRIPTION
Seems that our database has primary and vioscreen surveys sharing IDs in a number of legacy accounts.  This is frustrating since we need the ability to say what type a particular survey ID is, and saying both isn't part of our model.  This PR is a schema change to fork the IDs- primary surveys are assigned a new UUID and tables that reference the survey ID are updated or forked as necessary.  