### PR TITLE
Save preferred language to account table

### DIFF
--- a/microsetta_private_api/admin/tests/test_admin_api.py
+++ b/microsetta_private_api/admin/tests/test_admin_api.py
@@ -61,7 +61,8 @@ def setup_test_data():
                           12345,
                           "US"
                       ),
-                      "fakekit")
+                      "fakekit",
+                      "en-US")
         acct_repo.create_account(acc)
 
         with t.cursor() as cur:

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -87,7 +87,8 @@ class AdminTests(TestCase):
                               12345,
                               "US"
                           ),
-                          "fakekit")
+                          "fakekit",
+                          "en-US")
             acct_repo.create_account(acc)
 
             acc = Account(ADMIN_ACCT_ID,
@@ -104,7 +105,8 @@ class AdminTests(TestCase):
                               12345,
                               "US"
                           ),
-                          "fakekit")
+                          "fakekit",
+                          "en-US")
             acct_repo.create_account(acc)
             t.commit()
 

--- a/microsetta_private_api/api/_account.py
+++ b/microsetta_private_api/api/_account.py
@@ -140,6 +140,7 @@ def update_account(account_id, body, token_info):
             body['address']['post_code'],
             body['address']['country_code']
         )
+        acc.language = body['language']
 
         # 422 handling is done inside acct_repo
         acct_repo.update_account(acc)

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1742,6 +1742,11 @@ components:
       readOnly: true
       enum: ["standard", "admin"]
       example: "standard"
+    language:
+      type: string
+      readOnly: true
+      enum: ["en-US", "es-MX"]
+      example: "en-US"
     creation_time:
       type: string
       readOnly: true
@@ -1780,6 +1785,8 @@ components:
           $ref: '#/components/schemas/address'
         account_type:
           $ref: '#/components/schemas/account_type'
+        language:
+          $ref: '#/components/schemas/language'
         creation_time:
           $ref: '#/components/schemas/creation_time'
         update_time:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1744,8 +1744,8 @@ components:
       example: "standard"
     language:
       type: string
-      enum: ["en-US", "es-MX"]
-      example: "en-US"
+      enum: ["en_US", "es_MX"]
+      example: "en_US"
     creation_time:
       type: string
       readOnly: true

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1744,7 +1744,6 @@ components:
       example: "standard"
     language:
       type: string
-      readOnly: true
       enum: ["en-US", "es-MX"]
       example: "en-US"
     creation_time:
@@ -1796,6 +1795,7 @@ components:
         - last_name
         - email
         - address
