### PR TITLE
Migrate barcode

### DIFF
--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -118,18 +118,12 @@ class SampleRepo(BaseRepo):
             survey_ids = tuple([r[0] for r in cur.fetchall()])
 
             if len(survey_ids) > 0:
-                # if this was a previously assigned sample...
-                # remove stale relations
+                # if this was a previously assigned sample, then remove any
+                # stale relations
                 cur.execute("""DELETE FROM ag.source_barcodes_surveys
                                WHERE barcode=%s
                                    AND survey_id IN %s""",
                             (barcode, survey_ids))
-
-                # update any vioscreen associations to reflect the source
-                cur.execute("""UPDATE ag.vioscreen_registry
-                               SET source_id=%s
-                               WHERE sample_id=%s""",
-                            (source_id, sample_id))
 
             # collect new survey associations if they exist
             cur.execute("""SELECT survey_id
@@ -150,6 +144,12 @@ class SampleRepo(BaseRepo):
                                (barcode, survey_id)
                                VALUES (%s, %s)""",
                             updates)
+
+            # update any vioscreen associations to reflect the source
+            cur.execute("""UPDATE ag.vioscreen_registry
+                           SET source_id=%s
+                           WHERE sample_id=%s""",
+                        (source_id, sample_id))
 
     def _get_sample_barcode_from_id(self, sample_id):
         """Obtain a barcode from a ag.ag_kit_barcode_id"""

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -146,10 +146,58 @@ class SampleRepo(BaseRepo):
                             updates)
 
             # update any vioscreen associations to reflect the source
+            # and the account
+            cur.execute("""SELECT account_id
+                           FROM ag.source
+                           WHERE id=%s""",
+                        (source_id, ))
+            account_id = cur.fetchone()
             cur.execute("""UPDATE ag.vioscreen_registry
-                           SET source_id=%s
+                           SET source_id=%s, account_id=%s
                            WHERE sample_id=%s""",
-                        (source_id, sample_id))
+                        (source_id, account_id, sample_id))
+
+    def migrate_sample(self, sample_id, source_id_src, source_id_dst,
+                       areyousure=False):
+        """Migrate a sample among sources
+
+        WARNING !!!
+
+        This is NOT intended for general use. This is an
+        administrative method for correcting unusual circumstances, and the
+        person issuing this function call knows what they are doing.
+
+        WARNING !!!
+        """
+        if not areyousure:
+            raise RepoException("You aren't sure you want to do this")
+
+        if source_id_src == source_id_dst:
+            # nothing to do
+            return
+
+        with self._transaction.cursor() as cur:
+            # verify the destination source exists
+            cur.execute("SELECT id FROM ag.source where id=%s",
+                        (source_id_dst, ))
+            res = cur.fetchall()
+            if len(res) != 1:
+                raise RepoException(f"source ({source_id_dst}) does not exist")
+
+            # verify the sample is currently associated with source_id_src
+            cur.execute("""SELECT ag_kit_barcode_id
+                           FROM ag.ag_kit_barcodes
+                           WHERE source_id=%s
+                               AND ag_kit_barcode_id=%s""",
+                        (source_id_src, sample_id))
+            res = cur.fetchall()
+            if len(res) != 1:
+                raise RepoException(f"{len(res)} entries associated with "
+                                    f"source ({source_id_src}) and sample "
+                                    f"({sample_id})")
+
+            self._update_sample_association(sample_id, source_id_dst,
+                                            override_locked=True)
 
     def _get_sample_barcode_from_id(self, sample_id):
         """Obtain a barcode from a ag.ag_kit_barcode_id"""

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -107,13 +107,49 @@ class SampleRepo(BaseRepo):
                 raise RepoException(
                     "Sample association locked: Sample already received")
 
