### PR TITLE
dependency change broke conexxion.

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -1,5 +1,6 @@
 openapi-spec-validator < 0.2.10
 connexion[swagger-ui] < 2.7.1
+jsonschema < 4.0.0
 pyjwt[crypto]
 pytest
 pytest-cov


### PR DESCRIPTION
types_msg was removed by jsonschema in >= 4.0.0
- https://github.com/Julian/jsonschema/commit/00031cb043763842266877923552e40f0c8f36b5

this triggers a failure in connexxion valiation which uses that method.
Since the 3.x series works, we'll pin < 4.0.0