### PR TITLE
Uncomments the necessary files to show the consent form in spanish again

### DIFF
--- a/microsetta_private_api/LEGACY/locale_data/__init__.py
+++ b/microsetta_private_api/LEGACY/locale_data/__init__.py
@@ -11,7 +11,7 @@ from __future__ import division
 
 
 available_locales = set([
-    'american_gut', 'british_gut'])
+    'american_gut', 'british_gut', 'spanish_gut'])
 
 
 media_locale = {

--- a/microsetta_private_api/localization.py
+++ b/microsetta_private_api/localization.py
@@ -1,5 +1,5 @@
 from microsetta_private_api.LEGACY.locale_data import (american_gut,
-                                                       british_gut)
+                                                       british_gut, spanish_gut)
 
 EN_US = "en-US"
 EN_GB = "en-GB"
@@ -17,10 +17,9 @@ LANG_SUPPORT = {
     EN_GB: {
         NEW_PARTICIPANT_KEY: british_gut._NEW_PARTICIPANT,
         LANG_NAME_KEY: "british"
+    },
+    ES_MX: {
+        NEW_PARTICIPANT_KEY: spanish_gut._NEW_PARTICIPANT,
+        LANG_NAME_KEY: "spanish"
     }
-    # ,
-    # ES_MX: {
-    #     NEW_PARTICIPANT_KEY: spanish_gut._NEW_PARTICIPANT,
-    #     LANG_NAME_KEY: "spanish"
-    # }
 }

--- a/microsetta_private_api/localization.py
+++ b/microsetta_private_api/localization.py
@@ -1,5 +1,5 @@
-from microsetta_private_api.LEGACY.locale_data import (american_gut,
-                                                       british_gut, spanish_gut)
+from microsetta_private_api.LEGACY.locale_data \
+    import (american_gut, british_gut, spanish_gut)
 
 EN_US = "en-US"
 EN_GB = "en-GB"


### PR DESCRIPTION
No way to get here without modifying interface as well, and it looks like there are some placeholders in the translated consent form, but at least we can start working through issues with it once the rest of the localization changes are in place.  