### PR TITLE
Use integer validation for height and weight

### DIFF
--- a/microsetta_private_api/api/_survey.py
+++ b/microsetta_private_api/api/_survey.py
@@ -102,14 +102,14 @@ def read_survey_template(account_id, source_id, survey_template_id,
             "108": {
                 # Height
                 "inputType": "number",
-                "validator": "number",
+                "validator": "integer",
                 "min": 0,
                 "max": None
             },
             "113": {
                 # Weight
                 "inputType": "number",
-                "validator": "number",
+                "validator": "integer",
                 "min": 0,
                 "max": None
             }


### PR DESCRIPTION
These changes use integer rather than numeric validation. This is important as it mitigates people assuming this means meters, entering "1.5", when they really mean "150".