### PR TITLE
Daklapack order status checking

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,5 +1,5 @@
 openapi-spec-validator < 0.2.10
-connexion[swagger-ui]
+connexion[swagger-ui] < 2.7.1
 pyjwt[crypto]
 pytest
 pytest-cov

--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,5 +1,5 @@
 openapi-spec-validator < 0.2.10
-connexion[swagger-ui] < 2.7.1
+connexion[swagger-ui]
 pyjwt[crypto]
 pytest
 pytest-cov

--- a/microsetta_private_api/admin/daklapack_communication.py
+++ b/microsetta_private_api/admin/daklapack_communication.py
@@ -68,5 +68,10 @@ def _get_from_daklapack_api(url_suffix):
     oauth_session = _get_daklapack_oauth2_session()
     dak_order_get_url = f"{SERVER_CONFIG['daklapack_api_base_url']}" \
                         f"{url_suffix}"
+
     result = oauth_session.get(dak_order_get_url, headers=DAK_HEADERS)
+    if result.status_code >= 300:
+        raise ValueError(f"Getting {url_suffix} received status code "
+                         f"{result.status_code}: {result.json}")
+
     return result

--- a/microsetta_private_api/admin/daklapack_communication.py
+++ b/microsetta_private_api/admin/daklapack_communication.py
@@ -51,3 +51,22 @@ def send_daklapack_hold_email(daklapack_order):
         email_success = False
 
     return email_success
+
+
+def get_daklapack_orders_status(page_num):
+    return _get_from_daklapack_api(f"/api/orders?Page={page_num}")
+
+
+def get_daklapack_order_details(order_id):
+    return _get_from_daklapack_api(f"/api/orders/{order_id}")
+
+
+def _get_from_daklapack_api(url_suffix):
+    oauth_session = _get_daklapack_oauth2_session()
+    dak_order_get_url = f"{SERVER_CONFIG['daklapack_api_base_url']}" \
+                        f"{url_suffix}"
+    result = oauth_session.get(
+        dak_order_get_url,
+        headers={SERVER_CONFIG["daklapack_subscription_key_name"]:
+                 SERVER_CONFIG["daklapack_subscription_key_val"]})
+    return result

--- a/microsetta_private_api/admin/daklapack_communication.py
+++ b/microsetta_private_api/admin/daklapack_communication.py
@@ -3,6 +3,11 @@ from requests_oauthlib import OAuth2Session
 from microsetta_private_api.config_manager import SERVER_CONFIG
 from microsetta_private_api.tasks import send_basic_email as celery_send_email
 
+DAK_HEADERS = {
+    SERVER_CONFIG["daklapack_subscription_key_name"]:
+        SERVER_CONFIG["daklapack_subscription_key_val"]
+}
+
 ORDER_HOLD_TEMPLATE_PATH = "email/daklapack_fulfillment_hold_request"
 
 

--- a/microsetta_private_api/admin/daklapack_communication.py
+++ b/microsetta_private_api/admin/daklapack_communication.py
@@ -28,9 +28,7 @@ def post_daklapack_order(payload):
     dak_order_post_url = f"{SERVER_CONFIG['daklapack_api_base_url']}" \
                          f"/api/orders"
     result = oauth_session.post(
-        dak_order_post_url, json=payload,
-        headers={SERVER_CONFIG["daklapack_subscription_key_name"]:
-                 SERVER_CONFIG["daklapack_subscription_key_val"]})
+        dak_order_post_url, json=payload, headers=DAK_HEADERS)
     return result
 
 
@@ -54,7 +52,7 @@ def send_daklapack_hold_email(daklapack_order):
 
 
 def get_daklapack_orders_status(page_num):
-    return _get_from_daklapack_api(f"/api/orders?Page={page_num}")
+    return _get_from_daklapack_api(f"/api/orders?Page={int(page_num)}")
 
 
 def get_daklapack_order_details(order_id):
@@ -65,8 +63,5 @@ def _get_from_daklapack_api(url_suffix):
     oauth_session = _get_daklapack_oauth2_session()
     dak_order_get_url = f"{SERVER_CONFIG['daklapack_api_base_url']}" \
                         f"{url_suffix}"
-    result = oauth_session.get(
-        dak_order_get_url,
-        headers={SERVER_CONFIG["daklapack_subscription_key_name"]:
-                 SERVER_CONFIG["daklapack_subscription_key_val"]})
+    result = oauth_session.get(dak_order_get_url, headers=DAK_HEADERS)
     return result

--- a/microsetta_private_api/admin/daklapack_polling.py
+++ b/microsetta_private_api/admin/daklapack_polling.py
@@ -16,6 +16,7 @@ def poll_dak_orders():
 
     with Transaction() as t:
         poll_dak_orders_using_transaction(t)
+        t.commit()
 
 
 # This method exists (as a separate entity from poll_dak_orders)

--- a/microsetta_private_api/admin/daklapack_polling.py
+++ b/microsetta_private_api/admin/daklapack_polling.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.admin_repo import AdminRepo
@@ -212,6 +213,14 @@ def _store_single_sent_kit(admin_repo, order_proj_ids, single_article_dict):
     created_kit_info = admin_repo.create_kit(
         kit_name, box_id, address_dict, outbound_fedex_code,
         inbound_fedex_code, device_barcodes, order_proj_ids)
+
+    # addresses returned from the create are strings (that in this case
+    # hold representation of json); return them as json instead.
+    # Not doing graceful error handling here because if any of these
+    # keys/structures don't exist, something is wrong and we *should* error
+    for i in range(len(created_kit_info["created"])):
+        address_str = created_kit_info["created"][i]["address"]
+        created_kit_info["created"][i]["address"] = json.loads(address_str)
 
     return created_kit_info
 