+        - language
 
     address:   # taken from https://opensource.zalando.com/restful-api-guidelines/#address-fields
       description:

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -57,7 +57,7 @@ DUMMY_ACCT_INFO = {
     "email": TEST_EMAIL,
     "first_name": "Jane",
     "last_name": "Doe",
-    "language": "en-US",
+    "language": "en_US",
     KIT_NAME_KEY: EXISTING_KIT_NAME
 }
 DUMMY_ACCT_INFO_2 = {
@@ -71,7 +71,7 @@ DUMMY_ACCT_INFO_2 = {
     "email": TEST_EMAIL_2,
     "first_name": "Obie",
     "last_name": "Dobie",
-    "language": "en-US",
+    "language": "en_US",
     KIT_NAME_KEY: EXISTING_KIT_NAME_2
 }
 DUMMY_ACCT_ADMIN = {

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -57,6 +57,7 @@ DUMMY_ACCT_INFO = {
     "email": TEST_EMAIL,
     "first_name": "Jane",
     "last_name": "Doe",
+    "language": "en-US",
     KIT_NAME_KEY: EXISTING_KIT_NAME
 }
 DUMMY_ACCT_INFO_2 = {
@@ -70,6 +71,7 @@ DUMMY_ACCT_INFO_2 = {
     "email": TEST_EMAIL_2,
     "first_name": "Obie",
     "last_name": "Dobie",
+    "language": "en-US",
     KIT_NAME_KEY: EXISTING_KIT_NAME_2
 }
 DUMMY_ACCT_ADMIN = {
@@ -432,7 +434,8 @@ def _create_dummy_acct_from_t(t, create_dummy_1=True,
                 input_obj['address']['post_code'],
                 input_obj['address']['country_code']
             ),
-            input_obj['kit_name']
+            input_obj['kit_name'],
+            input_obj['language']
         )
     else:
         acct = Account.from_dict(input_obj, iss, sub)

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -604,6 +604,8 @@ class ApiTests(TestCase):
 
                 curr_query_str = urlencode(curr_query_dict)
                 curr_content_json = json.dumps(curr_content_dict)
+
+                print(curr_content_json)
                 curr_url = url if not curr_query_str else \
                     '{0}?{1}'.format(url, curr_query_str)
                 if action == "get":

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -605,7 +605,6 @@ class ApiTests(TestCase):
                 curr_query_str = urlencode(curr_query_dict)
                 curr_content_json = json.dumps(curr_content_dict)
 
-                print(curr_content_json)
                 curr_url = url if not curr_query_str else \
                     '{0}?{1}'.format(url, curr_query_str)
                 if action == "get":

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -164,7 +164,8 @@ class IntegrationTests(TestCase):
                               12345,
                               "US"
                           ),
-                          "fakekit")
+                          "fakekit",
+                          "en-US")
             acct_repo.create_account(acc)
 
             source_repo.create_source(Source(

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -165,7 +165,7 @@ class IntegrationTests(TestCase):
                               "US"
                           ),
                           "fakekit",
-                          "en-US")
+                          "en_US")
             acct_repo.create_account(acc)
 
             source_repo.create_source(Source(
@@ -439,7 +439,7 @@ class IntegrationTests(TestCase):
                 "first_name": "Jane",
                 "last_name": "Doe",
                 "kit_name": "jb_qhxqe",
-                "language": "en-US"
+                "language": "en_US"
             })
 
         # Registering with the authrocket associated with the mock account
@@ -513,7 +513,7 @@ class IntegrationTests(TestCase):
                 "first_name": "Dan",
                 "last_name": "H",
                 "kit_name": "fakekit",
-                "language": "en-US"
+                "language": "en_US"
             }
 
         # Hard to guess these two, so let's pop em out

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -438,7 +438,8 @@ class IntegrationTests(TestCase):
                 "email": FAKE_EMAIL,
                 "first_name": "Jane",
                 "last_name": "Doe",
-                "kit_name": "jb_qhxqe"
+                "kit_name": "jb_qhxqe",
+                "language": "en-US"
             })
 
         # Registering with the authrocket associated with the mock account
@@ -511,7 +512,8 @@ class IntegrationTests(TestCase):
                 "email": "foo@baz.com",
                 "first_name": "Dan",
                 "last_name": "H",
-                "kit_name": "fakekit"
+                "kit_name": "fakekit",
+                "language": "en-US"
             }
 
         # Hard to guess these two, so let's pop em out
@@ -529,6 +531,7 @@ class IntegrationTests(TestCase):
         fuzzy_data = fuzz(regular_data)
         fuzzy_data['email'] = the_email
         fuzzy_data['kit_name'] = kit_name
+        fuzzy_data['language'] = regular_data["language"]
 
         # submit an invalid account type
         fuzzy_data['account_type'] = "Voldemort"

--- a/microsetta_private_api/db/patches/0080.sql
+++ b/microsetta_private_api/db/patches/0080.sql
@@ -1,0 +1,5 @@
+-- language is a reserved keyword in some variants of sql, (but not Postgres)
+-- so we use preferred_language at the DB layer.
+ALTER TABLE account ADD COLUMN preferred_language VARCHAR;
+UPDATE account SET preferred_language='en-US';
+ALTER TABLE account ALTER COLUMN preferred_language SET NOT NULL;

--- a/microsetta_private_api/db/patches/0080.sql
+++ b/microsetta_private_api/db/patches/0080.sql
@@ -1,5 +1,5 @@
 -- language is a reserved keyword in some variants of sql, (but not Postgres)
 -- so we use preferred_language at the DB layer.
 ALTER TABLE account ADD COLUMN preferred_language VARCHAR;
