### PR TITLE
Allows admins to query barcodes with sql where clauses

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -589,4 +589,3 @@ def barcode_query(token_info, cond):
         t.rollback()  # Queries don't need to commit changes.
 
     return jsonify(barcodes), 200
-

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -493,3 +493,100 @@ def generate_activation_codes(body, token_info):
         results = [{"email": email, "code": map[email]} for email in map]
         t.commit()
     return jsonify(results), 200
+
+
+def list_barcode_query_fields(token_info):
+    validate_admin_access(token_info)
+
+    # Generates a json array declaring the filters
+    # that can be used for barcode queries
+    # Will be parseable by jQuery QueryBuilder
+    # to allow a user to modify queries.
+
+    # Barcode queries can filter on:
+    #   - project (categorical, any project in our db)
+    #   - sample_status (categorical, fixed list)
+    #   - sample_type (categorical, fixed list)
+
+    # See examples https://querybuilder.js.org/demo.html
+    # https://querybuilder.js.org/assets/demo-import-export.js
+
+    with Transaction() as t:
+        admin_repo = AdminRepo(t)
+        projects_list = admin_repo.get_projects(False)
+
+    filter_fields = []
+    filter_fields.append(
+        {
+            'id': 'project_id',
+            'label': 'Project',
+            'type': 'integer',
+            'input': 'select',
+            'values': {
+                x.project_id: x.project_name for x in projects_list
+            },
+            'operators': ['equal', 'not_equal']
+        }
+    )
+    filter_fields.append(
+        {
+            'id': 'sample_status',
+            'label': 'Sample Status',
+            'type': 'string',
+            'input': 'select',
+            'values': {
+                "sample-is-valid": "Sample Is Valid",
+                "no-associated-source": "No Associated Source",
+                "no-registered-account": "No Registered Account",
+                "no-collection-info": "No Collection Info",
+                "sample-has-inconsistencies": "Sample Has Inconsistencies",
+                "received-unknown-validity": "Received Unknown Validity"
+            },
+            'operators': ['equal', 'not_equal']
+        }
+    )
+    filter_fields.append(
+        {
+            'id': 'site_sampled',
+            'label': 'Sample Site',
+            'type': 'string',
+            'input': 'select',
+            'values': {
+                "Blood (skin prick)": "Blood (skin prick)",
+                "Saliva": "Saliva",
+                "Ear wax": "Ear wax",
+                "Forehead": "Forehead",
+                "Fur": "Fur",
+                "Hair": "Hair",
+                "Left hand": "Left hand",
+                "Left leg": "Left leg",
+                "Mouth": "Mouth",
+                "Nares": "Nares",
+                "Nasal mucus": "Nasal mucus",
+                "Right hand": "Right hand",
+                "Right leg": "Right leg",
+                "Stool": "Stool",
+                "Tears": "Tears",
+                "Torso": "Torso",
+                "Vaginal mucus": "Vaginal mucus"
+            },
+            'operators': ['equal', 'not_equal']
+        }
+    )
+
+    return jsonify(filter_fields), 200
+
+
+def barcode_query(token_info, cond):
+    # Validating admin access is absolutely critical here
+    # Failing to do so enables sql query access
+    # to non admin users
+    validate_admin_access(token_info)
+
+    with Transaction() as t:
+        repo = AdminRepo(t)
+        barcodes = repo.search_barcode(cond)
+        t.rollback()  # Queries don't need to commit changes.
+
+    return jsonify(barcodes), 200
+

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -27,6 +27,7 @@ from microsetta_private_api.admin.daklapack_communication import \
     post_daklapack_order, send_daklapack_hold_email
 from microsetta_private_api import localization
 from microsetta_private_api.admin.sample_summary import per_sample
+from microsetta_private_api.util.query_builder_to_sql import build_condition
 from werkzeug.exceptions import Unauthorized
 
 
@@ -577,7 +578,7 @@ def list_barcode_query_fields(token_info):
     return jsonify(filter_fields), 200
 
 
-def barcode_query(token_info, cond):
+def barcode_query(body, token_info):
     # Validating admin access is absolutely critical here
     # Failing to do so enables sql query access
     # to non admin users
@@ -585,7 +586,8 @@ def barcode_query(token_info, cond):
 
     with Transaction() as t:
         repo = AdminRepo(t)
-        barcodes = repo.search_barcode(cond)
+        cond, cond_params = build_condition(body)
+        barcodes = repo.search_barcode(cond, cond_params)
         t.rollback()  # Queries don't need to commit changes.
 
     return jsonify(barcodes), 200

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1590,6 +1590,38 @@ paths:
               schema:
                 type: array
 
