### PR TITLE
DO NOT MERGE: mktime bug minimal reproducible example

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,6 +31,7 @@ jobs:
   #        # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
   #        - 5432/tcp
   build:
+    runs-on: ubuntu-latest
     steps:
     # Downloads a copy of the code in your repository before running CI tests
     - name: Check out repository code

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -52,14 +52,14 @@ jobs:
         FUNDRAZR_TEST_ORG: "${{ secrets.FUNDRAZR_TEST_ORG }}"
       run: |
         # pull out the port so we can modify the configuration file easily
-        pgport=${{ job.services.postgres.ports[5432] }}
-        sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py
-        
-        # use hashes to avoid delimiter overlap with a URL
-        python set_github_secrets.py
+        #pgport=${{ job.services.postgres.ports[5432] }}
+        #sed -i "s/self.port = 5432/self.port = $pgport/" microsetta_private_api/config_manager.py
+        #
+        ## use hashes to avoid delimiter overlap with a URL
+        #python set_github_secrets.py
 
-        # PGPASSWORD is read by pg_restore, which is called by the build_db process. 
-        export PGPASSWORD=postgres
+        ## PGPASSWORD is read by pg_restore, which is called by the build_db process. 
+        #export PGPASSWORD=postgres
         
         conda create --yes -n test-microsetta-private python=3.9
         conda activate test-microsetta-private
@@ -68,7 +68,8 @@ jobs:
         pip install -e . --no-deps 
         
         # establish database state
-        python microsetta_private_api/LEGACY/build_db.py
+        #python microsetta_private_api/LEGACY/build_db.py
+        python tzbroken.py
 
     - name: Test
       shell: bash -l {0}

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,7 +31,7 @@ jobs:
   #        # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
   #        - 5432/tcp
   build:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
     # Downloads a copy of the code in your repository before running CI tests
     - name: Check out repository code

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -7,30 +7,30 @@ on:
     
 jobs:
   # derived from https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml
-  postgres-runner-job:
-    runs-on: ubuntu-latest
-      
-    # Service containers to run with `runner-job`
-    services:
-      # Label used to access the service container
-      postgres:
-        # Docker Hub image
-        image: postgres:13.4
-        env:
-          POSTGRES_DB: ag_test  
-          POSTGRES_USER: postgres  
-          POSTGRES_PASSWORD: postgres
-          
-        # Set health checks to wait until postgres has started
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
-          - 5432/tcp
-
+  #postgres-runner-job:
+  #  runs-on: ubuntu-latest
+  #    
+  #  # Service containers to run with `runner-job`
+  #  services:
+  #    # Label used to access the service container
+  #    postgres:
+  #      # Docker Hub image
+  #      image: postgres:13.4
+  #      env:
+  #        POSTGRES_DB: ag_test  
+  #        POSTGRES_USER: postgres  
+  #        POSTGRES_PASSWORD: postgres
+  #        
+  #      # Set health checks to wait until postgres has started
+  #      options: >-
+  #        --health-cmd pg_isready
+  #        --health-interval 10s
+  #        --health-timeout 5s
+  #        --health-retries 5
+  #      ports:
+  #        # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
+  #        - 5432/tcp
+  build:
     steps:
     # Downloads a copy of the code in your repository before running CI tests
     - name: Check out repository code

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -70,6 +70,8 @@ jobs:
         
         # establish database state
         #python microsetta_private_api/LEGACY/build_db.py
+        cat tzbroken.py
+
         python tzbroken.py
 
     - name: Test

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,7 +31,7 @@ jobs:
   #        # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
   #        - 5432/tcp
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     # Downloads a copy of the code in your repository before running CI tests
     - name: Check out repository code
@@ -71,7 +71,7 @@ jobs:
         # establish database state
         #python microsetta_private_api/LEGACY/build_db.py
         cat tzbroken.py
