### PR TITLE
Vioscreen Hotfix - Registry Table

### DIFF
--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -44,7 +44,8 @@ def read_survey_templates(account_id, source_id, language_tag, token_info):
 
 
 def read_survey_template(account_id, source_id, survey_template_id,
-                         language_tag, token_info, survey_redirect_url=None):
+                         language_tag, token_info, survey_redirect_url=None,
+                         vioscreen_ext_sample_id=None):
     _validate_account_access(token_info, account_id)
 
     # TODO: can we get rid of source_id?  I don't have anything useful to do
@@ -58,14 +59,20 @@ def read_survey_template(account_id, source_id, survey_template_id,
 
         # For external surveys, we generate links pointing out
         if survey_template_id == SurveyTemplateRepo.VIOSCREEN_ID:
-
+            if vioscreen_ext_sample_id:
+                # User is about to start a vioscreen survey for this sample
+                # record this in the database.
+                db_vioscreen_id = survey_template_repo.create_vioscreen_id(
+                    account_id, source_id, vioscreen_ext_sample_id
+                )
             url = vioscreen.gen_survey_url(
-                language_tag, survey_redirect_url
+                db_vioscreen_id, language_tag, survey_redirect_url
             )
             # TODO FIXME HACK: This field's contents are not specified!
             info.survey_template_text = {
                 "url": url
             }
+            t.commit()
             return jsonify(info), 200
 
         # For local surveys, we generate the json representing the survey

--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -65,6 +65,9 @@ def read_survey_template(account_id, source_id, survey_template_id,
                 db_vioscreen_id = survey_template_repo.create_vioscreen_id(
                     account_id, source_id, vioscreen_ext_sample_id
                 )
+            else:
+                raise ValueError("Vioscreen Template requires "
+                                 "vioscreen_ext_sample_id parameter.")
             url = vioscreen.gen_survey_url(
                 db_vioscreen_id, language_tag, survey_redirect_url
             )

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -551,6 +551,7 @@ paths:
         - $ref: '#/components/parameters/survey_template_id'
         - $ref: '#/components/parameters/language_tag'
         - $ref: '#/components/parameters/survey_redirect_url'
+        - $ref: '#/components/parameters/vioscreen_ext_sample_id'
       responses:
         '200':
           description: Successfully returned a specific survey template
@@ -1540,6 +1541,14 @@ components:
       schema:
         type: string
         example: "https://www.microsetta.org/accounts/72d2cc55-8522-4528-a85b-78be2ec0933f/sources/bfed3a1b-0855-4dce-9398-7c54f5b4ac8f"
+    vioscreen_ext_sample_id:
+      name: vioscreen_ext_sample_id
+      in: query
+      description: Identifies sample for vioscreen templates, indicates the user is being redirected to the response url and so vioscreen id should be logged
+      schema:
+        $ref: '#/components/schemas/sample_id'
+      required: False
+
     source_type:
       name: source_type
       in: query

--- a/microsetta_private_api/db/patches/0074.sql
+++ b/microsetta_private_api/db/patches/0074.sql
@@ -1,0 +1,14 @@
+-- create table to track vioscreen survey ids
+CREATE TABLE ag.vioscreen_registry
+(
+    account_id uuid NOT NULL,
+    source_id uuid NOT NULL,
+    sample_id uuid,
+    vio_id varchar NOT NULL,
+    CONSTRAINT fk_account FOREIGN KEY (account_id) REFERENCES ag.account( id ),
+    CONSTRAINT fk_source FOREIGN KEY (source_id) REFERENCES ag.source( id ),
+    CONSTRAINT fk_sample FOREIGN KEY (sample_id) REFERENCES ag.ag_kit_barcodes( ag_kit_barcode_id )
+);
+
+CREATE INDEX vio_reg_by_vio_id ON ag.vioscreen_registry (vio_id);
+CREATE UNIQUE INDEX vio_reg_by_sample ON ag.vioscreen_registry (account_id, source_id, sample_id);

--- a/microsetta_private_api/db/patches/0074.sql
+++ b/microsetta_private_api/db/patches/0074.sql
@@ -11,4 +11,4 @@ CREATE TABLE ag.vioscreen_registry
 );
 
 CREATE INDEX vio_reg_by_vio_id ON ag.vioscreen_registry (vio_id);
-CREATE UNIQUE INDEX vio_reg_by_sample ON ag.vioscreen_registry (account_id, source_id, sample_id);
+CREATE INDEX vio_reg_by_sample ON ag.vioscreen_registry (account_id, source_id, sample_id);

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -11,6 +11,7 @@ from microsetta_private_api.model.survey_template_question import \
 from microsetta_private_api.model.survey_template_trigger import \
         SurveyTemplateTrigger
 import copy
+import secrets
 
 
 class SurveyTemplateRepo(BaseRepo):
@@ -209,3 +210,23 @@ class SurveyTemplateRepo(BaseRepo):
 
             rows = cur.fetchall()
             return [SurveyTemplateTrigger(x[0], x[1]) for x in rows]
+
+    def create_vioscreen_id(self, account_id, source_id,
+                            vioscreen_ext_sample_id):
+        with self._transaction.cursor() as cur:
+            cur.execute("SELECT vio_id FROM vioscreen_registry WHERE "
+                        "account_id=%s AND "
+                        "source_id=%s AND "
+                        "sample_id=%s",
+                        (account_id, source_id, vioscreen_ext_sample_id))
+            rows = cur.fetchall()
+            if rows is None or len(rows) == 0:
+                vioscreen_id = secrets.token_hex(8)
+                cur.execute("INSERT INTO vioscreen_registry("
+                            "account_id, source_id, sample_id, vio_id) "
+                            "VALUES(%s, %s, %s, %s)",
+                            (account_id, source_id, vioscreen_ext_sample_id,
+                             vioscreen_id))
+            else:
+                vioscreen_id = rows[0][0]
+        return vioscreen_id

--- a/microsetta_private_api/util/vioscreen.py
+++ b/microsetta_private_api/util/vioscreen.py
@@ -1,5 +1,4 @@
 import base64
-import secrets
 import uuid
 from urllib.parse import urljoin
 
@@ -16,7 +15,7 @@ import requests
 from microsetta_private_api.config_manager import SERVER_CONFIG
 
 
-def gen_survey_url(language_tag, survey_redirect_url):
+def gen_survey_url(user_id, language_tag, survey_redirect_url):
     if not survey_redirect_url:
         raise BadRequest("Food Frequency Questionnaire Requires "
                          "survey_redirect_url")
@@ -25,7 +24,7 @@ def gen_survey_url(language_tag, survey_redirect_url):
     url = SERVER_CONFIG["vioscreen_endpoint"] + "/remotelogin.aspx?%s" % \
         url_encode(
               {
-                  b"Key": encrypt_key(secrets.token_hex(8),
+                  b"Key": encrypt_key(user_id,
                                       language_tag,
                                       survey_redirect_url),
                   b"RegCode": regcode.encode()


### PR DESCRIPTION
New table tracks and reuses vioscreen survey ids.  This is potentially a first step towards a sane schema for storing user surveys, and should allow us to reconstruct what sample led to each vioscreen survey manually if need be.  

This is probably not good enough to allow users to return to surveys they have already started, and needs to be tested to see behavior in such a case.  It also does not get updated when vioscreen surveys are attached to multiple samples within a source, does not know what to do when migrating existing vioscreen surveys that are associated with a source but not any samples, probably explodes if you delete a source with an associated vioscreen survey and so forth.  

I don't see a way to make the vioscreen round trip 100% rock solid- there is always a chance of network/power outage/user quitting browser that prevents us from hearing the finished survey.  The best we can do is try to keep track of the status and potentially allow users to return to incomplete surveys, which may be possible now that we hold onto the survey ID.  