### PR TITLE
Improve messaging for missing barcodes

### DIFF
--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -301,20 +301,20 @@ def _to_pandas_series(metadata, multiselect_map):
     sample_detail = metadata['sample']
     collection_timestamp = sample_detail.datetime_collected
 
+    if source_type is None:
+        raise RepoException("Sample is missing a source type")
+
     if source_type == 'human':
         sample_type = sample_detail.site
         sample_invariants = HUMAN_SITE_INVARIANTS[sample_type]
     elif source_type == 'animal':
         sample_type = sample_detail.site
         sample_invariants = {}
-    else:
-        if 'source' not in sample_detail:
-            # HACK: this can occur if a source does not have collection
-            # information?
-            return pd.Series([], index=[], name=name)
-
+    elif source_type == 'environmental':
         sample_type = sample_detail['source'].description
         sample_invariants = {}
+    else:
+        raise RepoException("Sample has an unknown sample type")
 
     values = [hsi, collection_timestamp]
     index = ['HOST_SUBJECT_ID', 'COLLECTION_TIMESTAMP']

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -1,11 +1,12 @@
 from ._constants import HUMAN_SITE_INVARIANTS, MISSING_VALUE
 from ._transforms import HUMAN_TRANSFORMS, apply_transforms
-
 from ..admin_repo import AdminRepo
 from ..survey_template_repo import SurveyTemplateRepo
 from ..transaction import Transaction
+from ...exceptions import RepoException
 from ...util import vue_adapter
 
+from werkzeug.exceptions import NotFound
 from collections import Counter
 import re
 import pandas as pd
@@ -79,9 +80,13 @@ def retrieve_metadata(sample_barcodes):
 
     fetched = []
     for sample_barcode in set(sample_barcodes):
-        bc_md, errors = _fetch_barcode_metadata(sample_barcode)
+        try:
+            bc_md, errors = _fetch_barcode_metadata(sample_barcode)
+        except (NotFound, RepoException) as e:
+            errors = e.args[0]
+
         if errors is not None:
-            error_report.append(errors)
+            error_report.append({sample_barcode: errors})
             continue
 
         fetched.append(bc_md)

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -82,8 +82,10 @@ def retrieve_metadata(sample_barcodes):
     for sample_barcode in set(sample_barcodes):
         try:
             bc_md, errors = _fetch_barcode_metadata(sample_barcode)
-        except (NotFound, RepoException) as e:
+        except RepoException as e:
             errors = e.args[0]
+        except NotFound as e:
+            errors = e.description
 
         if errors is not None:
             error_report.append({sample_barcode: errors})

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -4,6 +4,7 @@ import pandas.testing as pdt
 from werkzeug.exceptions import NotFound
 from microsetta_private_api.repo.metadata_repo._constants import (
     HUMAN_SITE_INVARIANTS, MISSING_VALUE)
+from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.repo.metadata_repo._repo import (
     _build_col_name,
     _find_duplicates,
@@ -202,6 +203,10 @@ class MetadataUtilTests(unittest.TestCase):
     def test_fetch_barcode_metadata_missing(self):
         with self.assertRaises(NotFound):
             _fetch_barcode_metadata('badbarcode')
+
+    def test_fetch_valid_unlinked_barcode(self):
+        with self.assertRaises(RepoException):
+            _fetch_barcode_metadata('000004126')
 
     def test_to_pandas_dataframe(self):
         data = [self.raw_sample_1, self.raw_sample_2]


### PR DESCRIPTION
A set of samples can now be provided, where some may be missing or bad, and the information about which sample is bad is retained. In addition, samples raising a `NotFound` repo exception will now be caught rather than bubbling out to the API layer