### PR TITLE
KICK: noop to trigger CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A private microservice to support The Microsetta Initiative
 ## Installation
 The private microservice depends on Postgres 9.5. For OSX users, we recommend installing [Postgres.app](https://postgresapp.com/). For Linux users, please consult documentation for the Linux distribution in use. 
 
-Create a new `conda` environment containing `flask` and other necessary packages:
+Create a new `conda` environment containing `flask` and other necessary packages: 
 
 `conda create -n microsetta-private-api flask psycopg2 natsort pycryptodome`
 

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,4 @@
-openapi-schema-validator < 0.1.3
+openapi-schema-validator < 0.1.2
 connexion[swagger-ui]
 pyjwt[crypto]
 pytest

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,3 @@
-openapi-schema-validator < 0.1.2
 openapi-spec-validator < 0.2.10
 connexion[swagger-ui]
 pyjwt[crypto]

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,6 +1,7 @@
+openapi-schema-validator < 0.1.3
 connexion[swagger-ui]
 pyjwt[crypto]
-pytest < 5.3.4
+pytest
 pytest-cov
 coveralls
 pycountry

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,4 +1,5 @@
 openapi-schema-validator < 0.1.2
+openapi-spec-validator < 0.2.10
 connexion[swagger-ui]
 pyjwt[crypto]
 pytest

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -128,11 +128,13 @@ class MetadataUtilTests(unittest.TestCase):
 
     def test_fetch_observed_survey_templates(self):
         exp = {1: {'survey_id': None,
+                   'survey_status': None,
                    'survey_template_id': 1,
                    'survey_template_title': 'Primary',
                    'survey_template_type': 'local',
                    'survey_template_version': '1.0'},
                2: {'survey_id': None,
+                   'survey_status': None,
                    'survey_template_id': 2,
                    'survey_template_title': 'Pet Information',
                    'survey_template_type': 'local',
@@ -148,6 +150,7 @@ class MetadataUtilTests(unittest.TestCase):
 
     def test_fetch_survey_template(self):
         exp = {'survey_id': None,
+               'survey_status': None,
                'survey_template_id': 1,
                'survey_template_title': 'Primary',
                'survey_template_type': 'local',


### PR DESCRIPTION
Testing CI. It is *possible* the failure is fixed as `openapi-schema-validator` released a new version over the weekend with a commit related to datetime. 