### PR TITLE
API: add a method to obtain barcode -> vioscreen users

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -15,6 +15,7 @@ from microsetta_private_api.repo.event_log_repo import EventLogRepo
 from microsetta_private_api.repo.kit_repo import KitRepo
 from microsetta_private_api.repo.sample_repo import SampleRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
+from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
 from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.admin_repo import AdminRepo

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -841,3 +841,11 @@ def delete_account(account_id, token_info):
         t.commit()
 
     return None, 204
+
+
+def get_vioscreen_sample_to_user(token_info):
+    validate_admin_access(token_info)
+    with Transaction() as t:
+        st_repo = SurveyTemplateRepo(t)
+        data = st_repo.get_vioscreen_sample_to_user()
+    return jsonify(data), 200

--- a/microsetta_private_api/admin/tests/test_admin_api.py
+++ b/microsetta_private_api/admin/tests/test_admin_api.py
@@ -150,6 +150,16 @@ class AdminApiTests(TestCase):
         self.client.__exit__(None, None, None)
         teardown_test_data()
 
+    def test_vioscreen_samples_to_barcodes(self):
+        response = self.client.get(
+            '/api/admin/vioscreen/username_to_barcode',
+            headers=MOCK_HEADERS
+        )
+        self.assertEqual(200, response.status_code)
+        response_obj = json.loads(response.data)
+        self.assertEqual(response_obj['000031536'],
+                         'b98c5ac966b754ff')
+
     def _test_project_create_success(self, project_info):
         input_json = json.dumps(project_info)
 

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1128,6 +1128,26 @@ paths:
         '404':
           $ref: '#/components/responses/404NotFound'
 
+  '/admin/vioscreen/username_to_barcode':
+    get:
+      operationId: microsetta_private_api.admin.admin_impl.get_vioscreen_sample_to_user
+      tags:
+        - Vioscreen
+      summary: Obtain a mapping from Vioscreen username to associated barcode
+      description: Obtain a mapping from Vioscreen username to associated barcode
+      responses:
+        '200':
+          description: Successfully returned username mapping
+          content:
+            application/json:
+              schema:
+                type:
+                  object
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+
   '/vioscreen/dietaryscore/type/{score_type}/code/{score_code}':
     get:
       operationId: microsetta_private_api.api.get_vioscreen_dietary_scores_by_component

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -530,6 +530,15 @@ class SurveyTemplateRepo(BaseRepo):
             else:
                 return res[0]
 
+    def get_vioscreen_sample_to_user(self):
+        """Obtain a mapping of sample ID to vioscreen user"""
+        with self._transaction.cursor() as cur:
+            cur.execute("""SELECT sample_id, vio_id
+                           FROM ag.vioscreen_registry
+                           WHERE sample_id IS NOT NULL
+                               AND vio_id IS NOT NULL""")
+            return {r[0]: r[1] for r in cur.fetchall()}
+
     def create_vioscreen_id(self, account_id, source_id,
                             vioscreen_ext_sample_id):
         with self._transaction.cursor() as cur:

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -531,12 +531,13 @@ class SurveyTemplateRepo(BaseRepo):
                 return res[0]
 
     def get_vioscreen_sample_to_user(self):
-        """Obtain a mapping of sample ID to vioscreen user"""
+        """Obtain a mapping of sample barcode to vioscreen user"""
         with self._transaction.cursor() as cur:
-            cur.execute("""SELECT sample_id, vio_id
+            cur.execute("""SELECT barcode, vio_id
                            FROM ag.vioscreen_registry
-                           WHERE sample_id IS NOT NULL
-                               AND vio_id IS NOT NULL""")
+                           JOIN ag.ag_kit_barcodes
+                               ON sample_id=ag_kit_barcode_id
+                           WHERE vio_id IS NOT NULL""")
             return {r[0]: r[1] for r in cur.fetchall()}
 
     def create_vioscreen_id(self, account_id, source_id,

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -381,3 +381,16 @@ class SurveyTemplateTests(unittest.TestCase):
                                                            TEST2_SOURCE_ID,
                                                            TEST2_SAMPLE_ID)
             self.assertEqual(obs, None)
+
+    def test_get_vioscreen_sample_to_user(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+            obs = template_repo.get_vioscreen_sample_to_user()
+
+        # manually checked from ag_test.ag.vioscreen_registry table
+        tests = [('e0a110de-7c0c-4a5f-a17d-19426a9d41df', 'b98c5ac966b754ff'),
+                 ('23271264-7918-4572-98cd-7405fc907c59', '8fecc8f34a133eb8'),
+                 ('7b387f96-1c6d-4edd-ad68-b179d6f846e7', '52abc2ea83c08b96')]
+        for sample, user in tests:
+            self.assertEqual(obs.get(sample), user)
+

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -387,9 +387,13 @@ class SurveyTemplateTests(unittest.TestCase):
             template_repo = SurveyTemplateRepo(t)
             obs = template_repo.get_vioscreen_sample_to_user()
 
-        # manually checked from ag_test.ag.vioscreen_registry table
-        tests = [('e0a110de-7c0c-4a5f-a17d-19426a9d41df', 'b98c5ac966b754ff'),
-                 ('23271264-7918-4572-98cd-7405fc907c59', '8fecc8f34a133eb8'),
-                 ('7b387f96-1c6d-4edd-ad68-b179d6f846e7', '52abc2ea83c08b96')]
+        # manually checked using
+        # select barcode, sample_id, vio_id
+        # from ag.vioscreen_registry
+        #    join ag.ag_kit_barcodes on sample_id=ag_kit_barcode_id
+        # limit 10;
+        tests = [('000031536', 'b98c5ac966b754ff'),
+                 ('000020495', '8fecc8f34a133eb8'),
+                 ('000023245', '52abc2ea83c08b96')]
         for sample, user in tests:
             self.assertEqual(obs.get(sample), user)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -393,4 +393,3 @@ class SurveyTemplateTests(unittest.TestCase):
                  ('7b387f96-1c6d-4edd-ad68-b179d6f846e7', '52abc2ea83c08b96')]
         for sample, user in tests:
             self.assertEqual(obs.get(sample), user)
-


### PR DESCRIPTION
We do not have an exposed method to obtain a barcode to vioscreen user association, which is necessary to transform extracted Vioscreen data for analysis 