### PR TITLE
database methods needed for forthcoming daklapack order polling

### DIFF
--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1140,7 +1140,7 @@ class AdminRepo(BaseRepo):
         with self._transaction.cursor() as cur:
             cur.execute(
                 "UPDATE barcodes.daklapack_order "
-                "SET " 
+                "SET "
                 "last_polling_timestamp = %s, "
                 "last_polling_status = %s "
                 "WHERE dak_order_id = %s",


### PR DESCRIPTION
I'm trying to add the daklapack order polling functionality in chunks to allow reasonable code-reviewing.  This is the first installment, which includes db methods in admin_repo.py to get and set info about already-submitted orders.