### PR TITLE
Update missing_sample_info.plain

### DIFF
--- a/microsetta_private_api/templates/email/missing_sample_info.plain
+++ b/microsetta_private_api/templates/email/missing_sample_info.plain
@@ -4,12 +4,15 @@ Hello {{contact_name |e}},
     Specifically, the following sample sent to the lab does not have a recorded sample type, date or time:
         Barcode {{sample_barcode |e}}
 
-    We require this information in order to process this sample in compliance with our human subjects research protocol. If you have a record of the associated sample type, date, and time for this sample, please provide us with this information.
-
     Based on what we can see, the sample type appears to be:
         Barcode {{sample_barcode |e}}: {{received_type |e}}
 
-    If you have more details about this sample, please communicate at microsetta@ucsd.edu by replying to this email. And if you have an approximate date and time of sample collection, we would greatly appreciate your sharing this information. We will then update your sample's information so it can be appropriately associated.
+ We require this information in order to process this sample in compliance with our human subjects research protocol. In order to update your sample's information to ensure it is compliant, our team will be able to do this on your behalf--but first, we would need your consent to do so and the following information:
+ - Collection date
+ - Collection time
+ - Sample type (the above sample type is a suggestion based on our lab)
+ 
+Please provide us with this information by replying to this email, and confirming that we can update your sample. We will then update your sample's information so it can be appropriately associated.
 
     If you have any questions, please reply to us at microsetta@ucsd.edu
 


### PR DESCRIPTION
This is a little rough around the edges as I'm hastily finishing up everything on my last day, but changing the wording of this notification email.  Essentially the issue is that participants get confused when they try to update their sample info by accessing their account, but can't since our system has locked the sample for editing, so it'd be nice to reduce that confusion by telling them what exactly they need to do (i.e. emailing us back with the following information).