### PR TITLE
Edge case on a few human samples

### DIFF
--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -337,7 +337,16 @@ def _to_pandas_series(metadata, multiselect_map):
 
     if source_type == 'human':
         sample_type = sample_detail.site
-        sample_invariants = HUMAN_SITE_INVARIANTS[sample_type]
+        sample_invariants = HUMAN_SITE_INVARIANTS.get(sample_type)
+
+        # there are a handful of samples that exhibit an unusual state
+        # of reporting as human, but a site sampled as Fur. I believe
+        # these are tests, but regardless, resolution is not clear.
+        # let's catch unexpected, and move forward so we don't bomb on
+        # a KeyError
+        if sample_invariants is None:
+            raise RepoException("Unexpected sample type: %s" % sample_type)
+
     elif source_type == 'animal':
         sample_type = sample_detail.site
         sample_invariants = {}

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -271,6 +271,17 @@ class MetadataUtilTests(unittest.TestCase):
         obs = _to_pandas_series(data, ms_map)
         pdt.assert_series_equal(obs, exp.loc[obs.index])
 
+    def test_to_pandsa_series_non_human_site(self):
+        data = self.raw_sample_1
+        data['sample'].d['site'] = 'Fur'
+
+        templates = {10: self.fake_survey_template1,
+                     1: self.fake_survey_template2}
+
+        ms_map = _construct_multiselect_map(templates)
+        with self.assertRaises(RepoException):
+            _to_pandas_series(data, ms_map)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
A few "human" samples report as having sampled "Fur", which *probably* is test data that leaked into production from what I spot checked. Regardless, it's not a bad thing to have this check in place