### PR TITLE
Only valid samples are locked

### DIFF
--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -502,7 +502,8 @@ def create_dummy_sample_objects(filled=False):
                     None,
                     info_dict['source_id'],
                     info_dict['account_id'],
-                    info_dict["sample_projects"])
+                    info_dict["sample_projects"],
+                    None)
 
     return sample_info, sample
 # endregion help methods

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -5,7 +5,7 @@ from microsetta_private_api.model.model_base import ModelBase
 class Sample(ModelBase):
     def __init__(self, sample_id, datetime_collected, site, notes, barcode,
                  latest_scan_timestamp, source_id, account_id,
-                 sample_projects):
+                 sample_projects, latest_scan_status):
         self.id = sample_id
         # NB: datetime_collected may be None if sample not yet used
         self.datetime_collected = datetime_collected
@@ -16,6 +16,7 @@ class Sample(ModelBase):
         self.site = site
         # NB: _latest_scan_timestamp may be None if not yet returned to lab
         self._latest_scan_timestamp = latest_scan_timestamp
+        self._latest_scan_status = latest_scan_status
         self.sample_projects = sample_projects
 
         self.source_id = source_id
@@ -23,14 +24,14 @@ class Sample(ModelBase):
 
     @property
     def is_locked(self):
-        # If a sample has been scanned into the system, that means its
-        # attributes can't be changed
-        return self._latest_scan_timestamp is not None
+        # If a sample has been scanned and is valid, it is locked.
+        return self._latest_scan_timestamp is not None and \
+               self._latest_scan_status == "sample-is-valid"
 
     @classmethod
     def from_db(cls, sample_id, date_collected, time_collected,
                 site, notes, barcode, latest_scan_timestamp,
-                source_id, account_id, sample_projects):
+                source_id, account_id, sample_projects, latest_scan_status):
         datetime_collected = None
         # NB a sample may NOT have date and time collected if it has been sent
         # out but not yet used
@@ -38,8 +39,8 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                   latest_scan_timestamp, source_id, account_id,
-                   sample_projects)
+                   latest_scan_timestamp, source_id,
+                   account_id, sample_projects, latest_scan_status)
 
     def to_api(self):
         return {

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -61,9 +61,11 @@ class SampleRepo(BaseRepo):
             return None
 
         sample_barcode = sample_row[5]
+        scan_timestamp = sample_row[6]
         sample_projects = self._retrieve_projects(sample_barcode)
+        sample_status = self.get_sample_status(sample_barcode, scan_timestamp)
 
-        return Sample.from_db(*sample_row, sample_projects)
+        return Sample.from_db(*sample_row, sample_projects, sample_status)
 
     # TODO: I'm still not entirely happy with the linking between samples and
     #  sources.  The new source_id is direct (and required for environmental


### PR DESCRIPTION
Updated sample constructor to include scan status, though it doesn't pass through api.  sample.is_locked now requires scan status of sample-is-valid

Fix #287 