--- a/microsetta_private_api/admin/daklapack_polling.py
+++ b/microsetta_private_api/admin/daklapack_polling.py
@@ -1,0 +1,208 @@
+from datetime import datetime
+from microsetta_private_api.repo.transaction import Transaction
+from microsetta_private_api.repo.admin_repo import AdminRepo
+from microsetta_private_api.admin import daklapack_communication as dc
+
+OUTBOUND_DEV_KEY = "outBoundDelivery"
+INBOUND_DEV_KEY = "inBoundDelivery"
+COLLECTION_DEVICE_TYPES = ["2point5ml_etoh_tube", "7ml_etoh_tube",
+                           "neoteryx_kit"]
+SENT_STATUS = "Sent"
+ERROR_STATUS = "Error"
+
+
+def poll_dak_orders():
+    """Get open orders' status from daklapack and process accordingly"""
+
+    with Transaction() as t:
+        poll_dak_orders_using_transaction(t)
+
+
+# This method exists (as a separate entity from poll_dak_orders)
+# exists only to make testing easier
+def poll_dak_orders_using_transaction(t):
+    """Use transaction to get open orders' status from daklapack and process"""
+
+    results = {SENT_STATUS: [], ERROR_STATUS: []}
+    admin_repo = AdminRepo(t)
+
+    # from our db, get list of daklapack orders that haven't been completed
+    open_dak_order_ids = admin_repo.get_unfinished_daklapack_order_ids()
+    curr_page = 0
+
+    # as long as there are still orders we need status info on
+    while len(open_dak_order_ids) > 0:
+        curr_page += 1
+
+        # call daklapack api to get another "page" of order statuses
+        dak_orders_response = dc.get_daklapack_orders_status(curr_page)
+        dak_orders_data = dak_orders_response.json["data"]
+
+        # for each order for which daklapack provided a status
+        for curr_datum in dak_orders_data:
+            curr_order_id = curr_datum["orderId"]
+
+            # ignore any order that is not an open order
+            if curr_order_id not in open_dak_order_ids:
+                continue  # to next order datum
+
+            # record the current order status, whatever it is, to db
+            curr_status = curr_datum["lastState"]["status"]
+            admin_repo.set_daklapack_order_poll_info(
+                curr_order_id, datetime.now(), curr_status)
+
+            if curr_status == ERROR_STATUS or curr_status == SENT_STATUS:
+                curr_creation_date = curr_datum["creationDate"]
+
+                per_article_info = process_order_articles(
+                    admin_repo, curr_order_id, curr_status,
+                    curr_creation_date)
+
+                # note extend not append--avoiding nested lists
+                results[curr_status].extend(per_article_info)
+
+                # if curr_status == ERROR_STATUS:
+                # TODO: cancel the errored order w daklapack
+                # end if error
+            # end if error or sent
+
+            # remove current order id from the list of order ids that we
+            # want to know the status of (since now we know)
+            open_dak_order_ids.remove(curr_order_id)
+
+            # exit once we have found info on all order ids we care about
+            if len(open_dak_order_ids) == 0:
+                break  # out of looping over each order datum
+        # next datum
+    # end while
+
+    # iff there were any errors,
+    # email a list of all the failed orders to
+    # an email address specified in the config
+    # errors = results[ERROR_STATUS]
+    # if len(errors) > 0:
+    #     dc.send_daklapack_errors_report_email(errors)
+
+    return results
+
+
+def process_order_articles(admin_repo, order_id, status, create_date):
+    per_article_outputs = []
+    order_proj_ids = None
+
+    if status == SENT_STATUS:
+        # get projects this order belongs to (needed later for kit creation)
+        order_proj_ids = admin_repo.get_projects_for_dak_order(order_id)
+
+    # call daklapack api to get detailed info on this single order
+    dak_orders_response = dc.get_daklapack_order_details(
+        order_id)
+
+    # loop over each kind of "daklapack article" in this order;
+    # NOTE that although the daklapack api allows >1 type of article (i.e.,
+    # more than one article code) per order,
+    # as of mid-2021, microsetta does NOT: microsetta-admin allows creation of
+    # daklapack orders with only a single article code, and each level of
+    # fundrazr contribution maps to a perk defined by a single article code.
+    dak_order_article_types = dak_orders_response.json["articles"]
+    for curr_article_type in dak_order_article_types:
+        article_instances = curr_article_type["articles"]
+
+        # for each instance of this article kind in the order
+        for curr_article_instance in article_instances:
+            if status == SENT_STATUS:
+                # (Per Daniel 2021-07-01, each instance of a daklapack article
+                # represents exactly one kit, no more or less.)
+                curr_output = _store_single_sent_kit(
+                    admin_repo, order_proj_ids, curr_article_instance)
+            elif status == ERROR_STATUS:
+                curr_output = _gather_article_error_info(
+                    order_id, create_date, curr_article_instance)
+            else:
+                raise ValueError(f"Order {order_id} has an unexpected status: "
+                                 f"{status}")
+
+            per_article_outputs.append(curr_output)
+        # next article instance
+    # next article type
+
+    return per_article_outputs
+
+
+def _store_single_sent_kit(admin_repo, order_proj_ids, single_article_dict):
+    device_barcodes = []
+    kit_name = box_id = None
+
+    # Gather info on address and outbound/inbound fedex tracking
+    # numbers for this particular article instance (i.e., kit).
+    # Per Edgar and Daniel, some kits:
+    # - will have outbound and inbound fedex tracking numbers
+    #   (e.g., typical fundrazr kits)
+    # - will have neither tracking numbers (e.g., a project just
+    #   purchasing kits)
+    # - will have an outbound tracking number (e.g., a project
+    #   where the participant drops their kit off somewhere)
+    # - will have an inbound tracking number (e.g., a hand out at
+    #   a conference)
+
+    outbound_fedex_code = inbound_fedex_code = None
+    if single_article_dict[OUTBOUND_DEV_KEY] is not None:
+        outbound_fedex_code = single_article_dict[
+            OUTBOUND_DEV_KEY]["code"]
+    if single_article_dict[INBOUND_DEV_KEY] is not None:
+        inbound_fedex_code = single_article_dict[
+            INBOUND_DEV_KEY]["code"]
+
+    address_dict = single_article_dict["sendInformation"]
+
+    # for each "scannable item" (i.e., barcoded thing) in a kit
+    scannable_kit_items = single_article_dict["scannableKitItems"]
+    for curr_scannable in scannable_kit_items:
+        # NB: the scannable item can theoretically have a lot of internal
+        # complexity, like a populated containerItems list that itself
+        # contains scannable items, on to infinity.  HOWEVER, microsetta
+        # has defined each article to equal exactly one kit, so it should
+        # not be necessary to dig into that.
+
+        # figure out what *kind* of barcoded thing this is and capture
+        # its barcode to the right field if it is a kind we care about
+        curr_scannable_type = curr_scannable["type"]
+        curr_barcode = curr_scannable["barcode"]
+        if curr_scannable_type in COLLECTION_DEVICE_TYPES:
+            device_barcodes.append(curr_barcode)
+        elif curr_scannable_type == "box":
+            box_id = curr_barcode
+        elif curr_scannable_type == "registration_card":
+            kit_name = curr_barcode
+        else:
+            # Daklapack barcodes this thing but we don't care about it
+            continue  # to next scannable kit item
+    # next scannable item
+
+    # create a new kit in db for this article instance
+    created_kit_info = admin_repo.create_kit(
+        kit_name, box_id, address_dict, outbound_fedex_code,
+        inbound_fedex_code, device_barcodes, order_proj_ids)
+
+    return created_kit_info
+
+
+def _gather_article_error_info(order_id, create_date, curr_article_instance):
+    # dig the info for an error report out of the article instance
+    curr_error_info = {"order_id": order_id,
+                       "article_code": curr_article_instance["articleCode"],
+                       "sent_to_address":
+                           curr_article_instance["sendInformation"],
+                       # per specifications, orders submitted by microsetta api
+                       # through the daklapack interface put the name of the
+                       # microsetta user who submitted the order into the
+                       # order's "companyName" field
+                       "order_submitter":
+                           curr_article_instance["sendInformation"]
+                           ["companyName"],
+                       "creation_date": create_date,
+                       "status_description":
+                           curr_article_instance["description"]
+                       }
+
+    return curr_error_info

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -224,11 +224,6 @@ class AdminTests(TestCase):
         with t.dict_cursor() as cur:
             if len(dummy_dak_order_ids) > 0:
                 # Delete all orders with specified ids