-UPDATE account SET preferred_language='en-US';
+UPDATE account SET preferred_language='en_US';
 ALTER TABLE account ALTER COLUMN preferred_language SET NOT NULL;

--- a/microsetta_private_api/model/account.py
+++ b/microsetta_private_api/model/account.py
@@ -30,7 +30,8 @@ class Account(ModelBase):
                 input_dict['address']['post_code'],
                 input_dict['address']['country_code']
             ),
-            input_dict['kit_name']
+            input_dict['kit_name'],
+            input_dict['language']
         )
         return result
 
@@ -38,6 +39,7 @@ class Account(ModelBase):
                  account_type, auth_issuer, auth_sub,
                  first_name, last_name,
                  address, created_with_kit_id,
+                 language,
                  creation_time=None, update_time=None):
         self.id = account_id
         self.email = email
@@ -50,6 +52,7 @@ class Account(ModelBase):
         self.created_with_kit_id = created_with_kit_id
         self.creation_time = creation_time
         self.update_time = update_time
+        self.language = language
 
     def to_api(self):
         # api is not given the auth_issuer or auth_sub
@@ -60,6 +63,7 @@ class Account(ModelBase):
             "email": self.email,
             "address": self.address.to_api(),
             "account_type": self.account_type,
+            "language": self.language,
             "creation_time": self.creation_time,
             "update_time": self.update_time,
             "kit_name": self.created_with_kit_id

--- a/microsetta_private_api/repo/account_repo.py
+++ b/microsetta_private_api/repo/account_repo.py
@@ -14,13 +14,14 @@ class AccountRepo(BaseRepo):
                 "account_type, auth_issuer, auth_sub, " \
                 "first_name, last_name, " \
                 "street, city, state, post_code, country_code, " \
-                "created_with_kit_id, creation_time, update_time"
+                "created_with_kit_id, preferred_language, " \
+                "creation_time, update_time"
 
     write_cols = "id, email, " \
                  "account_type, auth_issuer, auth_sub, " \
                  "first_name, last_name, " \
                  "street, city, state, post_code, country_code, " \
-                 "created_with_kit_id"
+                 "created_with_kit_id, preferred_language"
 
     @staticmethod
     def _row_to_addr(r):
@@ -43,6 +44,7 @@ class AccountRepo(BaseRepo):
             r['first_name'], r['last_name'],
             AccountRepo._row_to_addr(r),
             r['created_with_kit_id'],
+            r['preferred_language'],
             r['creation_time'], r['update_time'])
 
     @staticmethod
@@ -51,7 +53,7 @@ class AccountRepo(BaseRepo):
                 a.account_type, a.auth_issuer, a.auth_sub,
                 a.first_name, a.last_name) + \
                 AccountRepo._addr_to_row(a.address) + \
-                (a.created_with_kit_id, )
+                (a.created_with_kit_id, a.language)
 
     def claim_legacy_account(self, email, auth_iss, auth_sub):
         # Returns now-claimed legacy account if an unclaimed legacy account
@@ -153,7 +155,8 @@ class AccountRepo(BaseRepo):
                             "state = %s, "
                             "post_code = %s, "
                             "country_code = %s, "
-                            "created_with_kit_id = %s "
+                            "created_with_kit_id = %s, "
+                            "preferred_language = %s "
                             "WHERE "
                             "account.id = %s",
                             final_row
@@ -180,7 +183,8 @@ class AccountRepo(BaseRepo):
                             "%s, %s, "
                             "%s, %s, %s, "
                             "%s, %s, "
-                            "%s, %s, %s, %s, %s, %s)",
+                            "%s, %s, %s, %s, %s, "
+                            "%s, %s)",
                             AccountRepo._account_to_row(account))
                 return cur.rowcount == 1
         except psycopg2.errors.UniqueViolation as e:


### PR DESCRIPTION
I don't see an i18n branch in this repo, and this is going to break compatibility outside of the microsetta-interface i18n branch, so... maybe we should make an i18n branch on this side to merge this into?  

Private api side of setting language preference