### PR TITLE
Metadata Survey Updates

### DIFF
--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -25,18 +25,18 @@ def init_celery(celery, app):
     # Set up "Celery Beat", events that run on a fixed time interval
     celery.conf.beat_schedule = {
         # Vioscreen tokens are good for an hour, refresh every 55 minutes
-        "refresh_vioscreen_token": {
-            "task": "microsetta_private_api.util.vioscreen.refresh_headers",
-            "schedule": 55 * 60
-        },
-        "update_vioscreen_sessions": {
-            "task": "microsetta_private_api.util.vioscreen.update_session_detail",  # noqa
-            "schedule": 60 * 60 * 24  # every 24 hours
-        },
-        "poll_daklapack_orders": {
-            "task": "microsetta_private_api.admin.daklapack_polling.poll_dak_orders",  # noqa
-            "schedule":  60 * 60 * 24  # every 24 hours
-        },
+        #"refresh_vioscreen_token": {
+        #    "task": "microsetta_private_api.util.vioscreen.refresh_headers",
+        #    "schedule": 55 * 60
+        #},
+        #"update_vioscreen_sessions": {
+        #    "task": "microsetta_private_api.util.vioscreen.update_session_detail",  # noqa
+        #    "schedule": 60 * 60 * 24  # every 24 hours
+        #},
+        #"poll_daklapack_orders": {
+        #    "task": "microsetta_private_api.admin.daklapack_polling.poll_dak_orders",  # noqa
+        #    "schedule":  60 * 60 * 24  # every 24 hours
+        #},
         "update_qiita_metadata": {
             "task": "microsetta_private_api.tasks.update_qiita_metadata",  # noqa
             "schedule":  60 * 60 * 24  # every 24 hours

--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -25,18 +25,18 @@ def init_celery(celery, app):
     # Set up "Celery Beat", events that run on a fixed time interval
     celery.conf.beat_schedule = {
         # Vioscreen tokens are good for an hour, refresh every 55 minutes
-        #"refresh_vioscreen_token": {
-        #    "task": "microsetta_private_api.util.vioscreen.refresh_headers",
-        #    "schedule": 55 * 60
-        #},
-        #"update_vioscreen_sessions": {
-        #    "task": "microsetta_private_api.util.vioscreen.update_session_detail",  # noqa
-        #    "schedule": 60 * 60 * 24  # every 24 hours
-        #},
-        #"poll_daklapack_orders": {
-        #    "task": "microsetta_private_api.admin.daklapack_polling.poll_dak_orders",  # noqa
-        #    "schedule":  60 * 60 * 24  # every 24 hours
-        #},
+        "refresh_vioscreen_token": {
+            "task": "microsetta_private_api.util.vioscreen.refresh_headers",
+            "schedule": 55 * 60
+        },
+        "update_vioscreen_sessions": {
+            "task": "microsetta_private_api.util.vioscreen.update_session_detail",  # noqa
+            "schedule": 60 * 60 * 24  # every 24 hours
+        },
+        "poll_daklapack_orders": {
+            "task": "microsetta_private_api.admin.daklapack_polling.poll_dak_orders",  # noqa
+            "schedule":  60 * 60 * 24  # every 24 hours
+        },
         "update_qiita_metadata": {
             "task": "microsetta_private_api.tasks.update_qiita_metadata",  # noqa
             "schedule":  60 * 60 * 24  # every 24 hours

--- a/microsetta_private_api/celery_worker.py
+++ b/microsetta_private_api/celery_worker.py
@@ -2,8 +2,10 @@ from microsetta_private_api.server import app
 from microsetta_private_api.celery_utils import celery, init_celery
 from microsetta_private_api.util.vioscreen import refresh_headers
 from microsetta_private_api.admin.daklapack_polling import poll_dak_orders
+from microsetta_private_api.tasks import update_qiita_metadata
 init_celery(celery, app.app)
 
 # Run any celery tasks that require initialization on worker start
-refresh_headers.delay()  # Initialize the vioscreen task with a token
-poll_dak_orders.delay()  # check for orders
+#refresh_headers.delay()  # Initialize the vioscreen task with a token
+#poll_dak_orders.delay()  # check for orders
+update_qiita_metadata.delay()

--- a/microsetta_private_api/celery_worker.py
+++ b/microsetta_private_api/celery_worker.py
@@ -6,6 +6,6 @@ from microsetta_private_api.tasks import update_qiita_metadata
 init_celery(celery, app.app)
 
 # Run any celery tasks that require initialization on worker start
-#refresh_headers.delay()  # Initialize the vioscreen task with a token
-#poll_dak_orders.delay()  # check for orders
-update_qiita_metadata.delay()
+refresh_headers.delay()  # Initialize the vioscreen task with a token
+poll_dak_orders.delay()  # check for orders
+update_qiita_metadata.delay()  # run Qiita metadata push

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -189,19 +189,26 @@ def _fetch_survey_template(template_id):
         observed, the survey responses should not be considered valid.
     """
     with Transaction() as t:
+        error = None
+
         survey_template_repo = SurveyTemplateRepo(t)
         info = survey_template_repo.get_survey_template_link_info(
             template_id)
 
         # For local surveys, we generate the json representing the survey
-        survey_template = survey_template_repo.get_survey_template(
-            template_id, "en_US")
-        survey_template_text = vue_adapter.to_vue_schema(survey_template)
+        try:
+            survey_template = survey_template_repo.get_survey_template(
+                template_id, "en_US")
+        except NotFound as e:
+            error = e
 
-        info = info.to_api(None, None)
-        info['survey_template_text'] = survey_template_text
+        if error is None:
+            survey_template_text = vue_adapter.to_vue_schema(survey_template)
 
-        return info, None
+            info = info.to_api(None, None)
+            info['survey_template_text'] = survey_template_text
+
+        return info, error
 
 
 def _to_pandas_dataframe(metadatas, survey_templates):

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -22,8 +22,10 @@ jsonify = json.dumps
 # ignore list.
 TEMPLATES_TO_IGNORE = {10001, 10002, 10003, 10004, None}
 
+# TODO 2022-10-03
 # Adding questions from Cooking Oils & Oxalate-rich Foods survey
-# to ignore list as they don't exist in Qiita
+# to ignore list as they don't exist in Qiita (OILS_*). We're blocked on
+# pushing them, pending an update to Qiita's API.
 EBI_REMOVE = ['ABOUT_YOURSELF_TEXT', 'ANTIBIOTIC_CONDITION',
               'ANTIBIOTIC_MED', 'PM_NAME', 'PM_EMAIL',
               'BIRTH_MONTH', 'CAT_CONTACT', 'CAT_LOCATION',
@@ -184,7 +186,7 @@ def _fetch_survey_template(template_id):
     -------
     dict
         The survey structure as returned from the private API
-    dict or None
+    string or None
         Any error information associated with the retreival. If an error is
         observed, the survey responses should not be considered valid.
     """
@@ -200,7 +202,7 @@ def _fetch_survey_template(template_id):
             survey_template = survey_template_repo.get_survey_template(
                 template_id, "en_US")
         except NotFound as e:
-            error = e
+            error = repr(e)
 
         if error is None:
             survey_template_text = vue_adapter.to_vue_schema(survey_template)

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -18,8 +18,12 @@ jsonify = json.dumps
 # the vioscreen survey currently cannot be fetched from the database
 # there seems to be some detached survey IDs -- see 000089779
 # that account has a long and unusual history though
-TEMPLATES_TO_IGNORE = {10001, None}
+# Adding the MyFoodRepo, Polyphenol FFQ, and Spain FFQs to the
+# ignore list.
+TEMPLATES_TO_IGNORE = {10001, 10002, 10003, 10004, None}
 
+# Adding questions from Cooking Oils & Oxalate-rich Foods survey
+# to ignore list as they don't exist in Qiita
 EBI_REMOVE = ['ABOUT_YOURSELF_TEXT', 'ANTIBIOTIC_CONDITION',
               'ANTIBIOTIC_MED', 'PM_NAME', 'PM_EMAIL',
               'BIRTH_MONTH', 'CAT_CONTACT', 'CAT_LOCATION',
@@ -37,7 +41,10 @@ EBI_REMOVE = ['ABOUT_YOURSELF_TEXT', 'ANTIBIOTIC_CONDITION',
               'COVID_SYMPTOMS_OTHER', 'FERMENTED_CONSUMED_OTHER',
               'FERMENTED_OTHER', 'FERMENTED_PRODUCE_COMMERCIAL_OTHER',
               'FERMENTED_PRODUCE_PERSONAL_OTHER',
-              'OTHER_ANIMALS_FREE_TEXT']
+              'OTHER_ANIMALS_FREE_TEXT', 'OILS_FREQUENCY_VEGETABLE',
+              'OILS_FREQUENCY_ANIMAL', 'OILS_FREQUENCY_OTHER',
+              'OILS_FREQUENCY_MARGARINE', 'OILS_FREQUENCY_OXALATE'
+              'OILS_FREQUENCY_SOY']
 
 
 def drop_private_columns(df):

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -177,9 +177,8 @@ class MetadataUtilTests(unittest.TestCase):
                'survey_template_version': '1.0'}
         survey, errors = _fetch_survey_template(10001)
 
-        # verify that we obtained data, but also that we returned an error
-        # this reflects a remote survey, for which we can't extract local data
-        self.assertEqual(survey, exp)
+        # verify that _fetch_survey_template returns an error, reflecting
+        # that it's a remote survey for which we can't extract local data
         self.assertNotEqual(errors, None)
 
     def test_drop_private_columns(self):

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -167,6 +167,23 @@ class MetadataUtilTests(unittest.TestCase):
         self.assertEqual(survey, exp)
         self.assertEqual(errors, None)
 
+    def test_fetch_survey_template_remote(self):
+        exp = {'survey_id': None,
+               'survey_status': None,
+               'survey_template_id': 10001,
+               'survey_template_title': 'Vioscreen Food Frequency Questionnaire',
+               'survey_template_type': 'remote',
+               'survey_template_version': '1.0'}
+        survey, errors = _fetch_survey_template(1)
+
+        # concern here is that this key exists, not its content
+        survey.pop('survey_template_text')
+
+        # verify that we obtained data, but also that we returned an error
+        # this reflects a remote survey, for which we can't extract local data
+        self.assertEqual(survey, exp)
+        self.assertNotEqual(errors, None)
+
     def test_drop_private_columns(self):
         df = pd.DataFrame([[1, 2, 3], [4, 5, 6]],
                           columns=['pM_foo', 'okay', 'ABOUT_yourSELF_TEXT'])

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -175,7 +175,7 @@ class MetadataUtilTests(unittest.TestCase):
                    'Vioscreen Food Frequency Questionnaire',
                'survey_template_type': 'remote',
                'survey_template_version': '1.0'}
-        survey, errors = _fetch_survey_template(1)
+        survey, errors = _fetch_survey_template(10001)
 
         # concern here is that this key exists, not its content
         survey.pop('survey_template_text')

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -177,9 +177,6 @@ class MetadataUtilTests(unittest.TestCase):
                'survey_template_version': '1.0'}
         survey, errors = _fetch_survey_template(10001)
 
-        # concern here is that this key exists, not its content
-        survey.pop('survey_template_text')
-
         # verify that we obtained data, but also that we returned an error
         # this reflects a remote survey, for which we can't extract local data
         self.assertEqual(survey, exp)

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -171,7 +171,8 @@ class MetadataUtilTests(unittest.TestCase):
         exp = {'survey_id': None,
                'survey_status': None,
                'survey_template_id': 10001,
-               'survey_template_title': 'Vioscreen Food Frequency Questionnaire',
+               'survey_template_title':
+                   'Vioscreen Food Frequency Questionnaire',
                'survey_template_type': 'remote',
                'survey_template_version': '1.0'}
         survey, errors = _fetch_survey_template(1)

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -168,13 +168,7 @@ class MetadataUtilTests(unittest.TestCase):
         self.assertEqual(errors, None)
 
     def test_fetch_survey_template_remote(self):
-        exp = {'survey_id': None,
-               'survey_status': None,
-               'survey_template_id': 10001,
-               'survey_template_title':
-                   'Vioscreen Food Frequency Questionnaire',
-               'survey_template_type': 'remote',
-               'survey_template_version': '1.0'}
+        # attempt to fetch info for Vioscreen survey
         survey, errors = _fetch_survey_template(10001)
 
         # verify that _fetch_survey_template returns an error, reflecting


### PR DESCRIPTION
Updating the Metadata repo to reflect recent survey changes:
1) Adding MyFoodRepo, the Polyphenol FFQ, and the Spain FFQ to the ignored survey templates, as they're external surveys and can't be retrieved from the database.
2) Adding all of the fields in the locally hosted Cooking Oils & Oxalate-rich Foods survey to the EBI_REMOVE constant, as they don't exist in Qiita.