-
+        sudo systemsetup -gettimezone
         python tzbroken.py
 
     - name: Test

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,7 +31,7 @@ jobs:
   #        # based on https://github.com/actions/example-services/blob/master/.github/workflows/postgres-service.yml#L44-L72
   #        - 5432/tcp
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
     # Downloads a copy of the code in your repository before running CI tests
     - name: Check out repository code

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -64,8 +64,8 @@ jobs:
         conda create --yes -n test-microsetta-private python=3.9
         conda activate test-microsetta-private
         conda install --yes --file ci/conda_requirements.txt
-        pip install -r ci/pip_requirements.txt
-        pip install -e . --no-deps 
+        #pip install -r ci/pip_requirements.txt
+        #pip install -e . --no-deps 
         
         # establish database state
         #python microsetta_private_api/LEGACY/build_db.py

--- a/ci/conda_requirements.txt
+++ b/ci/conda_requirements.txt
@@ -1,6 +1,1 @@
-flake8
-psycopg2
-flask
-natsort
-pycryptodome
-pandas
+pytz

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -4,14 +4,9 @@ import pytz
 x = pytz.timezone('US/Pacific')
 y = datetime.datetime(2017,5,26,15,30,16)
 z = x.localize(y)
-try:
-    print(time.mktime(z.timetuple()))
-except Exception as e:
-    print(repr(e))
 
-try:
-    print(time.mktime(y.timetuple()))
-except Exception as e:
-    print(repr(e))
+# without pytz
+print(time.mktime(y.timetuple()))
 
-raise ValueError("trigger build failure")
+# with pytz
+print(time.mktime(z.timetuple()))

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -1,0 +1,7 @@
+import datetime
+import time
+import pytz
+x = pytz.timezone('US/Pacific')
+y = datetime.datetime(2017,5,26,15,30,16)
+z = x.localize(y)
+print(time.mktime(z.timetuple()))

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -6,13 +6,13 @@ y = datetime.datetime(2017,5,26,15,30,16)
 z = x.localize(y)
 
 # without pytz
-print(time.mktime(y.timetuple()))
+#print(time.mktime(y.timetuple()))
 
-print(y.timetuple())
-print(z.timetuple())
+#print(y.timetuple())
+#print(z.timetuple())
 
 # recommended test from stub42
 print(time.mktime((2017,5,26,15,30,16,4,146,1)))
 
 # with pytz
-print(time.mktime(z.timetuple()))
+#print(time.mktime(z.timetuple()))

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -8,5 +8,11 @@ z = x.localize(y)
 # without pytz
 print(time.mktime(y.timetuple()))
 
+print(y.timetuple())
+print(z.timetuple())
+
+# recommended test from stub42
+print(time.mktime((2017,5,26,15,30,16,4,146,1)))
+
 # with pytz
 print(time.mktime(z.timetuple()))

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -1,18 +1,2 @@
-import datetime
 import time
-import pytz
-x = pytz.timezone('US/Pacific')
-y = datetime.datetime(2017,5,26,15,30,16)
-z = x.localize(y)
-
-# without pytz
-#print(time.mktime(y.timetuple()))
-
-#print(y.timetuple())
-#print(z.timetuple())
-
-# recommended test from stub42
 print(time.mktime((2017,5,26,15,30,16,4,146,1)))
-
-# with pytz
-#print(time.mktime(z.timetuple()))

--- a/tzbroken.py
+++ b/tzbroken.py
@@ -4,4 +4,14 @@ import pytz
 x = pytz.timezone('US/Pacific')
 y = datetime.datetime(2017,5,26,15,30,16)
 z = x.localize(y)
-print(time.mktime(z.timetuple()))
+try:
+    print(time.mktime(z.timetuple()))
+except Exception as e:
+    print(repr(e))
+
+try:
+    print(time.mktime(y.timetuple()))
+except Exception as e:
+    print(repr(e))
+
+raise ValueError("trigger build failure")


### PR DESCRIPTION
The following changes provide a minimal reproducible example of what appears to be unexpected behavior, where the script `tzbroken.py` throws an `OverflowError`. The same script, when executed using python 3.9 and the same pytz library version on OS X 11.6.1, Ubuntu 18.04 and Centos 7.9, does not produce the exception. So far the issue appears isolated to github action instances. 