### PR TITLE
Expose Vioscreen Status

### DIFF
--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -120,11 +120,12 @@ def read_answered_surveys(account_id, source_id, language_tag, token_info):
                 source_id)
         api_objs = []
         for ans in answered_surveys:
-            template_id = survey_answers_repo.find_survey_template_id(ans)
+            template_id, status = survey_answers_repo.\
+                survey_template_id_and_status(ans)
             if template_id is None:
                 continue
             o = survey_template_repo.get_survey_template_link_info(template_id)
-            api_objs.append(o.to_api(ans))
+            api_objs.append(o.to_api(ans, status))
         return jsonify(api_objs), 200
 
 
@@ -142,13 +143,15 @@ def read_answered_survey(account_id, source_id, survey_id, language_tag,
         if not survey_answers:
             return jsonify(code=404, message="No survey answers found"), 404
 
-        template_id = survey_answers_repo.find_survey_template_id(survey_id)
+        template_id, status = survey_answers_repo.\
+            survey_template_id_and_status(survey_id)
         if template_id is None:
             return jsonify(code=422, message="No answers in survey"), 422
 
         template_repo = SurveyTemplateRepo(t)
         link_info = template_repo.get_survey_template_link_info(template_id)
         link_info.survey_id = survey_id
+        link_info.survey_status = status
         link_info.survey_text = survey_answers
         return jsonify(link_info), 200
 
@@ -199,11 +202,12 @@ def read_answered_survey_associations(account_id, source_id, sample_id,
 
         resp_obj = []
         for answered_survey in answered_surveys:
-            template_id = answers_repo.find_survey_template_id(answered_survey)
+            template_id, status = answers_repo.\
+                survey_template_id_and_status(answered_survey)
             if template_id is None:
                 continue
             info = template_repo.get_survey_template_link_info(template_id)
-            resp_obj.append(info.to_api(answered_survey))
+            resp_obj.append(info.to_api(answered_survey, status))
 
         t.commit()
         return jsonify(resp_obj), 200

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -602,6 +602,8 @@ paths:
                       properties:
                         survey_id:
                           $ref: '#/components/schemas/survey_id'
+                        survey_status:
+                          $ref: '#/components/schemas/survey_status'
                       required:
                         - survey_id
         '401':
@@ -668,6 +670,8 @@ paths:
                     properties:
                       survey_id:
                         $ref: '#/components/schemas/survey_id'
+                      survey_status:
+                        $ref: '#/components/schemas/survey_status'
                       survey_text:
                         $ref: '#/components/schemas/survey_text'
                     required:
@@ -886,6 +890,8 @@ paths:
                       properties:
                         survey_id:
                           $ref: '#/components/schemas/survey_id'
+                        survey_status:
+                          $ref: '#/components/schemas/survey_status'
                       required:
                         - survey_id
               example: # explicit examples hardcoded here because connexion can't seem to infer examples for lists
@@ -1971,6 +1977,10 @@ components:
     survey_id:
       type: string
       example: "69f697cb-8e52-4a4f-8db2-efffcfa186a5"
+    survey_status:
+      type: integer
+      example: 3
+      nullable: true
     survey_text:
       # The contents of this object ARE structured, but their structure is not specified in THIS api.
       type: object

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -1250,6 +1250,7 @@ class SurveyTests(ApiTests):
 
         expected_output = {
             "survey_template_id": PRIMARY_SURVEY_TEMPLATE_ID,
+            "survey_status": None,
             "survey_template_title": "Primary",
             "survey_template_version": "1.0",
             "survey_template_type": "local",
@@ -1421,6 +1422,7 @@ class SampleTests(ApiTests):
         expected_output = [
             {'survey_id': dummy_answered_survey_id,
              'survey_template_id': PRIMARY_SURVEY_TEMPLATE_ID,
+             'survey_status': None,
              'survey_template_title': "Primary",
              'survey_template_version': '1.0',
              'survey_template_type': 'local'

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -341,7 +341,8 @@ class IntegrationTests(TestCase):
             headers=MOCK_HEADERS
         )
         env_surveys = json.loads(resp.data)
-
+        # Survey status should not be in templates
+        self.assertNotIn("survey_status", bobo_surveys[0])
         self.assertListEqual([x["survey_template_id"] for x in bobo_surveys],
                              [1, 3, 4, 5, 6, 10001])
         self.assertListEqual([x["survey_template_id"] for x in doggy_surveys],
@@ -405,6 +406,9 @@ class IntegrationTests(TestCase):
                                )
         check_response(resp)
         retrieved_survey = json.loads(resp.data)
+        # Retrieved surveys should have a survey_status field, though it is
+        # None for everything but vioscreen.
+        self.assertIn("survey_status", retrieved_survey)
         self.assertDictEqual(retrieved_survey["survey_text"], model)
 
         # Clean up after the new survey

--- a/microsetta_private_api/model/survey_template.py
+++ b/microsetta_private_api/model/survey_template.py
@@ -13,9 +13,10 @@ class SurveyTemplateLinkInfo:
         self.survey_template_version = survey_template_version
         self.survey_template_type = survey_template_type
 
-    def to_api(self, survey_answers_id):
+    def to_api(self, survey_answers_id, survey_status):
         return {
             "survey_id": survey_answers_id,
+            "survey_status": survey_status,
             "survey_template_id": self.survey_template_id,
             "survey_template_title": self.survey_template_title,
             "survey_template_version": self.survey_template_version,

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -929,16 +929,16 @@ class AdminRepo(BaseRepo):
 
         answer_to_template_map = {}
         for answer_id in answer_ids:
-            template_id = survey_answers_repo.find_survey_template_id(
-                answer_id)
-            answer_to_template_map[answer_id] = template_id
+            template_id, status = survey_answers_repo.\
+                survey_template_id_and_status(answer_id)
+            answer_to_template_map[answer_id] = (template_id, status)
 
         # if a survey template is specified, filter the returned surveys
         if survey_template_id is not None:
             # TODO: This schema is so awkward for this type of query...
             answers = []
             for answer_id in answer_ids:
-                if answer_to_template_map[answer_id] == survey_template_id:
+                if answer_to_template_map[answer_id][0] == survey_template_id:
                     answers.append(answer_id)
 
             if len(answers) == 0:
@@ -969,7 +969,8 @@ class AdminRepo(BaseRepo):
 
             all_survey_answers.append(
                 {
-                    "template": answer_to_template_map[answer_id],
+                    "template": answer_to_template_map[answer_id][0],
+                    "survey_status": answer_to_template_map[answer_id][1],
                     "response": survey_answers
                 })
 

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -183,7 +183,7 @@ def _fetch_survey_template(template_id):
             template_id, 'en-US')
         survey_template_text = vue_adapter.to_vue_schema(survey_template)
 
-        info = info.to_api(None)
+        info = info.to_api(None, None)
         info['survey_template_text'] = survey_template_text
 
         return info, None

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -26,7 +26,7 @@ from microsetta_private_api.repo.vioscreen_repo import VioscreenRepo
 
 class SurveyAnswersRepo(BaseRepo):
 
-    def find_survey_template_id(self, survey_answers_id):
+    def survey_template_id_and_status(self, survey_answers_id):
         # TODO FIXME HACK:  There has GOT TO BE an easier way!
         with self._transaction.cursor() as cur:
             cur.execute("SELECT survey_id, survey_question_id "
@@ -54,9 +54,9 @@ class SurveyAnswersRepo(BaseRepo):
                 status = vioscreen_repo._get_vioscreen_status(
                     survey_answers_id)
                 if status is not None:
-                    return SurveyTemplateRepo.VIOSCREEN_ID
+                    return SurveyTemplateRepo.VIOSCREEN_ID, status
                 else:
-                    return None
+                    return None, None
                     # TODO: Maybe this should throw an exception, but doing so
                     #  locks the end user out of the minimal implementation
                     #  if they submit an empty survey response.
@@ -71,7 +71,8 @@ class SurveyAnswersRepo(BaseRepo):
                         (arbitrary_question_id,))
 
             survey_template_id = cur.fetchone()[0]
-            return survey_template_id
+            # Can define statuses for our internal surveys later if we want
+            return survey_template_id, None
 
     def list_answered_surveys(self, account_id, source_id):
         with self._transaction.cursor() as cur:


### PR DESCRIPTION
Sends the vioscreen_status across the api in a new survey_status field that allows the interface to decide whether to show the report pdf or the survey link.  