### PR TITLE
Vioscreen ID race condition

### DIFF
--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -225,6 +225,13 @@ class SurveyTemplateRepo(BaseRepo):
     def create_vioscreen_id(self, account_id, source_id,
                             vioscreen_ext_sample_id):
         with self._transaction.cursor() as cur:
+            # This transaction scans for existing IDs,
+            # then generates a new ID if none exist
+            # To prevent workers from seeing stale state,
+            # and thus each generating multiple new IDs
+            # in the case of multiple workers,
+            # we lock the vioscreen_registry table
+            self._transaction.lock_table("vioscreen_registry")
             # test if an existing ID is available
             existing = self.get_vioscreen_id_if_exists(account_id, source_id,
                                                        vioscreen_ext_sample_id)

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -2,6 +2,7 @@ from microsetta_private_api.config_manager import AMGUT_CONFIG
 import psycopg2.pool
 import psycopg2.extras
 import atexit
+from psycopg2 import sql
 
 
 class Transaction:
@@ -35,6 +36,14 @@ class Transaction:
         if not self._closed:
             self.rollback()
         Transaction._POOL.putconn(self._conn)
+
+    def lock_table(self, table):
+        # Just access exclusive mode for now- hard to escape the lock mode
+        # in psycopg2.
+        with self.cursor() as cur:
+            cur.execute(sql.SQL("LOCK TABLE {} IN ACCESS EXCLUSIVE MODE").format(
+                sql.Identifier(table))
+            )
 
     def commit(self):
         if self._closed:

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -41,8 +41,9 @@ class Transaction:
         # Just access exclusive mode for now- hard to escape the lock mode
         # in psycopg2.
         with self.cursor() as cur:
-            cur.execute(sql.SQL("LOCK TABLE {} IN ACCESS EXCLUSIVE MODE").format(
-                sql.Identifier(table))
+            cur.execute(
+                sql.SQL("LOCK TABLE {} IN ACCESS EXCLUSIVE MODE")
+                .format(sql.Identifier(table))
             )
 
     def commit(self):


### PR DESCRIPTION
Uses access exclusive lock on vioscreen_registry to address race condition in generation of vioscreen ids

Fix #353 