### PR TITLE
Repo + Model layers for Preparations

### DIFF
--- a/microsetta_private_api/db/patches/0073.sql
+++ b/microsetta_private_api/db/patches/0073.sql
@@ -1,0 +1,12 @@
+-- create table to summarize sequencing results for each barcode+preparation pairing
+CREATE TABLE barcodes.preparation
+(
+    barcode varchar NOT NULL,
+    preparation_id int NOT NULL,
+    preparation_type varchar NOT NULL,
+    num_sequences bigint NOT NULL,
+    CONSTRAINT fk_barcode FOREIGN KEY ( barcode ) REFERENCES barcodes.barcode( barcode )
+);
+
+CREATE UNIQUE INDEX preparation_barcode_prep_id ON barcodes.preparation (barcode, preparation_id);
+CREATE UNIQUE INDEX preparation_prep_id_barcode ON barcodes.preparation (preparation_id, barcode);

--- a/microsetta_private_api/model/preparation.py
+++ b/microsetta_private_api/model/preparation.py
@@ -1,0 +1,21 @@
+from microsetta_private_api.model.model_base import ModelBase
+
+
+# A particular sample (indicated by its barcode), can be examined multiple
+# times.  This involves preparing the sample in a particular way
+# (16S or shotgun...), then running the prepared sample through the sequencer.
+# This object indicates a preparation that a sample has gone through, and the
+# results of sequencing that prep.
+class Preparation(ModelBase):
+    def __init__(self,
+                 barcode,
+                 preparation_id,
+                 preparation_type,
+                 num_sequences):
+        self.barcode = barcode
+        self.preparation_id = preparation_id
+        self.preparation_type = preparation_type
+        self.num_sequences = num_sequences
+
+    def to_api(self):
+        return self.__dict__.copy()

--- a/microsetta_private_api/repo/barcode_repo.py
+++ b/microsetta_private_api/repo/barcode_repo.py
@@ -1,0 +1,57 @@
+from microsetta_private_api.model.preparation import Preparation
+from microsetta_private_api.repo.base_repo import BaseRepo
+
+
+class BarcodeRepo(BaseRepo):
+    """
+    Repo handling interactions with barcodes.barcode and surrounding tables
+    """
+
+    def __init__(self, transaction):
+        super().__init__(transaction)
+
+    @staticmethod
+    def _row_to_prep(r):
+        return Preparation(
+            barcode=r["barcode"],
+            preparation_id=r["preparation_id"],
+            preparation_type=r["preparation_type"],
+            num_sequences=r["num_sequences"]
+        )
+
+    @staticmethod
+    def _prep_to_row(p):
+        return (p.barcode,
+                p.preparation_id,
+                p.preparation_type,
+                p.num_sequences)
+
+    def list_preparations(self, barcode):
+        with self._transaction.dict_cursor() as cur:
+            cur.execute(
+                "SELECT "
+                "barcode, preparation_id, preparation_type, num_sequences "
+                "FROM preparation "
+                "WHERE barcode=%s", (barcode,)
+            )
+            rows = cur.fetchall()
+            return [self._row_to_prep(r) for r in rows]
+
+    def delete_preparation(self, barcode, preparation_id):
+        with self._transaction.cursor() as cur:
+            cur.execute(
+                "DELETE FROM preparation "
+                "WHERE barcode=%s AND preparation_id=%s",
+                (barcode, preparation_id,)
+            )
+            return cur.rowcount == 1
+
+    def upsert_preparation(self, preparation: Preparation):
+        self.delete_preparation(preparation.barcode,
+                                preparation.preparation_id)
+        with self._transaction.cursor() as cur:
+            cur.execute(
+                "INSERT into preparation"
+                "(barcode, preparation_id, preparation_type, num_sequences)"
+                "VALUES(%s, %s, %s, %s)", self._prep_to_row(preparation)
+            )

