### PR TITLE
Modified unittest to better handle floats

### DIFF
--- a/microsetta_private_api/repo/tests/test_account.py
+++ b/microsetta_private_api/repo/tests/test_account.py
@@ -112,8 +112,8 @@ class AccountTests(unittest.TestCase):
                             "WHERE id = %s",
                             (ACCT_ID_1,))
                 r = cur.fetchone()
-                self.assertEqual(r['latitude'], RESULT_LAT)
-                self.assertEqual(r['longitude'], RESULT_LONG)
+                self.assertAlmostEqual(r['latitude'], RESULT_LAT, 9)
+                self.assertAlmostEqual(r['longitude'], RESULT_LONG, 9)
                 self.assertTrue(r['address_verified'])
                 self.assertFalse(r['cannot_geocode'])
 


### PR DESCRIPTION
Changed use of assertEquals() to assertAlmostEquals().
Set comparison to nine decimal places, which should be good enough even
for lat/lons.