### PR TITLE
Per sample barcode summaries including email support

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -396,20 +396,20 @@ def query_email_stats(body, token_info):
     return jsonify(results), 200
 
 
-def query_project_barcode_stats(body, token_info):
+def query_project_barcode_stats(body, token_info, strip_sampleid):
     validate_admin_access(token_info)
     email = body.get("email")
     project = body["project"]
-    celery_per_sample_summary.delay(email, project)
+    celery_per_sample_summary.delay(email, project, strip_sampleid)
     return None, 200
 
 
-def query_barcode_stats(body, token_info):
+def query_barcode_stats(body, token_info, strip_sampleid):
     validate_admin_access(token_info)
     barcodes = body["sample_barcodes"]
     if len(barcodes) > 1000:
-        return jsonify({"message": "Too manny barcodes requested"}), 429
-    summary = per_sample(None, barcodes)
+        return jsonify({"message": "Too manny barcodes requested"}), 400
+    summary = per_sample(None, barcodes, strip_sampleid)
     return jsonify(summary), 200
 
 

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -406,9 +406,8 @@ def query_project_barcode_stats(body, token_info):
 
 def query_barcode_stats(body, token_info):
     validate_admin_access(token_info)
-    print(body)
     barcodes = body["sample_barcodes"]
-    if len(barcodes) > 100:
+    if len(barcodes) > 1000:
         return jsonify({"message": "Too manny barcodes requested"}), 429
     summary = per_sample(None, barcodes)
     return jsonify(summary), 200

--- a/microsetta_private_api/admin/sample_summary.py
+++ b/microsetta_private_api/admin/sample_summary.py
@@ -1,0 +1,90 @@
+from microsetta_private_api.model.source import Source
+from microsetta_private_api.repo.sample_repo import SampleRepo
+from microsetta_private_api.repo.transaction import Transaction
+from microsetta_private_api.repo.admin_repo import AdminRepo
+from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
+from microsetta_private_api.repo.vioscreen_repo import VioscreenSessionRepo
+from werkzeug.exceptions import NotFound
+
+
+def per_sample(project, barcodes):
+    summaries = []
+    with Transaction() as t:
+        admin_repo = AdminRepo(t)
+        sample_repo = SampleRepo(t)
+        template_repo = SurveyTemplateRepo(t)
+        vs_repo = VioscreenSessionRepo(t)
+
+        if project is not None:
+            project_barcodes = admin_repo.get_project_barcodes(project)
+        else:
+            project = 'Unspecified'
+
+        if barcodes is None:
+            barcodes = project_barcodes
+
+        #######
+        #########
+        for barcode in barcodes[:100]:
+            diag = admin_repo.retrieve_diagnostics_by_barcode(barcode)
+            if diag is None:
+                raise NotFound(f"Barcode not found: {barcode}")
+
+            sample = diag['sample']
+            account = diag['account']
+            source = diag['source']
+
+            account_email = None if account is None else account.email
+            source_email = None
+            source_type = None if source is None else source.source_type
+            vio_id = None
+
+            if source is not None and source_type is Source.SOURCE_TYPE_HUMAN:
+                source_email = source.email
+
+                vio_id = template_repo.get_vioscreen_id_if_exists(account.id,
+                                                                  source.id,
+                                                                  sample.id)
+
+            # at least one sample has been observed that "is_microsetta",
+            # described in the barcodes.project_barcode table, but which is
+            # unexpectedly not present in ag.ag_kit_barcodes
+            if sample is None:
+                sample_status = None
+                sample_site = None
+                ffq_complete = None
+                ffq_taken = None
+            else:
+                sample_status = sample_repo.get_sample_status(
+                    sample.barcode,
+                    sample._latest_scan_timestamp
+                )
+                sample_site = sample.site
+                ffq_complete, ffq_taken, _ = vs_repo.get_ffq_status_by_sample(
+                    sample.id
+                )
+
+            summary = {
+                "sampleid": barcode,
+                "project": project,
+                "source-type": source_type,
+                "site-sampled": sample_site,
+                "source-email": source_email,
+                "account-email": account_email,
+                "vioscreen_username": vio_id,
+                "ffq-taken": ffq_taken,
+                "ffq-complete": ffq_complete,
+                "sample-status": sample_status,
+                "sample-received": sample_status is not None
+            }
+
+            for status in ["sample-is-valid",
+                           "no-associated-source",
+                           "no-registered-account",
+                           "no-collection-info",
+                           "sample-has-inconsistencies",
+                           "received-unknown-validity"]:
+                summary[status] = sample_status == status
+
+            summaries.append(summary)
+    return summaries

