### PR TITLE
Expire subjects

### DIFF
--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -495,6 +495,8 @@ class IntegrationTests(TestCase):
         )
         check_response(resp, 404)
 
+    @skipIf(SERVER_CONFIG['myfoodrepo_url'] in ('', 'mfr_url_placeholder'),
+            "MFR secrets not provided")
     def test_bobo_takes_myfoodrepo_without_slots(self):
         bobo = self._bobo_to_claim_a_sample()
 

--- a/microsetta_private_api/server_config.json
+++ b/microsetta_private_api/server_config.json
@@ -33,6 +33,7 @@
   "myfoodrepo_key": "mfr_key_placeholder",
   "myfoodrepo_slots": 15,
   "myfoodrepo_study": "mfr_study_placeholder",
+  "myfoodrepo_participation_days": 8,
   "fundrazr_key": "fundrazr_api_placeholder",
   "fundrazr_url": "fundrazr_url_placeholder",
   "fundrazr_organization": "fundrazr_org_placeholder"

--- a/microsetta_private_api/util/myfoodrepo.py
+++ b/microsetta_private_api/util/myfoodrepo.py
@@ -1,3 +1,6 @@
+import datetime
+import pytz
+
 from microsetta_private_api.config_manager import SERVER_CONFIG
 from microsetta_private_api.client.myfoodrepo import MFRClient
 
@@ -8,10 +11,19 @@ def gen_survey_url(mfr_id):
 
 
 def create_subj():
+    # WARNING
+    # This creates a subject *remotely* but does not associate the
+    # ID with a source
+
     client = MFRClient(SERVER_CONFIG["myfoodrepo_study"])
+    participation_length = SERVER_CONFIG["myfoodrepo_participation_days"]
     cohort = client.default_cohort
 
-    # should we set the subject to expire after a given time period?
     subj = client.create_subj(cohort)
+    subj_id = subj.data.subject.key
 
-    return subj.data.subject.key
+    now = datetime.datetime.now(pytz.utc)
+    expire_at = now + datetime.timedelta(days=participation_length)
+    client.update_subj(cohort, subj_id, expire_at)
+
+    return subj_id

--- a/microsetta_private_api/util/tests/test_myfoodrepo.py
+++ b/microsetta_private_api/util/tests/test_myfoodrepo.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import skipIf
 from dateutil import parser
 import pytz
 import datetime
@@ -9,6 +10,8 @@ from microsetta_private_api.client.myfoodrepo import MFRClient
 
 
 class MyFoodRepoTests(unittest.TestCase):
+    @skipIf(SERVER_CONFIG['myfoodrepo_url'] in ('', 'mfr_url_placeholder'),
+            "MFR secrets not provided")
     def test_create_subj(self):
         client = MFRClient(SERVER_CONFIG["myfoodrepo_study"])
         exp_delta = SERVER_CONFIG["myfoodrepo_participation_days"]

--- a/microsetta_private_api/util/tests/test_myfoodrepo.py
+++ b/microsetta_private_api/util/tests/test_myfoodrepo.py
@@ -1,0 +1,31 @@
+import unittest
+from dateutil import parser
+import pytz
+import datetime
+
+from microsetta_private_api.config_manager import SERVER_CONFIG
+from microsetta_private_api.util.myfoodrepo import create_subj
+from microsetta_private_api.client.myfoodrepo import MFRClient
+
+
+class MyFoodRepoTests(unittest.TestCase):
+    def test_create_subj(self):
+        client = MFRClient(SERVER_CONFIG["myfoodrepo_study"])
+        exp_delta = SERVER_CONFIG["myfoodrepo_participation_days"]
+
+        subj_id = create_subj()
+
+        obs = client.read_subj(client.default_cohort, subj_id)
+
+        obs_date = obs.data.subject.expired_at
+        obs_date = parser.parse(obs_date)
+
+        now = datetime.datetime.now(pytz.utc)
+
+        # allow for a 1 minute time between when we set expiration and our test
+        self.assertEqual((obs_date - now).days, exp_delta - 1)
+        self.assertGreater((obs_date - now).seconds, 24 * 59 * 60)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds subject expiration at creation to limit their participation. Note that we set expiration at 8 days, but we will tell participants 7 days to allow a little bit of wiggle room.

I'll fix the broken CI tests in here once CI completes