### PR TITLE
Extend kit creation code, barcodes.kit table for daklapack kits

### DIFF
--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -13,8 +13,9 @@ from microsetta_private_api.model.account import Account
 from microsetta_private_api.model.address import Address
 from microsetta_private_api.model.daklapack_order import DaklapackOrder
 from microsetta_private_api.repo.account_repo import AccountRepo
-from microsetta_private_api.repo.admin_repo import AdminRepo, _get_kit_tuples, \
-    KIT_BOX_ID_KEY, KIT_OUTBOUND_KEY, KIT_ADDRESS_KEY, KIT_INBOUND_KEY
+from microsetta_private_api.repo.admin_repo import AdminRepo, \
+    _get_kit_tuples, KIT_BOX_ID_KEY, KIT_OUTBOUND_KEY, KIT_ADDRESS_KEY, \
+    KIT_INBOUND_KEY
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.admin.admin_impl import validate_admin_access
 
@@ -451,7 +452,7 @@ class AdminRepoTests(AdminTests):
         kit_names = ["DM24-A3CF9", "DM05-B3CF9"]
 
         expected_out = [(kit_uuids[0], kit_names[0],
-                         None, None, None,kit_uuids[0]),
+                         None, None, None, kit_uuids[0]),
                         (kit_uuids[1], kit_names[1],
                          None, None, None, kit_uuids[1])]
 

--- a/microsetta_private_api/db/patches/0083.sql
+++ b/microsetta_private_api/db/patches/0083.sql
@@ -1,0 +1,10 @@
+-- rename the "fedex_tracking" column to specify it is the *outbound* fedex
+-- tracking code, and add an inbound fedex tracking code column too
+-- add a new "box_id" column to the kit table and populate it
+-- (for all records to date) with the kit uuid;
+-- require it be not null
+ALTER TABLE barcodes.kit RENAME COLUMN fedex_tracking TO outbound_fedex_tracking;
+ALTER TABLE barcodes.kit ADD COLUMN inbound_fedex_tracking varchar NULL;
+ALTER TABLE barcodes.kit ADD COLUMN box_id varchar NULL;
+UPDATE barcodes.kit SET box_id = kit_uuid;
+ALTER TABLE barcodes.kit ALTER COLUMN box_id SET NOT NULL;

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1140,7 +1140,7 @@ class AdminRepo(BaseRepo):
         with self._transaction.cursor() as cur:
             cur.execute(
                 "UPDATE barcodes.daklapack_order "
-                "SET " 
+                "SET "
                 "last_polling_timestamp = %s, "
                 "last_polling_status = %s "
                 "WHERE dak_order_id = %s",


### PR DESCRIPTION
Refactor most of `create_kits` function in `admin_repo.py` into private functions that can be used by both `create_kits` and a new `create_kit` (note singular :) function that takes in barcodes, box id, and kit name specified by Daklapack (instead of generating them internally). Extend `barcodes.kit` table to contain a box id separate from a kit id as well as two different fedex tracking numbers (instead of one).