### PR TITLE
Wrong member variable

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -252,7 +252,7 @@ def send_email(body, token_info):
             endpoint = SERVER_CONFIG["endpoint"]
 
             if account_id is not None:
-                language = diag['account'].preferred_language
+                language = diag['account'].language
 
             if sample_id is not None and \
                source_id is not None and \

--- a/microsetta_private_api/admin/tests/test_admin_api.py
+++ b/microsetta_private_api/admin/tests/test_admin_api.py
@@ -1060,3 +1060,24 @@ class AdminApiTests(TestCase):
                          exp_status)
         n_src = sum([v['source-email'] is not None for v in response_obj])
         self.assertEqual(n_src, 1)
+
+    def test_send_email(self):
+        def mock_func(*args, **kwargs):
+            pass
+
+        info = {
+            "issue_type": 'sample',
+            "template_args": {"sample_barcode": '000004220'},
+            'template': 'sample_is_valid'
+        }
+
+        with patch("microsetta_private_api.admin.admin_impl."
+                   "celery_send_email") as mock_celery_send_email:
+            mock_celery_send_email.apply_async = mock_func
+
+            response = self.client.post(
+                "api/admin/email",
+                content_type="application/json",
+                data=json.dumps(info),
+                headers=MOCK_HEADERS)
+            self.assertEqual(204, response.status_code)


### PR DESCRIPTION
Impacting production, `send_email` was accidentally using the wrong member variable off of `account`