--- a/microsetta_private_api/repo/barcode_repo.py
+++ b/microsetta_private_api/repo/barcode_repo.py
@@ -7,9 +7,6 @@ class BarcodeRepo(BaseRepo):
     Repo handling interactions with barcodes.barcode and surrounding tables
     """
 
-    def __init__(self, transaction):
-        super().__init__(transaction)
-
     @staticmethod
     def _row_to_prep(r):
         return Preparation(

--- a/microsetta_private_api/repo/tests/test_barcode_repo.py
+++ b/microsetta_private_api/repo/tests/test_barcode_repo.py
@@ -1,0 +1,105 @@
+from microsetta_private_api.api.tests.test_integration import \
+    _create_mock_kit, _remove_mock_kit
+from microsetta_private_api.model.preparation import Preparation
+from microsetta_private_api.repo.barcode_repo import BarcodeRepo
+import unittest
+
+from microsetta_private_api.repo.transaction import Transaction
+
+BC1 = "77777777"
+BC2 = "88888888"
+BC3 = "99999999"
+S1 = '99999999-aaaa-aaaa-aaaa-bbbbcccccccc'
+S2 = '99999999-aaaa-aaaa-aaaa-bbbbcccccccd'
+S3 = '99999999-aaaa-aaaa-aaaa-bbbbccccccce'
+
+FAKE_BARCODES = [BC1, BC2, BC3]
+FAKE_SAMPLES = [S1, S2, S3]
+
+
+class BarcodeTests(unittest.TestCase):
+    def setUp(self):
+        with Transaction() as t:
+            _create_mock_kit(t,
+                             barcodes=FAKE_BARCODES,
+                             mock_sample_ids=FAKE_SAMPLES)
+            t.commit()
+
+    def tearDown(self):
+        with Transaction() as t:
+            _remove_mock_kit(t,
+                             barcodes=FAKE_BARCODES,
+                             mock_sample_ids=FAKE_SAMPLES)
+            t.commit()
+
+    def test_upsert_prep(self):
+        with Transaction() as t:
+            r = BarcodeRepo(t)
+            h = Preparation(
+                BC1,
+                99999999,
+                "16S",
+                127
+            )
+
+            self.assertEqual(
+                len(r.list_preparations(BC1)),
+                0,
+                "Preexisting Barcode Prep!?"
+            )
+
+            r.upsert_preparation(h)
+            self.assertEqual(
+                len(r.list_preparations(BC1)),
+                1,
+                "Failed to insert preparation"
+            )
+
+            h.barcode = BC2
+            r.upsert_preparation(h)
+            self.assertEqual(
+                len(r.list_preparations(BC1)),
+                1,
+                "Inserting for BC2 removed from BC1 (but many-to-many)"
+            )
+            self.assertEqual(
+                len(r.list_preparations(BC2)),
+                1,
+                "Failed to insert preparation (not in bc2)"
+            )
+
+            g = r.list_preparations(BC2)[0]
+            self.assertDictEqual(h.to_api(), g.to_api())
+
+            t.rollback()
+
+    def test_add_preps(self):
+        with Transaction() as t:
+            r = BarcodeRepo(t)
+            for i in range(10):
+                h = Preparation(
+                    BC3,
+                    99999990 + i,
+                    "16S",
+                    127
+                )
+
+                r.upsert_preparation(h)
+            self.assertEqual(len(r.list_preparations(BC1)), 0)
+            self.assertEqual(len(r.list_preparations(BC2)), 0)
+            self.assertEqual(len(r.list_preparations(BC3)), 10)
+            t.rollback()
+
+    def test_del_prep(self):
+        with Transaction() as t:
+            r = BarcodeRepo(t)
+            h = Preparation(BC3, 99999999, "WGS", 57182302)
+
+            self.assertEqual(r.delete_preparation(BC3, 99999999), 0,
+                             "Successfully deleted nonexisted prep?")
+            r.upsert_preparation(h)
+            self.assertEqual(r.delete_preparation(BC3, 99999999), 1,
+                             "Failed to delete prep")
+            self.assertEqual(r.delete_preparation(BC3, 99999999), 0,
+                             "Successfully deleted same prep twice?")
+            t.rollback()


### PR DESCRIPTION
Added a table linking barcodes and preps (and saying how many sequences were found in each barcode+prep pairing), added a Preparation model and a new BarcodeRepo for handling queries based on barcode that can retrieve Preparations