### PR TITLE
Allow for replacing verify_jwt

### DIFF
--- a/microsetta_private_api/api/__init__.py
+++ b/microsetta_private_api/api/__init__.py
@@ -1,6 +1,7 @@
 from ._account import (
     find_accounts_for_login, register_account, claim_legacy_acct,
-    read_account, update_account, check_email_match, verify_jwt,
+    read_account, update_account, check_email_match, _verify_jwt,
+    _verify_jwt_mock
 )
 from ._consent import (
     render_consent_doc,
@@ -39,6 +40,17 @@ from ._campaign import (
 from ._interested_user import (
     create_interested_user
 )
+
+from ..config_manager import SERVER_CONFIG
+
+
+verify_jwt = _verify_jwt
+if SERVER_CONFIG.get('disable_authentication', False):
+    import sys
+    print("WARNING: jwt authentication disabled",
+          file=sys.stderr, flush=True)
+    verify_jwt = _verify_jwt_mock
+
 
 __all__ = [
     'find_accounts_for_login',

--- a/microsetta_private_api/api/_account.py
+++ b/microsetta_private_api/api/_account.py
@@ -15,6 +15,7 @@ from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.activation_repo import ActivationRepo
 from microsetta_private_api.repo.kit_repo import KitRepo
 from microsetta_private_api.repo.transaction import Transaction
+from microsetta_private_api.config_manager import SERVER_CONFIG
 
 
 def find_accounts_for_login(token_info):
@@ -161,7 +162,35 @@ JWT_SCHEMES = (
 )
 
 
-def verify_jwt(token):
+def _verify_jwt_mock(token):
+    assert SERVER_CONFIG.get('disable_authentication', False)
+
+    ###########################################################################
+    # WARNING: use of this mock DISABLES verification of the JWT              #
+    #                                                                         #
+    # This method is intended only for use during integration testing         #
+    ###########################################################################
+    email_verification_key = 'email_verified'
+
+    token_info = None
+    try:
+        token_info = jwt.decode(token, options={"verify_signature": False})
+    except InvalidTokenError:
+        pass
+
+    # if we can't get out the encoded email, then we can't do anything
+    # interesting anyway
+    if token_info is None:
+        raise Unauthorized(INVALID_TOKEN_MSG)
+
+    # allow the test harness to explore email verification
+    if token_info[email_verification_key] is not True:
+        raise Forbidden("Email is not verified")
+
+    return token_info
+
+
+def _verify_jwt(token):
     email_verification_key = 'email_verified'
 
     token_info = None


### PR DESCRIPTION
Provide a means to substitute `verify_jwt` as to facilitate integration testing between -interface and -private-api