-                temp = cur.mogrify(
-                    "DELETE FROM barcodes.daklapack_order "
-                    "WHERE dak_order_id IN %s",
-                    (tuple(dummy_dak_order_ids),))
-
                 cur.execute(
                     "DELETE FROM barcodes.daklapack_order "
                     "WHERE dak_order_id IN %s",

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -117,62 +117,93 @@ class AdminTests(TestCase):
     def teardown_test_data():
         with Transaction() as t:
             acct_repo = AccountRepo(t)
+            AdminTests.delete_dummy_dak_orders(t)
             acct_repo.delete_account(STANDARD_ACCT_ID)
             acct_repo.delete_account(ADMIN_ACCT_ID)
             t.commit()
 
     @staticmethod
-    def make_dummy_dak_orders(t, bonus_record=False):
-        # create some orders;
-        # need a valid submitter id from the account table to input
+    def construct_dummy_dak_order_data(t, bonus_records=False):
+        submitter_id = 'dummy submitter id'
+
+        # need a valid submitter id from the account table to actually
+        # insert into db
+        if t is not None:
+            with t.dict_cursor() as cur:
+                cur.execute("SELECT id, first_name, last_name "
+                            "FROM ag.account "
+                            "WHERE account_type = 'admin' "
+                            "ORDER BY id "
+                            "LIMIT 1;")
+                submitter_record = cur.fetchone()
+                submitter_id = submitter_record[0]
+
+        dummy_orders = [('7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                         submitter_id, 'Already completed: Sent', None,
+                         '{"orderId": '
+                         '"7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
+                         dateutil.parser.isoparse(
+                             "2020-10-09T22:43:52.219328Z"),
+                         None, "Sent"),
+                        ('8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                         submitter_id, 'Already polled but incomplete; '
+                                       'will be Error', None,
+                         '{"orderId": '
+                         '"8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
+                         dateutil.parser.isoparse(
+                             "2021-10-09T22:43:52.219328Z"),
+                         None, "Pending"),
+                        ('9ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                         submitter_id, 'Already completed: Error', None,
+                         '{"orderId": '
+                         '"9ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
+                         dateutil.parser.isoparse(
+                             "2020-10-09T22:43:52.219328Z"),
+                         None, "Error"),
+                        ('0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                         submitter_id, 'Not yet polled; will be Sent', None,
+                         '{"orderId": '
+                         '"0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
+                         dateutil.parser.isoparse(
+                             "2021-10-09T22:43:52.219328Z"),
+                         None, None)]
+
+        if bonus_records:
+            dummy_orders.append(
+                ('abc917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                 submitter_id, 'Not yet polled; will be Inproduction', None,
+                 '{"orderId": '
+                 '"abc917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
+                 dateutil.parser.isoparse(
+                     "2021-10-10T22:43:52.219328Z"),
+                 None, None))
+
+            dummy_orders.append(
+                ('99746684-8a2b-45d9-9337-4742bf6734cc',
+                 submitter_id, 'Not yet polled; won\'t be in Dak orders', None,
+                 '{"orderId": '
+                 '"99746684-8a2b-45d9-9337-4742bf6734cc"}',
+                 dateutil.parser.isoparse(
+                     "2021-10-10T22:43:52.219328Z"),
+                 None, None))
+
+            dummy_orders.append(
+                ('bf3ef5f7-ae20-45d0-8cfb-d5c0db8024fe',
+                 submitter_id, 'Not yet polled; will error in save', None,
+                 '{"orderId": '
+                 '"bf3ef5f7-ae20-45d0-8cfb-d5c0db8024fe"}',
+                 dateutil.parser.isoparse(
+                     "2021-10-10T22:43:52.219328Z"),
+                 None, None))
+
+        return dummy_orders
+
+    @staticmethod
+    def make_dummy_dak_orders(t, bonus_records=False):
+        dummy_orders = AdminTests.construct_dummy_dak_order_data(
+            t, bonus_records)
+
         with t.dict_cursor() as cur:
-            cur.execute("SELECT id, first_name, last_name "
-                        "FROM ag.account "
-                        "WHERE account_type = 'admin' "
-                        "ORDER BY id "
-                        "LIMIT 1;")
-            submitter_record = cur.fetchone()
-            submitter_id = submitter_record[0]
-
-            dummy_orders = [('7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
-                             submitter_id, 'dummy 1', None,
-                             '{"orderId": '
-                             '"7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
-                             dateutil.parser.isoparse(
-                                 "2020-10-09T22:43:52.219328Z"),
-                             None, "Sent"),
-                            ('8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
-                             submitter_id, 'dummy 2', None,
-                             '{"orderId": '
-                             '"8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
-                             dateutil.parser.isoparse(
-                                 "2021-10-09T22:43:52.219328Z"),
-                             None, "Pending"),
-                            ('9ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
-                             submitter_id, 'dummy 3', None,
-                             '{"orderId": '
-                             '"9ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
-                             dateutil.parser.isoparse(
-                                 "2020-10-09T22:43:52.219328Z"),
-                             None, "Error"),
-                            ('0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
-                             submitter_id, 'dummy 4', None,
-                             '{"orderId": '
-                             '"0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
-                             dateutil.parser.isoparse(
-                                 "2021-10-09T22:43:52.219328Z"),
-                             None, None)]
-
-            if bonus_record:
-                dummy_orders.append(
-                    ('abc917ef-0c4d-431a-9aa0-0a1f4f41f44b',
-                     submitter_id, 'dummy 5', None,
-                     '{"orderId": '
-                     '"abc917ef-0c4d-431a-9aa0-0a1f4f41f44b"}',
-                     dateutil.parser.isoparse(
-                         "2021-10-10T22:43:52.219328Z"),
-                     None, None))
-
             cur.executemany("INSERT INTO barcodes.daklapack_order "
                             "(dak_order_id, submitter_acct_id, "
                             "description, fulfillment_hold_msg, "
@@ -181,7 +212,27 @@ class AdminTests(TestCase):
                             "VALUES (%s, %s, %s, %s,%s, %s, %s, %s)",
                             dummy_orders)
 
-            return dummy_orders
+        return dummy_orders
+
+    @staticmethod
+    def delete_dummy_dak_orders(t, dummy_dak_order_ids=None):
+        if dummy_dak_order_ids is None:
+            dummy_orders = AdminTests.construct_dummy_dak_order_data(
+                None, bonus_records=True)
+            dummy_dak_order_ids = [i[0] for i in dummy_orders]
+
+        with t.dict_cursor() as cur:
+            if len(dummy_dak_order_ids) > 0:
+                # Delete all orders with specified ids
+                temp = cur.mogrify(
+                    "DELETE FROM barcodes.daklapack_order "
+                    "WHERE dak_order_id IN %s",
+                    (tuple(dummy_dak_order_ids),))
+
+                cur.execute(
+                    "DELETE FROM barcodes.daklapack_order "
+                    "WHERE dak_order_id IN %s",
+                    (tuple(dummy_dak_order_ids),))
 
     def test_validate_admin_access(self):
         token_info_std = {
@@ -1093,7 +1144,7 @@ class AdminRepoTests(AdminTests):
 
             admin_repo = AdminRepo(t)
             real_out = admin_repo.get_unfinished_daklapack_order_ids()
-            self.assertEqual(expected_out, real_out)
+            self.assertEqual(sorted(expected_out), sorted(real_out))
 
     def test_get_projects_for_dak_order(self):
         with Transaction() as t:

--- a/microsetta_private_api/admin/tests/test_daklapack_polling.py
+++ b/microsetta_private_api/admin/tests/test_daklapack_polling.py
@@ -595,14 +595,15 @@ class DaklapackPollingTests(AdminTests):
                   'status_description': None}],
             'Sent':
                 [{'created': [
-                    {'address': '{"firstName": "Natalia J Phillips", '
-                                '"lastName": "", "address1": "2166  '
-                                'Chapmans Lane", "insertion": "", '
-                                '"address2": "", "postalCode": "88103", '
-                                '"city": "Clovis", "state": "NM", '
-                                '"country": "USA", "countryCode": "US", '
-                                '"phone": "505-784-5252", "companyName": '
-                                '"Jane Doe"}',
+                    {'address': {'firstName': 'Natalia J Phillips',
+                                 'lastName': '',
+                                 'address1': '2166  Chapmans Lane',
+                                 'insertion': '',
+                                 'address2': '', 'postalCode': '88103',
+                                 'city': 'Clovis', 'state': 'NM',
+                                 'country': 'USA', 'countryCode': 'US',
+                                 'phone': '505-784-5252',
+                                 'companyName': 'Jane Doe'},
                      'box_id': 'DEFX',
                      'inbound_fedex_tracking': None,
                      'kit_id': 'DEFR',
@@ -661,29 +662,33 @@ class DaklapackPollingTests(AdminTests):
         expected_out = [
             {'created': [
                 {'kit_id': 'ABCR',
+                 'address': {'firstName': 'Natalia J Phillips',
+                             'lastName': '',
+                             'address1': '2166  Chapmans Lane',
+                             'insertion': '',
+                             'address2': '', 'postalCode': '88103',
+                             'city': 'Clovis', 'state': 'NM',
+                             'country': 'USA', 'countryCode': 'US',
+                             'phone': '505-784-5252',
+                             'companyName': 'Jane Doe'},
                  'box_id': 'ABCX',
-                 'address': '{"firstName": "Natalia J Phillips", '
-                            '"lastName": "", "address1": "2166  '
-                            'Chapmans Lane", "insertion": "", "address2": "", '
-                            '"postalCode": "88103", "city": "Clovis", '
-                            '"state": "NM", "country": "USA", '
-                            '"countryCode": "US", "phone": "505-784-5252", '
-                            '"companyName": "Jane Doe"}',
                  'outbound_fedex_tracking': 'Tracking Code 1',
                  'inbound_fedex_tracking': 'Tracking Code 2',
                  'sample_barcodes': ['ABCT', 'ABCN']
-                 }
+                 },
             ]},
             {'created': [
                 {'kit_id': 'ABCR2',
                  'box_id': 'ABCX2',
-                 'address': '{"firstName": "Natalia J Phillips", '
-                            '"lastName": "", "address1": "2166  '
-                            'Chapmans Lane", "insertion": "", "address2": "", '
-                            '"postalCode": "88103", "city": "Clovis", '
-                            '"state": "NM", "country": "USA", '
-                            '"countryCode": "US", "phone": "505-784-5252", '
-                            '"companyName": "Jane Doe"}',
+                 'address': {'firstName': 'Natalia J Phillips',
+                             'lastName': '',
+                             'address1': '2166  Chapmans Lane',
+                             'insertion': '',
+                             'address2': '', 'postalCode': '88103',
+                             'city': 'Clovis', 'state': 'NM',
+                             'country': 'USA', 'countryCode': 'US',
+                             'phone': '505-784-5252',
+                             'companyName': 'Jane Doe'},
                  'outbound_fedex_tracking': 'Tracking Code 2',
                  'inbound_fedex_tracking': None,
                  'sample_barcodes': ['ABCT2', 'ABCN2']
@@ -692,13 +697,15 @@ class DaklapackPollingTests(AdminTests):
             {'created': [
                 {'kit_id': 'DEFR',
                  'box_id': 'DEFX',
-                 'address': '{"firstName": "Natalia J Phillips", '
-                            '"lastName": "", "address1": "2166  '
-                            'Chapmans Lane", "insertion": "", "address2": "", '
-                            '"postalCode": "88103", "city": "Clovis", '
-                            '"state": "NM", "country": "USA", '
-                            '"countryCode": "US", "phone": "505-784-5252", '
-                            '"companyName": "Jane Doe"}',
+                 'address': {'firstName': 'Natalia J Phillips',
+                             'lastName': '',
+                             'address1': '2166  Chapmans Lane',
+                             'insertion': '',
+                             'address2': '', 'postalCode': '88103',
+                             'city': 'Clovis', 'state': 'NM',
+                             'country': 'USA', 'countryCode': 'US',
+                             'phone': '505-784-5252',
+                             'companyName': 'Jane Doe'},
                  'outbound_fedex_tracking': None,
                  'inbound_fedex_tracking': None,
                  'sample_barcodes': ['DEFT']

--- a/microsetta_private_api/admin/tests/test_daklapack_polling.py
+++ b/microsetta_private_api/admin/tests/test_daklapack_polling.py
@@ -1,0 +1,724 @@
+import json
+from flask import Response
+from unittest.mock import patch
+from microsetta_private_api.repo.transaction import Transaction
+from microsetta_private_api.admin.daklapack_polling import \
+    process_order_articles, poll_dak_orders_using_transaction
+from microsetta_private_api.repo.admin_repo import AdminRepo
+from microsetta_private_api.admin.tests.test_admin_repo import AdminTests
+
+
+def make_test_response(status_code, json_dict):
+    result = Response(response=json.dumps(json_dict) + "\n",
+                      status=status_code,
+                      mimetype='application/json')
+    return result
+
+
+class DaklapackPollingTests(AdminTests):
+    ARTICLES_INFO = {"articles": [
+        {"articleCode": "350201",
+         "total": 2,
+         "new": 0,
+         "inProduction": 0,
+         "sent": 2,
+         "errors": 0,
+         "articles": [
+             {"internalId": "729f7149-4889-42b3-8368-1b68284d5b95",
+              "articleCode": "350201",
+              "status": "Sent",
+              "description": "A test description",
+              "sendInformation": {
+                  "firstName": "Natalia J Phillips", "lastName": "",
+                  "address1": "2166  Chapmans Lane", "insertion": "",
+                  "address2": "", "postalCode": "88103", "city": "Clovis",
+                  "state": "NM", "country": "USA", "countryCode": "US",
+                  "phone": "505-784-5252", "companyName": "Jane Doe"
+              },
+              "shippingProvider": {
+                  "name": "FedEx", "shippingType": "FEDEX_2_DAY"
+              },
+              "scannableKitItems": [
+                  {"type": "7ml_etoh_tube", "barcode": "ABCT",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "registration_card", "barcode": "ABCR",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "box", "barcode": "ABCX",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "Form", "barcode": "ABCF",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "neoteryx_kit", "barcode": "ABCN",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   }
+              ],
+              "inBoundDelivery": {"code": "Tracking Code 2"},
+              "outBoundDelivery": {"code": "Tracking Code 1"},
+              "code": None, "plannedSendDate": None
+              },
+             {"internalId": "9e07e45b-c302-4f8a-b040-21b30d6b28e0",
+              "articleCode": "350201",
+              "status": "Sent",
+              "description": None,
+              "sendInformation": {
+                  "firstName": "Natalia J Phillips", "lastName": "",
+                  "address1": "2166  Chapmans Lane", "insertion": "",
+                  "address2": "", "postalCode": "88103", "city": "Clovis",
+                  "state": "NM", "country": "USA", "countryCode": "US",
+                  "phone": "505-784-5252", "companyName": "Jane Doe"
+              },
+              "shippingProvider": {
+                  "name": "FedEx", "shippingType": "FEDEX_2_DAY"
+              },
+              "scannableKitItems": [
+                  {"type": "7ml_etoh_tube", "barcode": "ABCT2",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "registration_card", "barcode": "ABCR2",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "box", "barcode": "ABCX2",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "Form", "barcode": "ABCF2",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "neoteryx_kit", "barcode": "ABCN2",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   }
+              ],
+              "inBoundDelivery": None,
+              "outBoundDelivery": {"code": "Tracking Code 2"},
+              "code": None, "plannedSendDate": None
+              }  # end article instance
+         ]},  # end "articles" (instance) list, single article (type) entry
+        {"articleCode": "350100",
+         "total": 1,
+         "new": 0,
+         "inProduction": 0,
+         "sent": 1,
+         "errors": 0,
+         "articles": [
+             {"internalId": "8abf7149-4889-42b3-8368-1b68284d5b95",
+              "articleCode": "350100",
+              "status": "Sent",
+              "description": None,
+              "sendInformation": {
+                  "firstName": "Natalia J Phillips", "lastName": "",
+                  "address1": "2166  Chapmans Lane", "insertion": "",
+                  "address2": "", "postalCode": "88103", "city": "Clovis",
+                  "state": "NM", "country": "USA", "countryCode": "US",
+                  "phone": "505-784-5252", "companyName": "Jane Doe"
+              },
+              "shippingProvider": {
+                  "name": "FedEx", "shippingType": "FEDEX_2_DAY"
+              },
+              "scannableKitItems": [
+                  {"type": "registration_card", "barcode": "DEFR",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "2point5ml_etoh_tube", "barcode": "DEFT",
+                   "creationDate": "2021-02-26T08:48:16.7885478Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   },
+                  {"type": "box", "barcode": "DEFX",
+                   "creationDate": "2021-02-26T08:48:16.788439Z",
+                   "itemCount": 1,
+                   "containerItems": []
+                   }
+              ],
+              "inBoundDelivery": None,
+              "outBoundDelivery": None,
+              "code": None, "plannedSendDate": None
+              }  # end article instance
+         ]}  # end "articles" (instance) list, single article (type) entry
+    ]}  # end "articles" (type) list, outer dict
+
+    def _check_last_polling_status(self, t, dak_order_id, expected_status):
+        with t.dict_cursor() as cur:
+            cur.execute("SELECT last_polling_status "
+                        "FROM barcodes.daklapack_order "
+                        "WHERE dak_order_id =  %s",
+                        (dak_order_id,))
+            curr_records = cur.fetchall()
+            self.assertEqual(len(curr_records), 1)
+            self.assertEqual(expected_status, curr_records[0][0])
+
+    def test_poll_dak_orders_using_transaction(self):
+        order_statuses_pg_1 = {
+          "isSuccess": True,
+          "messages": None,
+          "total": 3,
+          "data": [
+            {
+              "id": "020a5c97-6837-4bc2-99e6-7cdad38230e7",
+              "orderId": "abc917ef-0c4d-431a-9aa0-0a1f4f41f44b",
+              "creationDate": "2021-02-26T08:30:18.805519Z",
+              "plannedSendDate": None,
+              "statusLedger": [
+                {
+                  "changeDate": "2021-02-26T08:30:18.8050976Z",
+                  "status": "New",
+                  "origin": "OrderApi",
+                  "description": ""
+                },
+                {
+                  "changeDate": "2021-02-26T09:30:18.8050976Z",
+                  "status": "Inproduction",
+                  "origin": "OrderApi",
+                  "description": ""
+                }
+              ],
+              "lastState": {
+                "changeDate": "2021-02-26T08:41:43.0786247Z",
+                "status": "Inproduction",
+                "origin": "OrderApi",
+                "description": ""
+              },
+              "shippingProvider": {
+                "name": "FedEx",
+                "shippingType": "FEDEX_2_DAY"
+              },
+              "orderLines": [
+                {
+                  "articleId": "350100",
+                  "amount": 2
+                }
+              ],
+              "code": None,
+              "reference": None,
+              "nawId": "20b34834-3399-4cfd-9abe-accdbf34e3e2"
+            },
+            {
+              "id": "4b96304d-96ff-4ab3-8eb6-0aa44046d69b",
+              "orderId": "0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b",
+              "creationDate": "2021-02-26T08:36:00.2250124Z",
+              "plannedSendDate": None,
+              "statusLedger": [
+                {
+                  "changeDate": "2021-02-26T08:36:00.2245913Z",
+                  "status": "New",
+                  "origin": "OrderApi",
+                  "description": ""
+                },
+                {
+                  "changeDate": "2021-02-26T09:30:18.8050976Z",
+                  "status": "Inproduction",
+                  "origin": "OrderApi",
+                  "description": ""
+                },
+                {
+                  "changeDate": "2021-02-26T08:49:28.2010144Z",
+                  "status": "Sent",
+                  "origin": "OrderApi",
+                  "description": ""
+                }
+              ],
+              "lastState": {
+                "changeDate": "2021-02-26T08:49:28.2010144Z",
+                "status": "Sent",
+                "origin": "OrderApi",
+                "description": ""
+              },
+              "shippingProvider": {
+                "name": "FedEx",
+                "shippingType": "FEDEX_2_DAY"
+              },
+              "orderLines": [
+                {
+                  "articleId": "350100",
+                  "amount": 2
+                }
+              ],
+              "code": None,
+              "reference": None,
+              "nawId": "a236b632-b77a-4f3b-b537-75e58c9fae77"
+            }
+          ]
+        }
+
+        order_statuses_pg_2 = {
+          "isSuccess": True,
+          "messages": None,
+          "total": 3,
+          "data":  [
+            {
+              # This one won't be in our db's list of open orders;
+              # we're imagining it was seen/dealt with in the past
+              "id": "566bdadb-df00-462b-9bfc-1f1c652216ed",
+              "orderId": "OX3HOOD",
+              "creationDate": "2021-02-26T08:36:12.4267351Z",
+              "plannedSendDate": None,
+              "statusLedger": [
+                {
+                  "changeDate": "2021-02-26T08:36:12.4263206Z",
+                  "status": "New",
+                  "origin": "OrderApi",
+                  "description": ""
+                },
+                {
+                  "changeDate": "2021-02-26T09:30:18.8050976Z",
+                  "status": "Inproduction",
+                  "origin": "OrderApi",
+                  "description": ""
+                },
+                {
+                  "changeDate": "2021-02-26T08:41:43.0786247Z",
+                  "status": "Error",
+                  "origin": "OrderApi",
+                  "description": ""
+                }
+              ],
+              "lastState": {
+                "changeDate": "2021-02-26T08:41:43.0786247Z",
+                "status": "Error",
+                "origin": "OrderApi",
+                "description": ""
+              },
+              "shippingProvider": {
+                "name": "FedEx",
+                "shippingType": "FEDEX_2_DAY"
+              },
+              "orderLines": [
+                {
+                  "articleId": "350100",
+                  "amount": 2
+                }
+              ],
+              "code": None,
+              "reference": None,
+              "nawId": "84169469-4e84-4b73-833b-1b790baebc20"
+            },
+            {
+              "id": "AACbdadb-df00-462b-9bfc-1f1c652216ed",
+              "orderId": "8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b",
+              "creationDate": "2021-02-26T08:36:12.4267351Z",
+              "plannedSendDate": None,
+              "statusLedger": [
+                  {
+                      "changeDate": "2021-02-26T08:36:12.4263206Z",
+                      "status": "New",
+                      "origin": "OrderApi",
+                      "description": ""
+                  },
+                  {
+                      "changeDate": "2021-02-26T09:30:18.8050976Z",
+                      "status": "Inproduction",
+                      "origin": "OrderApi",
+                      "description": ""
+                  },
+                  {
+                      "changeDate": "2021-02-26T08:41:43.0786247Z",
+                      "status": "Error",
+                      "origin": "OrderApi",
+                      "description": ""
+                  }
+              ],
+              "lastState": {
+                  "changeDate": "2021-02-26T08:41:43.0786247Z",
+                  "status": "Error",
+                  "origin": "OrderApi",
+                  "description": ""
+              },
+              "shippingProvider": {
+                  "name": "FedEx",
+                  "shippingType": "FEDEX_2_DAY"
+              },
+              "orderLines": [
+                  {
+                      "articleId": "350100",
+                      "amount": 2
+                  }
+              ],
+              "code": None,
+              "reference": None,
+              "nawId": "84169469-4e84-4b73-833b-1b790baebc20"
+            }
+          ]
+        }
+
+        articles_for_orders = [
+            {"articles": [
+                {"articleCode": "350100",
+                 "total": 1,
+                 "new": 0,
+                 "inProduction": 0,
+                 "sent": 1,
+                 "errors": 0,
+                 "articles": [
+                     {"internalId": "8abf7149-4889-42b3-8368-1b68284d5b95",
+                      "articleCode": "350100",
+                      "status": "Sent",
+                      "description": None,
+                      "sendInformation": {
+                          "firstName": "Natalia J Phillips", "lastName": "",
+                          "address1": "2166  Chapmans Lane", "insertion": "",
+                          "address2": "", "postalCode": "88103",
+                          "city": "Clovis",
+                          "state": "NM", "country": "USA", "countryCode": "US",
+                          "phone": "505-784-5252", "companyName": "Jane Doe"
+                      },
+                      "shippingProvider": {
+                          "name": "FedEx", "shippingType": "FEDEX_2_DAY"
+                      },
+                      "scannableKitItems": [
+                          {"type": "registration_card", "barcode": "DEFR",
+                           "creationDate": "2021-02-26T08:48:16.788439Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           },
+                          {"type": "2point5ml_etoh_tube", "barcode": "DEFT",
+                           "creationDate": "2021-02-26T08:48:16.7885478Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           },
+                          {"type": "box", "barcode": "DEFX",
+                           "creationDate": "2021-02-26T08:48:16.788439Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           }
+                      ],
+                      "inBoundDelivery": None,
+                      "outBoundDelivery": None,
+                      "code": None, "plannedSendDate": None
+                      }  # end article instance
+                 ]}
+                # end "articles" (instance) list, single article (type) entry
+            ]},  # end "articles" (type) list, outer dict
+            {"articles": [
+                {"articleCode": "350102",
+                 "total": 1,
+                 "new": 0,
+                 "inProduction": 0,
+                 "sent": 1,
+                 "errors": 0,
+                 "articles": [
+                     {"internalId": "8abf7149-4889-42b3-8368-1b68284d5b95",
+                      "articleCode": "350100",
+                      "status": "Sent",
+                      "description": None,
+                      "sendInformation": {
+                          "firstName": "John J Doe", "lastName": "",
+                          "address1": "1  East Lane", "insertion": "",
+                          "address2": "", "postalCode": "88103",
+                          "city": "Truth or Consequences",
+                          "state": "NM", "country": "USA", "countryCode": "US",
+                          "phone": "505-784-5252", "companyName": "Jane Doe"
+                      },
+                      "shippingProvider": {
+                          "name": "FedEx", "shippingType": "FEDEX_2_DAY"
+                      },
+                      "scannableKitItems": [
+                          {"type": "registration_card", "barcode": "DEFR",
+                           "creationDate": "2021-02-26T08:48:16.788439Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           },
+                          {"type": "2point5ml_etoh_tube", "barcode": "DEFT",
+                           "creationDate": "2021-02-26T08:48:16.7885478Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           },
+                          {"type": "box", "barcode": "DEFX",
+                           "creationDate": "2021-02-26T08:48:16.788439Z",
+                           "itemCount": 1,
+                           "containerItems": []
+                           }
+                      ],
+                      "inBoundDelivery": None,
+                      "outBoundDelivery": None,
+                      "code": None, "plannedSendDate": None
+                      }  # end article instance
+                 ]}
+                # end "articles" (instance) list, single article (type) entry
+            ]}  # end "articles" (type) list, outer dict
+        ]
+
+        expected_out = {
+            'Error':
+                [{'article_code': '350100',
+                  'creation_date': '2021-02-26T08:36:12.4267351Z',
+                  'order_id': '8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+                  'order_submitter': 'Jane Doe',
+                  'sent_to_address': {
+                      'address1': '1  East Lane',
+                      'address2': '',
+                      'city': 'Truth or Consequences',
+                      'companyName': 'Jane Doe',
+                      'country': 'USA',
+                      'countryCode': 'US',
+                      'firstName': 'John J Doe',
+                      'insertion': '',
+                      'lastName': '',
+                      'phone': '505-784-5252',
+                      'postalCode': '88103',
+                      'state': 'NM'},
+                  'status_description': None}],
+            'Sent':
+                [{'created': [
+                    {'address': '{"firstName": "Natalia J Phillips", '
+                                '"lastName": "", "address1": "2166  '
+                                'Chapmans Lane", "insertion": "", '
+                                '"address2": "", "postalCode": "88103", '
+                                '"city": "Clovis", "state": "NM", '
+                                '"country": "USA", "countryCode": "US", '
+                                '"phone": "505-784-5252", "companyName": '
+                                '"Jane Doe"}',
+                     'box_id': 'DEFX',
+                     'inbound_fedex_tracking': None,
+                     'kit_id': 'DEFR',
+                     'outbound_fedex_tracking': None,
+                     'sample_barcodes': ['DEFT']}]}]}
+
+        with Transaction() as t:
+            self.make_dummy_dak_orders(t, bonus_record=True)
+
+            # NB: these have to be patched *where they will be looked up*, not
+            # where they are originally defined; see
+            # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+            with patch("microsetta_private_api.admin.daklapack_communication."
+                       "get_daklapack_orders_status") as mock_dak_orders_info:
+                mock_dak_orders_info.side_effect = [make_test_response(
+                    200, order_statuses_pg_1), make_test_response(
+                    200, order_statuses_pg_2)]
+
+                with patch(
+                        "microsetta_private_api.admin.daklapack_communication."
+                        "get_daklapack_order_details") as mock_dak_order_info:
+                    mock_dak_order_info.side_effect = [make_test_response(
+                        200, articles_for_orders[0]), make_test_response(
+                        200, articles_for_orders[1])]
+
+                    real_out = poll_dak_orders_using_transaction(t)
+
+            # for three incomplete orders, check status in db
+            self._check_last_polling_status(
+                t, "abc917ef-0c4d-431a-9aa0-0a1f4f41f44b", "Inproduction")
+            self._check_last_polling_status(
+                t, "0ed917ef-0c4d-431a-9aa0-0a1f4f41f44b", "Sent")
+            self._check_last_polling_status(
+                t, "8ed917ef-0c4d-431a-9aa0-0a1f4f41f44b", "Error")
+
+            # remove the kit_uuid from the real output before testing
+            # since that can't be known ahead of time
+            del real_out["Sent"][0]["created"][0]["kit_uuid"]
+            self.assertEqual(expected_out, real_out)
+
+    def test_process_order_articles_sent_status(self):
+        expected_out = [
+            {'created': [
+                {'kit_id': 'ABCR',
+                 'box_id': 'ABCX',
+                 'address': '{"firstName": "Natalia J Phillips", '
+                            '"lastName": "", "address1": "2166  '
+                            'Chapmans Lane", "insertion": "", "address2": "", '
+                            '"postalCode": "88103", "city": "Clovis", '
+                            '"state": "NM", "country": "USA", '
+                            '"countryCode": "US", "phone": "505-784-5252", '
+                            '"companyName": "Jane Doe"}',
+                 'outbound_fedex_tracking': 'Tracking Code 1',
+                 'inbound_fedex_tracking': 'Tracking Code 2',
+                 'sample_barcodes': ['ABCT', 'ABCN']
+                 }
+            ]},
+            {'created': [
+                {'kit_id': 'ABCR2',
+                 'box_id': 'ABCX2',
+                 'address': '{"firstName": "Natalia J Phillips", '
+                            '"lastName": "", "address1": "2166  '
+                            'Chapmans Lane", "insertion": "", "address2": "", '
+                            '"postalCode": "88103", "city": "Clovis", '
+                            '"state": "NM", "country": "USA", '
+                            '"countryCode": "US", "phone": "505-784-5252", '
+                            '"companyName": "Jane Doe"}',
+                 'outbound_fedex_tracking': 'Tracking Code 2',
+                 'inbound_fedex_tracking': None,
+                 'sample_barcodes': ['ABCT2', 'ABCN2']
+                 }
+            ]},
+            {'created': [
+                {'kit_id': 'DEFR',
+                 'box_id': 'DEFX',
+                 'address': '{"firstName": "Natalia J Phillips", '
+                            '"lastName": "", "address1": "2166  '
+                            'Chapmans Lane", "insertion": "", "address2": "", '
+                            '"postalCode": "88103", "city": "Clovis", '
+                            '"state": "NM", "country": "USA", '
+                            '"countryCode": "US", "phone": "505-784-5252", '
+                            '"companyName": "Jane Doe"}',
+                 'outbound_fedex_tracking': None,
+                 'inbound_fedex_tracking': None,
+                 'sample_barcodes': ['DEFT']
+                 }
+            ]}
+        ]
+
+        with Transaction() as t:
+            dummy_orders = self.make_dummy_dak_orders(t)
+            an_order_id = dummy_orders[0][0]
+            admin_repo = AdminRepo(t)
+
+            # NB: these have to be patched *where they will be looked up*, not
+            # where they are originally defined; see
+            # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+            with patch("microsetta_private_api.admin.daklapack_communication."
+                       "get_daklapack_order_details") as mock_dak_order_info:
+                mock_dak_order_info.side_effect = [make_test_response(
+                    200, self.ARTICLES_INFO)]
+
+                real_out = process_order_articles(
+                    admin_repo, an_order_id, "Sent",
+                    "2021-02-26T08:30:18.805519Z")
+
+                self.assertEqual(len(expected_out), len(real_out))
+                # kit uuids can't be predicted for test, so pop them out
+                for curr_created_dict in real_out:
+                    curr_details_dict = curr_created_dict["created"][0]
+                    curr_details_dict.pop("kit_uuid")
+                self.assertEqual(expected_out, real_out)
+
+        # Note: transaction is not committed so db changes don't stick :)
+
+    def test_process_order_articles_error_status(self):
+        expected_out = [
+            {'article_code': '350201',
+             'creation_date': '2021-02-26T08:30:18.805519Z',
+             'order_id': '7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+             'order_submitter': 'Jane Doe',
+             'sent_to_address': {
+                'address1': '2166  Chapmans Lane',
+                'address2': '',
+                'city': 'Clovis',
+                'companyName': 'Jane Doe',
+                'country': 'USA',
+                'countryCode': 'US',
+                'firstName': 'Natalia J Phillips',
+                'insertion': '',
+                'lastName': '',
+                'phone': '505-784-5252',
+                'postalCode': '88103',
+                'state': 'NM'},
+             'status_description': "A test description"},
+            {'article_code': '350201',
+             'creation_date': '2021-02-26T08:30:18.805519Z',
+             'order_id': '7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+             'order_submitter': 'Jane Doe',
+             'sent_to_address':
+                 {'address1': '2166  Chapmans Lane',
+                  'address2': '',
+                  'city': 'Clovis',
+                  'companyName': 'Jane Doe',
+                  'country': 'USA',
+                  'countryCode': 'US',
+                  'firstName': 'Natalia J Phillips',
+                  'insertion': '',
+                  'lastName': '',
+                  'phone': '505-784-5252',
+                  'postalCode': '88103',
+                  'state': 'NM'},
+             'status_description': None},
+            {'article_code': '350100',
+             'creation_date': '2021-02-26T08:30:18.805519Z',
+             'order_id': '7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b',
+             'order_submitter': 'Jane Doe',
+             'sent_to_address': {
+                'address1': '2166  Chapmans Lane',
+                'address2': '',
+                'city': 'Clovis',
+                'companyName': 'Jane Doe',
+                'country': 'USA',
+                'countryCode': 'US',
+                'firstName': 'Natalia J Phillips',
+                'insertion': '',
+                'lastName': '',
+                'phone': '505-784-5252',
+                'postalCode': '88103',
+                'state': 'NM'},
+             'status_description': None}]
+
+        with Transaction() as t:
+            dummy_orders = self.make_dummy_dak_orders(t)
+            an_order_id = dummy_orders[0][0]
+            admin_repo = AdminRepo(t)
+
+            # NB: these have to be patched *where they will be looked up*, not
+            # where they are originally defined; see
+            # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+            with patch("microsetta_private_api.admin.daklapack_communication."
+                       "get_daklapack_order_details") as mock_dak_order_info:
+                # NB: this is returning the same json as for the "sent"
+                # case; this json says each article was sent (which would
+                # not be the case in the "error" case) but that field isn't
+                # used for the "error" case so I am not bothering to make a
+                # whole new input to change that field for verisimilitude
+                mock_dak_order_info.side_effect = [make_test_response(
+                    200, self.ARTICLES_INFO)]
+
+                real_out = process_order_articles(
+                    admin_repo, an_order_id, "Error",
+                    "2021-02-26T08:30:18.805519Z")
+
+                self.assertEqual(len(expected_out), len(real_out))
+                # # kit uuids can't be predicted for test, so pop them out
+                # for curr_created_dict in real_out:
+                #     curr_details_dict = curr_created_dict["created"][0]
+                #     curr_details_dict.pop("kit_uuid")
+                self.assertEqual(expected_out, real_out)
+
+        # Note: transaction is not committed so db changes don't stick :)
+
+    def test_process_order_articles_unknown_status(self):
+        with Transaction() as t:
+            dummy_orders = self.make_dummy_dak_orders(t)
+            an_order_id = dummy_orders[0][0]
+            admin_repo = AdminRepo(t)
+
+            # NB: these have to be patched *where they will be looked up*, not
+            # where they are originally defined; see
+            # https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+            with patch("microsetta_private_api.admin.daklapack_communication."
+                       "get_daklapack_order_details") as mock_dak_order_info:
+                # NB: this is returning the same json as for the "sent"
+                # case; this json says each article was sent (which would
+                # not be the case in the "unknown" case) but that field isn't
+                # used for the "unknown" case so I am not bothering to make a
+                # whole new input to change that field for verisimilitude
+                mock_dak_order_info.side_effect = [make_test_response(
+                    200, self.ARTICLES_INFO)]
+
+                with self.assertRaisesRegex(
+                        ValueError,
+                        "Order 7ed917ef-0c4d-431a-9aa0-0a1f4f41f44b "
+                        "has an unexpected status: InProduction"):
+
+                    process_order_articles(
+                        admin_repo, an_order_id, "InProduction",
+                        "2021-02-26T08:30:18.805519Z")
+
+        # Note: transaction is not committed so db changes don't stick :)


### PR DESCRIPTION
This code provides the logic of checking the status of outstanding daklapack orders via the daklapack api, recording the current status to our daklapack orders table, creating a new kit for any order that was successfully sent, and gathering descriptive info about any order that errored out.

Note that this code does not include (a) the celery-based scheduling of this status-checking functionality or (b) the (again celery-based) emailing of the descriptive info about any errored orders to someone at microsetta who has to deal with them.  Those code pieces are ready to go and I will put them up as their own PR once this is reviewed, since this seems meaty enough by itself.

This also does not include the automated cancellation with daklapack of any errored order.  I need a bit of help from Bas at daklapack to finish that code off.