--- a/microsetta_private_api/admin/sample_summary.py
+++ b/microsetta_private_api/admin/sample_summary.py
@@ -7,7 +7,7 @@ from microsetta_private_api.repo.vioscreen_repo import VioscreenSessionRepo
 from werkzeug.exceptions import NotFound
 
 
-def per_sample(project, barcodes):
+def per_sample(project, barcodes, strip_sampleid):
     summaries = []
     with Transaction() as t:
         admin_repo = AdminRepo(t)
@@ -37,8 +37,8 @@ def per_sample(project, barcodes):
             source_type = None if source is None else source.source_type
             vio_id = None
 
-            if source is not None and source_type is Source.SOURCE_TYPE_HUMAN:
-                source_email = source.email
+            if source is not None and source_type == Source.SOURCE_TYPE_HUMAN:
+                source_email = source.source_data.email
 
                 vio_id = template_repo.get_vioscreen_id_if_exists(account.id,
                                                                   source.id,
@@ -63,7 +63,7 @@ def per_sample(project, barcodes):
                 )
 
             summary = {
-                "sampleid": barcode,
+                "sampleid": None if strip_sampleid else barcode,
                 "project": project,
                 "source-type": source_type,
                 "site-sampled": sample_site,

--- a/microsetta_private_api/admin/sample_summary.py
+++ b/microsetta_private_api/admin/sample_summary.py
@@ -23,9 +23,7 @@ def per_sample(project, barcodes):
         if barcodes is None:
             barcodes = project_barcodes
 
-        #######
-        #########
-        for barcode in barcodes[:100]:
+        for barcode in barcodes:
             diag = admin_repo.retrieve_diagnostics_by_barcode(barcode)
             if diag is None:
                 raise NotFound(f"Barcode not found: {barcode}")

--- a/microsetta_private_api/admin/tests/test_admin_api.py
+++ b/microsetta_private_api/admin/tests/test_admin_api.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from flask import Response
 import json
 import microsetta_private_api.server
+from microsetta_private_api.celery_utils import celery
 from microsetta_private_api.model.account import Account, Address
 from microsetta_private_api.model.project import Project
 from microsetta_private_api.repo.transaction import Transaction
@@ -25,6 +26,10 @@ DUMMY_PROJ_NAME = "test project"
 # send to daklapack, it is stored as an int in our db's daklapack_article table
 # so our private api expects it to be sent as an int
 DUMMY_INT_DAK_ARTICLE_CODE = int(DUMMY_DAK_ARTICLE_CODE)
+
+# force celery tasks to run locally rather than dispatch
+# see https://docs.celeryproject.org/en/latest/userguide/configuration.html#std-setting-task_always_eager  # noqa
+celery.task_always_eager = False
 
 
 def teardown_test_data():

--- a/microsetta_private_api/admin/tests/test_admin_api.py
+++ b/microsetta_private_api/admin/tests/test_admin_api.py
@@ -976,51 +976,23 @@ class AdminApiTests(TestCase):
                 mock_email.side_effect = [True]
                 self._test_post_daklapack_orders(order_info, 401)
 
-    def test_query_barcode_stats_no_project_no_barcodes(self):
-        input_json = json.dumps({'project': 0, 'sample_barcodes': None})
+    def test_query_project_barcode_stats_project(self):
+        input_json = json.dumps({'project': 7, 'email': 'foobar'})
 
         response = self.client.post(
-            "api/admin/account_barcode_summary",
+            "api/admin/account_project_barcode_summary",
             content_type='application/json',
             data=input_json,
             headers=MOCK_HEADERS
         )
 
-        # an empty string project should be unkown
-        self.assertEqual(404, response.status_code)
-
-    def test_query_barcode_stats_project_no_barcodes(self):
-        input_json = json.dumps({'project': 7, 'sample_barcodes': None})
-
-        response = self.client.post(
-            "api/admin/account_barcode_summary",
-            content_type='application/json',
-            data=input_json,
-            headers=MOCK_HEADERS
-        )
-
+        # ...we assume the system is processing to send an email
+        # so nothing specific to verify on the response data
         self.assertEqual(200, response.status_code)
-
-        response_obj = json.loads(response.data)
-
-        # there are 24 samples with project 7 in the test db
-        self.assertEqual(len(response_obj), 24)
-
-        # ...10 have been received
-        self.assertEqual(sum([v['sample-received']
-                              for v in response_obj]), 10)
-
-        # ...9 are valid
-        self.assertEqual(sum([v['sample-is-valid']
-                              for v in response_obj]), 9)
-
-        # ...1 is missing a source
-        self.assertEqual(sum([v['no-associated-source']
-                              for v in response_obj]), 1)
 
     def test_query_barcode_stats_project_barcodes(self):
         barcodes = ['000010307', '000023344', '000036855']
-        input_json = json.dumps({'project': 7, 'sample_barcodes': barcodes})
+        input_json = json.dumps({'sample_barcodes': barcodes})
 
         response = self.client.post(
             "api/admin/account_barcode_summary",

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -300,6 +300,19 @@ class AdminRepoTests(AdminTests):
             self.assertGreater(len(diag['scans_info']), 0)
             self.assertGreater(len(diag['projects_info']), 0)
 
+    def test_get_project_name_fail(self):
+        with Transaction() as t:
+            admin_repo = AdminRepo(t)
+
+            with self.assertRaisesRegex(NotFound, "not found"):
+                admin_repo.get_project_name(9999999)
+
+    def test_get_project_name(self):
+        with Transaction() as t:
+            admin_repo = AdminRepo(t)
+            obs = admin_repo.get_project_name(1)
+            self.assertEqual(obs, 'American Gut Project')
+
     def test_get_project_barcodes_fail(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1510,6 +1510,30 @@ paths:
               schema:
                 type: array
 
+  '/admin/account_project_barcode_summary':
+    post:
+      operationId: microsetta_private_api.admin.admin_impl.query_project_barcode_stats
+      tags:
+        - Admin
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                'project':
+                  type: integer
+                'email':
+                  type: string
+
+      responses:
+        '200':
+          description: Successfully triggered the summary job
+        '404':
+          description: Requested project not found
+        '429':
+          description: Too many barcodes requested
+
   '/admin/account_barcode_summary':
     post:
       operationId: microsetta_private_api.admin.admin_impl.query_barcode_stats
@@ -1527,18 +1551,17 @@ paths:
                     # not using the defined schema for sample_barcode as it is 
                     # readOnly
                     type: string
-                  nullable: true
-                project:
-                  type: integer
       responses:
         '200':
           description: Return list of dictionaries of sample status for requested accounts
-        '404':
-          description: Project not found, or requested barcodes not found
           content:
             application/json:
               schema:
-                type: object
+                type: array
+                items:
+                  type: object
+        '404':
+          description: Requested barcodes not found
 
   '/admin/activation':
     post:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1513,6 +1513,8 @@ paths:
   '/admin/account_project_barcode_summary':
     post:
       operationId: microsetta_private_api.admin.admin_impl.query_project_barcode_stats
+      parameters:
+        - $ref: '#/components/parameters/strip_sampleid'
       tags:
         - Admin
       requestBody:
@@ -1531,12 +1533,14 @@ paths:
           description: Successfully triggered the summary job
         '404':
           description: Requested project not found
-        '429':
+        '400':
           description: Too many barcodes requested
 
   '/admin/account_barcode_summary':
     post:
       operationId: microsetta_private_api.admin.admin_impl.query_barcode_stats
+      parameters:
+        - $ref: '#/components/parameters/strip_sampleid'
       tags:
         - Admin
       requestBody:
@@ -1595,6 +1599,13 @@ components:
       description: Unique id specifying a user account
       schema:
         $ref: '#/components/schemas/account_id'
+      required: true
+    strip_sampleid:
+      name: strip_sampleid
+      in: query
+      description: Whether to strip barcode information
+      schema:
+        type: boolean
       required: true
     kit_id:
       name: kit_id

--- a/microsetta_private_api/db/patches/0080.sql
+++ b/microsetta_private_api/db/patches/0080.sql
@@ -1,0 +1,2 @@
+-- Scans are often looked up by barcode
+CREATE INDEX barcode_scans_barcode_idx ON barcodes.barcode_scans (barcode);

--- a/microsetta_private_api/model/log_event.py
+++ b/microsetta_private_api/model/log_event.py
@@ -38,6 +38,8 @@ class EventSubtype(Enum):
     DAK_ORDER_HOLD = "daklapack_order_hold"
     # Pester daniel if for what are expected to be unusual situations
     PESTER_DANIEL = "pester_daniel"
+    # for project per-sample summaries
+    EMAIL_PER_PROJECT_SUMMARY = "per_project_summary"
 
 
 class LogEvent(ModelBase):

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -414,6 +414,41 @@ class AdminRepo(BaseRepo):
 
             return diagnostic
 
+    def get_project_name(self, project_id):
+        """Obtain the name of a project using the project_id
+
+        Parameters
+        ----------
+        project_id : int
+            The project ID to obtain barcodes for
+
+        Returns
+        -------
+        str
+            The name of the project
+
+        Raises
+        ------
+        NotFound
+            The project ID could not be found
+        """
+        test = """SELECT EXISTS(
+                    SELECT 1
+                    FROM barcodes.project
+                    WHERE project_id=%s
+                  )"""
+        query = """SELECT project
+                   FROM barcodes.project
+                   WHERE project_id=%s"""
+
+        with self._transaction.cursor() as cur:
+            cur.execute(test, [project_id, ])
+            if not cur.fetchone()[0]:
+                raise NotFound(f"Project f'{project_id}' not found")
+            else:
+                cur.execute(query, [project_id, ])
+                return cur.fetchone()[0]
+
     def get_project_barcodes(self, project_id):
         """Obtain the barcodes associated with a project
 

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -38,7 +38,7 @@ def per_sample_summary(email, project):
 
     # NOTE: we are not using .delay so this action remains
     # within the current celery task
-    template_args = {'date': date, 'project': project},
+    template_args = {'date': date, 'project': project}
     send_basic_email(email,
                      f"[TMI-summary] Project {project}",
                      'email/sample_summary',

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -3,6 +3,7 @@ from microsetta_private_api.util.email import SendEmail
 from microsetta_private_api.model.log_event import EventType, EventSubtype
 from microsetta_private_api.admin.email_templates import EmailMessage, \
     BasicEmailMessage
+from microsetta_private_api.admin.sample_summary import per_sample
 
 
 @celery.task(ignore_result=True)
@@ -20,3 +21,11 @@ def send_basic_email(to_email, subject, template_base_fp, req_template_keys,
     msg_obj = BasicEmailMessage(subject, template_base_fp, req_template_keys,
                                 event_type, event_subtype)
     SendEmail.send(to_email, msg_obj, msg_args, from_email)
+
+
+@celery.task(ignore_result=True)
+def per_sample_summary(email, project):
+    summaries = per_sample(project, barcodes=None)
+    import pandas as pd
+    blah = pd.DataFrame(summaries)
+    blah.to_csv('/tmp/footest.stuff')

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -28,8 +28,9 @@ def send_basic_email(to_email, subject, template_base_fp, req_template_keys,
 
 
 @celery.task(ignore_result=True)
-def per_sample_summary(email, project):
-    summaries = per_sample(project, barcodes=None)
+def per_sample_summary(email, project, strip_sampleid):
+    summaries = per_sample(project, barcodes=None,
+                           strip_sampleid=strip_sampleid)
     df = pd.DataFrame(summaries)
     _, path = tempfile.mkstemp()
     df.to_csv(path)

--- a/microsetta_private_api/templates/email/sample_summary.jinja2
+++ b/microsetta_private_api/templates/email/sample_summary.jinja2
@@ -1,0 +1,2 @@
+<p>{{ date }}</p>
+<p>{{ project }}</p>

--- a/microsetta_private_api/templates/email/sample_summary.plain
+++ b/microsetta_private_api/templates/email/sample_summary.plain
@@ -1,0 +1,2 @@
+{{ date }}
+{{ project }}

--- a/microsetta_private_api/util/tests/test_email.py
+++ b/microsetta_private_api/util/tests/test_email.py
@@ -84,6 +84,27 @@ class EmailTests(unittest.TestCase):
             SendEmail.send("foo", self.message)
         self.assertEqual(SendEmail._connect.call_count, 4)
 
+    def test_send_valid_message_attachment(self):
+        SendEmail._connect = MockConnect(False)
+
+        SendEmail.send("foo", self.message, attachment_filepath=__file__,
+                       attachment_filename='testfile')
+        obs = SendEmail.connection.observed.as_string()
+        self.assertRegex(obs, 'Content-Type: text/html')
+        self.assertRegex(obs, 'Content-Type: text/plain')
+        self.assertRegex(obs, ('Content-Disposition: attachment; '
+                               'filename="testfile"'))
+        self.assertRegex(obs, 'a plain message')
+        self.assertRegex(obs, "<html>a html message</html>")
+
+    def test_send_valid_message_badattachments(self):
+        SendEmail._connect = MockConnect(False)
+
+        with self.assertRaises(AssertionError):
+            SendEmail.send("foo", self.message, attachment_filepath=__file__)
+        with self.assertRaises(AssertionError):
+            SendEmail.send("foo", self.message, attachment_filename="foo")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Testing out the celery component right now. The directed procedure using a specified set of barcodes via microsetta admin appears to check out locally