### PR TITLE
Migrate to tmi

### DIFF
--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -415,7 +415,6 @@ class MigrationSupport:
         project_ids = [69, 110, 72, 93, 97, 101, 102, 107, 75, 90, 92, 128]
 
         for project in project_ids:
-            print(project)
             # gather all kits for the project which are not
             # in the ag.ag_kit table
             TRN.add("""SELECT kit_id, array_agg(barcode)
@@ -429,7 +428,7 @@ class MigrationSupport:
                        GROUP BY kit_id""",
                     (project, ))
             kit_barcodes = TRN.execute()[-1]
-            print(len(kit_barcodes))
+
             # recreate the steps taken at kit creation
             # see https://github.com/biocore/microsetta-private-api/blob/2a6c5fd9a7c3aa925c45f9f6cc3a6626cee3ee8f/microsetta_private_api/repo/admin_repo.py#L746-L763  # noqa
             for kit, barcodes in kit_barcodes:

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -446,6 +446,12 @@ class MigrationSupport:
                                (ag_kit_id, barcode)
                                VALUES (%s, %s)""",
                             (kit_uuid, barcode))
+
+            # remark the project as TMI
+            TRN.add("""UPDATE barcodes.project
+                       SET is_microsetta=t
+                       WHERE project_id=%s""",
+                    (project, ))
             TRN.execute()
 
     MIGRATION_LOOKUP = {

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -405,11 +405,55 @@ class MigrationSupport:
                     (r[0], r[1], r[2], r[3]))
         TRN.execute()
 
+    @staticmethod
+    def migrate_77(TRN):
+        # a few studies were remarked as not-TMI when they actually are. A
+        # retroactive update to these studies is necessary. In some cases
+        # the studies have samples which are both present in the TMI structures
+        # and some which are not, stemming from kits having been created
+        # after remarking the project as non-TMI.
+        project_ids = [69, 110, 72, 93, 97, 101, 102, 107, 75, 90, 92, 128]
+
+        for project in project_ids:
+            print(project)
+            # gather all kits for the project which are not
+            # in the ag.ag_kit table
+            TRN.add("""SELECT kit_id, array_agg(barcode)
+                       FROM barcodes.barcode
+                           JOIN barcodes.project_barcode USING (barcode)
+                       WHERE project_id=%s
+                           AND kit_id NOT IN (
+                               SELECT supplied_kit_id
+                               FROM ag.ag_kit
+                               )
+                       GROUP BY kit_id""",
+                    (project, ))
+            kit_barcodes = TRN.execute()[-1]
+            print(len(kit_barcodes))
+            # recreate the steps taken at kit creation
+            # see https://github.com/biocore/microsetta-private-api/blob/2a6c5fd9a7c3aa925c45f9f6cc3a6626cee3ee8f/microsetta_private_api/repo/admin_repo.py#L746-L763  # noqa
+            for kit, barcodes in kit_barcodes:
+                # add these kits to ag_kit
+                kit_uuid = str(uuid.uuid4())
+                TRN.add("""INSERT INTO ag.ag_kit
+                           (ag_kit_id, supplied_kit_id, swabs_per_kit)
+                           VALUES (%s, %s, %s)""",
+                        (kit_uuid, kit, len(barcodes)))
+
+                # add the associated barcodes to ag_kit_barcodes
+                for barcode in barcodes:
+                    TRN.add("""INSERT INTO ag.ag_kit_barcodes
+                               (ag_kit_id, barcode)
+                               VALUES (%s, %s)""",
+                            (kit_uuid, barcode))
+            TRN.execute()
+
     MIGRATION_LOOKUP = {
         "0048.sql": migrate_48.__func__,
         "0050.sql": migrate_50.__func__,
         "0070.sql": migrate_70.__func__,
         "0074.sql": migrate_74.__func__,
+        "0077.sql": migrate_77.__func__,
         # ...
     }
 

--- a/microsetta_private_api/db/migration_support.py
+++ b/microsetta_private_api/db/migration_support.py
@@ -449,7 +449,7 @@ class MigrationSupport:
 
             # remark the project as TMI
             TRN.add("""UPDATE barcodes.project
-                       SET is_microsetta=t
+                       SET is_microsetta=true
                        WHERE project_id=%s""",
                     (project, ))
             TRN.execute()

--- a/microsetta_private_api/db/patches/0077.sql
+++ b/microsetta_private_api/db/patches/0077.sql
@@ -1,0 +1,5 @@
+-- Intentionally Left Blank.  See the corresponding python function in
+-- migration_support.py
+
+-- (Note that empty queries are not supported, so need a placeholder)
+SELECT 1;


### PR DESCRIPTION
A few projects are actually TMI but were not remarked as so in the database. This patch performs the necessary migrations. It was spot checked on staging as these projects do not exist in the test database. 