+  '/admin/barcode_query_fields':
+    get:
+      operationId: microsetta_private_api.admin.admin_impl.list_barcode_query_fields
+      tags:
+        - Admin
+      responses:
+        '200':
+          description: Returns array of fields, types and values
+          content:
+            application/json:
+              schema:
+                type: array
+
+  '/admin/barcode_query':
+    get:
+      operationId: microsetta_private_api.admin.admin_impl.barcode_query
+      tags:
+        - Admin
+      parameters:
+        - $ref: '#/components/parameters/cond'
+      responses:
+        '200':
+          description: Returns array of barcodes
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  # not using the defined schema for sample_barcode as it is
+                  # readOnly
+                  type: string
+
 components:
   parameters:
     # path parameters
@@ -1665,6 +1697,13 @@ components:
       schema:
         $ref: '#/components/schemas/activation_code'
       required: true
+    cond:
+      name: cond
+      in: query
+      description: sql query where clause
+      schema:
+        $ref: '#/components/schemas/cond'
+        required: true
     email:
       name: email
       in: query
@@ -2315,6 +2354,9 @@ components:
     include_private:
       type: boolean
       default: false
+
+    cond:
+      type: string
 
   examples:
     human_adult_source:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1604,12 +1604,15 @@ paths:
                 type: array
 
   '/admin/barcode_query':
-    get:
+    post:
       operationId: microsetta_private_api.admin.admin_impl.barcode_query
       tags:
         - Admin
-      parameters:
-        - $ref: '#/components/parameters/cond'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
       responses:
         '200':
           description: Returns array of barcodes
@@ -1697,13 +1700,6 @@ components:
       schema:
         $ref: '#/components/schemas/activation_code'
       required: true
-    cond:
-      name: cond
-      in: query
-      description: sql query where clause
-      schema:
-        $ref: '#/components/schemas/cond'
-        required: true
     email:
       name: email
       in: query
@@ -2354,9 +2350,6 @@ components:
     include_private:
       type: boolean
       default: false
-
-    cond:
-      type: string
 
   examples:
     human_adult_source:

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1107,12 +1107,14 @@ class AdminRepo(BaseRepo):
                         "LEFT JOIN barcodes.barcode_scans "
                         "USING (barcode) "
                         "LEFT JOIN ( "
-                        "SELECT barcode, max(scan_timestamp) AS scan_timestamp "
+                        "SELECT barcode, max(scan_timestamp) "
+                        "AS scan_timestamp "
                         "FROM barcodes.barcode_scans "
                         "GROUP BY barcode "
                         ") AS latest_scan "
                         "ON barcode_scans.barcode = latest_scan.barcode "
-                        "AND barcode_scans.scan_timestamp = latest_scan.scan_timestamp "
+                        "AND barcode_scans.scan_timestamp = "
+                        "latest_scan.scan_timestamp "
                         "WHERE " + sql_cond)
             return [r[0] for r in cur.fetchall()]
 

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1100,12 +1100,15 @@ class AdminRepo(BaseRepo):
 
     def search_barcode(self, sql_cond, cond_params):
         # Security Note:
-        # Even with sql queries correctly escaped, exposing a conditional query oracle
-        # with unlimited queries grants full read access to all tables joined within
-        # the query
-        # That is, administrator users searching with this method can reconstruct
+        # Even with sql queries correctly escaped,
+        # exposing a conditional query oracle
+        # with unlimited queries grants full read access
+        # to all tables joined within the query
+        # That is, administrator users searching with
+        # this method can reconstruct
         # project_barcode, ag_kit_barcodes and barcode_scans
