### PR TITLE
Fix some issues with deleting samples/sources and vioscreen_registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A private microservice to support The Microsetta Initiative
 ## Installation
 The private microservice depends on Postgres 9.5. For OSX users, we recommend installing [Postgres.app](https://postgresapp.com/). For Linux users, please consult documentation for the Linux distribution in use. 
 
-Create a new `conda` environment containing `flask` and other necessary packages:
+Create a new `conda` environment containing `flask` and other necessary packages: 
 
 `conda create -n microsetta-private-api flask psycopg2 natsort pycryptodome`
 

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,4 @@
-openapi-schema-validator < 0.1.3
+openapi-schema-validator < 0.1.2
 connexion[swagger-ui]
 pyjwt[crypto]
 pytest

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,3 @@
-openapi-schema-validator < 0.1.2
 openapi-spec-validator < 0.2.10
 connexion[swagger-ui]
 pyjwt[crypto]

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,6 +1,7 @@
+openapi-schema-validator < 0.1.3
 connexion[swagger-ui]
 pyjwt[crypto]
-pytest < 5.3.4
+pytest
 pytest-cov
 coveralls
 pycountry

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,5 @@
 openapi-schema-validator < 0.1.2
+openapi-spec-validator < 0.2.10
 connexion[swagger-ui]
 pyjwt[crypto]
 pytest

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -128,11 +128,13 @@ class MetadataUtilTests(unittest.TestCase):
 
     def test_fetch_observed_survey_templates(self):
         exp = {1: {'survey_id': None,
+                   'survey_status': None,
                    'survey_template_id': 1,
                    'survey_template_title': 'Primary',
                    'survey_template_type': 'local',
                    'survey_template_version': '1.0'},
                2: {'survey_id': None,
+                   'survey_status': None,
                    'survey_template_id': 2,
                    'survey_template_title': 'Pet Information',
                    'survey_template_type': 'local',
@@ -148,6 +150,7 @@ class MetadataUtilTests(unittest.TestCase):
 
     def test_fetch_survey_template(self):
         exp = {'survey_id': None,
+               'survey_status': None,
                'survey_template_id': 1,
                'survey_template_title': 'Primary',
                'survey_template_type': 'local',

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -341,6 +341,15 @@ class SurveyAnswersRepo(BaseRepo):
                         "barcode = %s AND "
                         "survey_id = %s",
                         (s.barcode, survey_id))
+            # Also delete from vioscreen registry
+            cur.execute("UPDATE vioscreen_registry "
+                        "SET deleted=true "
+                        "WHERE "
+                        "account_id = %s AND "
+                        "source_id = %s AND "
+                        "sample_id = %s AND "
+                        "vio_id = %s",
+                        (account_id, source_id, sample_id, survey_id))
 
     def build_metadata_map(self):
         with self._transaction.cursor() as cur:

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -83,10 +83,9 @@ class SurveyAnswersRepo(BaseRepo):
                         (account_id, source_id))
 
             rows = cur.fetchall()
-            # Surveys are answered if they are not vioscreen, or if they are
-            # vioscreen and their status is 3.
-            answered_surveys = [r[0] for r in rows
-                                if r[1] is None or r[1] == 3]
+            # Now that vioscreen_status is sent down to client, we can consider
+            # vioscreen surveys to be answered regardless of their status.
+            answered_surveys = [r[0] for r in rows]
         return answered_surveys
 
     def list_answered_surveys_by_sample(


### PR DESCRIPTION
Fix - Deleting a source now sets delete flag in vioscreen_registry when vioscreen_status was None, 0, 1, 2, or 3 (rather than just None or 3)

Fix - Deleting a sample now sets delete flag in vioscreen_registry

Major Change - Clicking the link to start a vioscreen survey now adds a new entry to ag_login_surveys with a vioscreen_status of -1 and associates that empty survey with the chosen sample in source_barcodes_surveys, this was required to keep vioscreen_registry and ag_login_surveys in sync with each other.

Fix - Starting a vioscreen survey and immediately backing out/closing the browser, then deleting the sample/source correctly marks that vioscreen survey deleted in vioscreen_registry, removes it from source_barcodes_surveys (when deleting the sample), and removes it from ag_login_surveys (when deleting the source)

We still lose information about the source from vioscreen_registry upon deleting the survey, I don't have a clean way to keep it while maintaining the foreign keys, potentially we could store a duplicate column or remove the foreign key.  