-            cur.execute("UPDATE "
-                        "ag_kit_barcodes "
-                        "SET "
-                        "source_id = %s "
-                        "WHERE "
-                        "ag_kit_barcode_id = %s",
+            barcode = existing_sample.barcode
+
+            # collect old survey associations if they exist
+            cur.execute("""SELECT survey_id
+                           FROM ag.ag_login_surveys
+                           JOIN ag.ag_kit_barcodes USING (source_id)
+                           WHERE ag_kit_barcode_id=%s""",
+                        (sample_id, ))
+            survey_ids = tuple([r[0] for r in cur.fetchall()])
+
+            if len(survey_ids) > 0:
+                # if this was a previously assigned sample...
+                # remove stale relations
+                cur.execute("""DELETE FROM ag.source_barcodes_surveys
+                               WHERE barcode=%s
+                                   AND survey_id IN %s""",
+                            (barcode, survey_ids))
+
+                # update any vioscreen associations to reflect the source
+                cur.execute("""UPDATE ag.vioscreen_registry
+                               SET source_id=%s
+                               WHERE sample_id=%s""",
+                            (source_id, sample_id))
+
+            # collect new survey associations if they exist
+            cur.execute("""SELECT survey_id
+                           FROM ag.ag_login_surveys
+                           WHERE source_id=%s""",
+                        (source_id, ))
+            survey_ids = [r[0] for r in cur.fetchall()]
+
+            # set the barcode source association
+            cur.execute("""UPDATE ag_kit_barcodes
+                           SET source_id = %s
+                           WHERE ag_kit_barcode_id = %s""",
                         (source_id, sample_id))
+
+            # set barcode survey associations
+            updates = [(barcode, sid) for sid in survey_ids]
+            cur.executemany("""INSERT INTO ag.source_barcodes_surveys
+                               (barcode, survey_id)
+                               VALUES (%s, %s)""",
+                            updates)
 
     def _get_sample_barcode_from_id(self, sample_id):
         """Obtain a barcode from a ag.ag_kit_barcode_id"""

--- a/microsetta_private_api/repo/survey_answers_repo.py
+++ b/microsetta_private_api/repo/survey_answers_repo.py
@@ -296,6 +296,9 @@ class SurveyAnswersRepo(BaseRepo):
             cur.execute("DELETE FROM survey_answers_other WHERE "
                         "survey_id = %s",
                         (survey_id,))
+            cur.execute("DELETE FROM source_barcodes_surveys WHERE "
+                        "survey_id = %s",
+                        (survey_id,))
             cur.execute("DELETE FROM ag_login_surveys WHERE "
                         "ag_login_id = %s AND survey_id = %s",
                         (acct_id, survey_id))

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -1,0 +1,71 @@
+import unittest
+from microsetta_private_api.repo.sample_repo import SampleRepo
+from microsetta_private_api.repo.transaction import Transaction
+
+
+class SampleTests(unittest.TestCase):
+    def _get_source_from_sample(self, t, sample_id):
+        cur = t.cursor()
+        cur.execute("""SELECT account_id, source_id
+                       FROM ag.ag_kit_barcodes
+                       JOIN ag.source ON source_id=source.id
+                       WHERE ag_kit_barcode_id=%s""",
+                    (sample_id, ))
+        return cur.fetchone()
+
+    def _sample_in_source(self, source_samples, sample_id):
+        found = False
+        for sample in source_samples:
+            if sample.id == sample_id:
+                found = True
+                break
+        return found
+
+    def test_migrate_sample(self):
+        # uuids differ in second group
+        samp1 = 'd8592c74-85f0-2135-e040-8a80115d6401'  # 000001766
+        samp2 = 'ceaa6fd6-0861-4335-aa35-da1857bd5294'  # 000067789
+
+        with Transaction() as t:
+            acct1, src1 = self._get_source_from_sample(t, samp1)
+            acct2, src2 = self._get_source_from_sample(t, samp2)
+
+            sr = SampleRepo(t)
+
+            # get original source associations
+            src1_samples = sr.get_samples_by_source(acct1, src1)
+            src2_samples = sr.get_samples_by_source(acct2, src2)
+
+            # verify samples are part of the original source
+            self.assertTrue(self._sample_in_source(src1_samples, samp1))
+            self.assertTrue(self._sample_in_source(src2_samples, samp2))
+
+            # swap associations
+            sr._update_sample_association(samp1, src2, True)
+            sr._update_sample_association(samp2, src1, True)
+
+            # get new samples by source
+            src1_samples = sr.get_samples_by_source(acct1, src1)
+            src2_samples = sr.get_samples_by_source(acct2, src2)
+
+            # verify samples are part of the new source
+            self.assertTrue(self._sample_in_source(src1_samples, samp2))
+            self.assertTrue(self._sample_in_source(src2_samples, samp1))
+
+            # verify samples are not part of the original source
+            self.assertFalse(self._sample_in_source(src1_samples, samp1))
+            self.assertFalse(self._sample_in_source(src2_samples, samp2))
+
+            # fix associations
+            sr._update_sample_association(samp1, src1, True)
+            sr._update_sample_association(samp2, src2, True)
+
+            # ...and verify assocations are fixed
+            src1_samples = sr.get_samples_by_source(acct1, src1)
+            src2_samples = sr.get_samples_by_source(acct2, src2)
+            self.assertTrue(self._sample_in_source(src1_samples, samp1))
+            self.assertTrue(self._sample_in_source(src2_samples, samp2))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -22,7 +22,6 @@ class SampleTests(unittest.TestCase):
         return found
 
     def test_migrate_sample(self):
-        # uuids differ in second group
         samp1 = 'd8592c74-85f0-2135-e040-8a80115d6401'  # 000001766
         samp2 = 'ceaa6fd6-0861-4335-aa35-da1857bd5294'  # 000067789
 


### PR DESCRIPTION
We have a need to migrate barcodes from one source to another on an existing project. 

These modifications update the internal references, and also account for the `source_barcodes_surveys` table 