-        # given enough queries, including columns that are not returned by the select
+        # given enough queries, including columns
+        # that are not returned by the select
         with self._transaction.cursor() as cur:
             cur.execute(
                 sql.SQL(

--- a/microsetta_private_api/util/query_builder_to_sql.py
+++ b/microsetta_private_api/util/query_builder_to_sql.py
@@ -1,0 +1,83 @@
+# Take model objects from the jquery query builder
+# and convert them into escaped sql where clauses
+
+from psycopg2 import sql
+from microsetta_private_api.exceptions import RepoException
+
+# If we ever implement remaining operators, be sure to
+# check that parameterized arguments are generated in
+# the correct order
+supported_operators = {
+    'equal': '=',
+    'not_equal': '!=',
+    # in,
+    # not_in,
+    'less': "<",
+    'less_or_equal': "<=",
+    'greater': ">",
+    'greater_or_equal': ">=",
+    # between,
+    # not_between,
+    # begins_with,
+    # not_begins_with,
+    # contains,
+    # not_contains,
+    # ends_with,
+    # not_ends_with,
+    # is_empty,
+    # is_not_empty,
+    # is_null,
+    # is_not_null,
+}
+
+
+def build_condition(top_level_obj):
+    def build_condition_helper_group(root_obj, out_values, is_top_level=False):
+        condition = root_obj['condition']
+        rules = root_obj['rules']
+
+        if condition == 'AND':
+            join_str = " and "
+        elif condition == 'OR':
+            join_str = " or "
+        else:
+            raise RepoException("Unknown condition: " + str(condition))
+
+        cond = sql.SQL(join_str)\
+            .join([build_condition_helper(x, out_values) for x in rules])
+        if not is_top_level:
+            cond = sql.SQL('({cond})').format(cond=cond)
+        return cond
+
+    def build_condition_helper_rule(root_obj, out_values):
+        id = root_obj['id']
+        field = root_obj['field']
+        type = root_obj['type']
+        input = root_obj['input']
+        operator = root_obj['operator']
+        value = root_obj['value']
+
+        if operator not in supported_operators:
+            raise RepoException("Unsupported query operator: " + str(operator))
+        cond = "{id} " + supported_operators[operator] + " {value}"
+
+        out_values.append(value)
+        return sql.SQL(cond).format(id=sql.Identifier(id), value=sql.Placeholder())
+
+    def build_condition_helper(root_obj, out_values, is_top_level=False):
+        if "condition" in root_obj:
+            return build_condition_helper_group(
+                root_obj,
+                out_values,
+                is_top_level=is_top_level)
+        else:
+            return build_condition_helper_rule(root_obj, out_values)
+
+    valid = top_level_obj['valid']
+
+    if not valid:
+        raise RepoException("Query is invalid")
+
+    out_values = []
+
+    return build_condition_helper(top_level_obj, out_values, is_top_level=True), out_values

--- a/microsetta_private_api/util/query_builder_to_sql.py
+++ b/microsetta_private_api/util/query_builder_to_sql.py
@@ -51,9 +51,9 @@ def build_condition(top_level_obj):
 
     def build_condition_helper_rule(root_obj, out_values):
         id = root_obj['id']
-        field = root_obj['field']
-        type = root_obj['type']
-        input = root_obj['input']
+        # field = root_obj['field']
+        # type = root_obj['type']
+        # input = root_obj['input']
         operator = root_obj['operator']
         value = root_obj['value']
 
@@ -62,7 +62,9 @@ def build_condition(top_level_obj):
         cond = "{id} " + supported_operators[operator] + " {value}"
 
         out_values.append(value)
-        return sql.SQL(cond).format(id=sql.Identifier(id), value=sql.Placeholder())
+        return sql.SQL(cond).format(
+            id=sql.Identifier(id),
+            value=sql.Placeholder())
 
     def build_condition_helper(root_obj, out_values, is_top_level=False):
         if "condition" in root_obj:
@@ -80,4 +82,7 @@ def build_condition(top_level_obj):
 
     out_values = []
 
-    return build_condition_helper(top_level_obj, out_values, is_top_level=True), out_values
+    return build_condition_helper(
+        top_level_obj,
+        out_values,
+        is_top_level=True), out_values

--- a/microsetta_private_api/util/tests/test_query_builder_to_sql.py
+++ b/microsetta_private_api/util/tests/test_query_builder_to_sql.py
@@ -1,0 +1,181 @@
+from microsetta_private_api.util.query_builder_to_sql import build_condition
+import unittest
+import json
+from microsetta_private_api.repo.transaction import Transaction
+
+
+class EmailTests(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def tearDown(self):
+        pass
+
+    def test_parameterized_sql(self):
+        query_builder_example = json.loads(
+            """
+            {
+              "condition": "AND",
+              "rules": [
+                {
+                  "id": "price",
+                  "field": "price",
+                  "type": "double",
+                  "input": "number",
+                  "operator": "less",
+                  "value": 10.25
+                },
+                {
+                  "condition": "OR",
+                  "rules": [
+                    {
+                      "id": "category",
+                      "field": "category",
+                      "type": "integer",
+                      "input": "select",
+                      "operator": "equal",
+                      "value": 2
+                    },
+                    {
+                      "id": "category",
+                      "field": "category",
+                      "type": "integer",
+                      "input": "select",
+                      "operator": "equal",
+                      "value": 1
+                    }
+                  ]
+                }
+              ],
+              "valid": true
+            }
+            """)
+
+        condition, params = build_condition(query_builder_example)
+        with Transaction() as t:
+            self.assertEqual(
+                condition.as_string(t.cursor()),
+                '"price" < %s and ("category" = %s or "category" = %s)'
+            )
+            self.assertListEqual(
+                params,
+                [10.25, 2, 1]
+            )
+            t.rollback()
+
+    def test_many_groups(self):
+        query_builder_example = json.loads(
+            """
+            {
+              "condition": "AND",
+              "rules": [
+                {
+                  "id": "price",
+                  "field": "price",
+                  "type": "double",
+                  "input": "number",
+                  "operator": "less",
+                  "value": 10.25
+                },
+                {
+                  "condition": "OR",
+                  "rules": [
+                    {
+                      "id": "category",
+                      "field": "category",
+                      "type": "integer",
+                      "input": "select",
+                      "operator": "equal",
+                      "value": 2
+                    },
+                    {
+                      "id": "category",
+                      "field": "category",
+                      "type": "integer",
+                      "input": "select",
+                      "operator": "equal",
+                      "value": 1
+                    },
+                    {
+                      "condition": "AND",
+                      "rules": [
+                        {
+                          "id": "name",
+                          "field": "name",
+                          "type": "string",
+                          "input": "text",
+                          "operator": "equal",
+                          "value": "Foobar"
+                        }
+                      ]
+                    },
+                    {
+                      "condition": "AND",
+                      "rules": [
+                        {
+                          "id": "in_stock",
+                          "field": "in_stock",
+                          "type": "integer",
+                          "input": "radio",
+                          "operator": "equal",
+                          "value": 1
+                        },
+                        {
+                          "id": "category",
+                          "field": "category",
+                          "type": "integer",
+                          "input": "select",
+                          "operator": "equal",
+                          "value": 1
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ],
+              "valid": true
+            }
+            """)
+
+        condition, params = build_condition(query_builder_example)
+        with Transaction() as t:
+            self.assertEqual(
+                condition.as_string(t.cursor()),
+                '"price" < %s and ("category" = %s or "category" = %s or ("name" = %s) or ("in_stock" = %s and "category" = %s))'  # noqa
+            )
+            self.assertListEqual(
+                params,
+                [10.25, 2, 1, "Foobar", 1, 1]
+            )
+            t.rollback()
+
+    def test_sql_injection(self):
+        query_builder_example = json.loads(
+            """
+            {
+              "condition": "AND",
+              "rules": [
+                {
+                  "id": "1\\"=\\"1\\" or \\"name",
+                  "field": "name",
+                  "type": "string",
+                  "input": "text",
+                  "operator": "equal",
+                  "value": "bobby\\" or 1=1\\"\\\\; DROP TABLES;"
+                }
+              ],
+              "valid": true
+            }
+            """)
+
+        condition, params = build_condition(query_builder_example)
+        with Transaction() as t:
+            self.assertEqual(
+                condition.as_string(t.cursor()),
+                '"1""=""1"" or ""name" = %s'
+            )
+            self.assertListEqual(
+                params,
+                ['bobby" or 1=1"\\; DROP TABLES;']
+            )
+            t.rollback()

--- a/microsetta_private_api/util/tests/test_query_builder_to_sql.py
+++ b/microsetta_private_api/util/tests/test_query_builder_to_sql.py
@@ -4,7 +4,7 @@ import json
 from microsetta_private_api.repo.transaction import Transaction
 
 
-class EmailTests(unittest.TestCase):
+class QueryBuilderToSqlTests(unittest.TestCase):
     def setUp(self):
         pass
 


### PR DESCRIPTION
This is the private api side of using jquery's querybuilder to let admin users pick barcode search criteria.  

This side takes the where clause from the user as is, which is a huge red flag for sql injection.  May be worth asking how George handled this on the public api side, as taking in the full json query object and parsing it into sql in python might be safer (but will require some extra libraries it looks like).  

Depending on our threat model, this may or may not be an issue-
  Queries are only allowed to be performed by admin users (and an adversary achieving admin access generally grants substantial access to the database anyway)
  Transactions are rolled back, so an admin user shouldn't be able to cause lasting damage by mistake
  Queries are limited to the where clause of specific tables (assuming they can't escape out, which I can't guarantee)
  The only usage of the route comes from microsetta-interface where all user data is correctly escaped in the generation of the where clause.  
