### PR TITLE
Scrub bug

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -796,6 +796,7 @@ def delete_account(account_id, token_info):
         src_repo = SourceRepo(t)
         samp_repo = SampleRepo(t)
         sar_repo = SurveyAnswersRepo(t)
+        template_repo = SurveyTemplateRepo(t)
 
         acct = acct_repo.get_account(account_id)
         if acct is None:
@@ -806,6 +807,7 @@ def delete_account(account_id, token_info):
                 return None, 204
 
         sample_count = 0
+        account_has_external = False
         sources = src_repo.get_sources_in_account(account_id)
 
         for source in sources:
@@ -813,6 +815,11 @@ def delete_account(account_id, token_info):
 
             has_samples = len(samples) > 0
             sample_count += len(samples)
+            has_external = template_repo.has_external_surveys(account_id,
+                                                              source.id)
+
+            if has_external:
+                account_has_external = True
 
             for sample in samples:
                 # we scrub rather than disassociate in the event that the
@@ -826,15 +833,17 @@ def delete_account(account_id, token_info):
                 for survey_id in surveys:
                     sar_repo.scrub(account_id, source.id, survey_id)
                 src_repo.scrub(account_id, source.id)
-            else:
-                # if we do not have associated samples, then the source
-                # is safe to delete
+
+            if not has_samples and not has_external:
+                # if we do not have associated samples, or external surveys,
+                # then the source is safe to delete
                 for survey_id in surveys:
                     sar_repo.delete_answered_survey(account_id, survey_id)
                 src_repo.delete_source(account_id, source.id)
 
         # an account is safe to delete if there are no associated samples
-        if sample_count > 0:
+        # and does not have external surveys
+        if sample_count > 0 or account_has_external:
             acct_repo.scrub(account_id)
         else:
             acct_repo.delete_account(account_id)

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -827,9 +827,9 @@ def delete_account(account_id, token_info):
                 samp_repo.scrub(account_id, source.id, sample.id)
 
             surveys = sar_repo.list_answered_surveys(account_id, source.id)
-            if has_samples:
-                # if we have samples, we need to scrub survey / source
-                # free text
+            if has_samples or has_external:
+                # if we have samples or external surveys, we need to scrub
+                # survey / source free text
                 for survey_id in surveys:
                     sar_repo.scrub(account_id, source.id, survey_id)
                 src_repo.scrub(account_id, source.id)

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -333,13 +333,14 @@ def delete_dummy_accts():
                 all_sample_ids.extend(sample_ids)
 
                 # Dissociate any secondary surveys.
-                # IMPORTANT: the order of operations here matters. It is necessary
-                # to delete external surveys PRIOR to deleting survey answers
-                # as the survey answers deletion will set source_id to NULL
-                # for entries in the registries
+                # IMPORTANT: the order of operations here matters. It is
+                # necessary to delete external surveys PRIOR to deleting survey
+                # answers as the survey answers deletion will set source_id to
+                # NULL for entries in the registries
                 template_repo.delete_myfoodrepo(curr_acct_id, curr_source.id)
                 template_repo.delete_vioscreen(curr_acct_id, curr_source.id)
-                template_repo.delete_polyphenol_ffq(curr_acct_id, curr_source.id)
+                template_repo.delete_polyphenol_ffq(curr_acct_id,
+                                                    curr_source.id)
                 template_repo.delete_spain_ffq(curr_acct_id, curr_source.id)
 
                 # Dissociate all samples linked to this source from all

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -18,6 +18,7 @@ from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.account_repo import AccountRepo
 from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
+from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
 from microsetta_private_api.repo.sample_repo import SampleRepo
 from microsetta_private_api.repo.vioscreen_repo import (
     VioscreenSessionRepo, VioscreenPercentEnergyRepo,
@@ -311,6 +312,7 @@ def delete_dummy_accts():
         survey_answers_repo = SurveyAnswersRepo(t)
         sample_repo = SampleRepo(t)
         barcode_repo = BarcodeRepo(t)
+        template_repo = SurveyTemplateRepo(t)
 
         # Delete fake kit and barcode preps
         barcode_repo.delete_preparation(BC1, 1234)
@@ -342,6 +344,19 @@ def delete_dummy_accts():
                     sample_repo.dissociate_sample(curr_acct_id, curr_source.id,
                                                   curr_sample_id,
                                                   override_locked=True)
+
+                # Dissociate any secondary surveys
+                # TODO: write these
+                #template_repo.delete_myfoodrepo(curr_acct_id, curr_source.id)
+                #template_repo.delete_vioscreen_ffq(curr_acct_id, curr_source.id)
+                #template_repo.delete_polyphenol_ffq(curr_acct_id, curr_source.id)
+                #template_repo.delete_spain_ffq(curr_acct_id, curr_source.id)
+                # placeholder
+                cur = t.cursor()
+                cur.execute("""DELETE FROM ag.myfoodrepo_registry
+                               WHERE account_id=%s AND source_id=%s""",
+                            (curr_acct_id, curr_source.id))
+                cur.commit()
 
                 # Finally, delete the source
                 source_repo.delete_source(curr_acct_id, curr_source.id)
@@ -1050,6 +1065,42 @@ class AccountTests(ApiTests):
 
         # check response code
         self.assertEqual(401, response.status_code)
+
+    def test_account_scrub_no_samples_has_secondary_survey_bug(self):
+        # setup an account with a source and sample
+        dummy_acct_id, dummy_source_id = create_dummy_source(
+            "Bo", Source.SOURCE_TYPE_HUMAN, DUMMY_HUMAN_SOURCE,
+            create_dummy_1=True)
+
+        _ = create_dummy_acct(create_dummy_1=False,
+                              iss=ACCT_MOCK_ISS_3,
+                              sub=ACCT_MOCK_SUB_3,
+                              dummy_is_admin=True)
+
+        # "take" the myfoodrepo survey
+        response = self.client.get(
+            '/api/accounts/%s/sources/%s/survey_templates/%s' %
+            (dummy_acct_id, dummy_source_id, SurveyTemplateRepo.MYFOODREPO_ID),
+            headers=self.dummy_auth)
+
+        # now let's scrub it
+        response = self.client.delete(
+            '/api/accounts/%s' %
+            (dummy_acct_id,),
+            headers=make_headers(FAKE_TOKEN_ADMIN))
+
+        # check response code
+        self.assertEqual(204, response.status_code)
+
+        # verify deleting is idempotent. If the account was scrubbed, then
+        # we get a 204. If the account was deleted, we get a 404
+        response = self.client.delete(
+            '/api/accounts/%s' %
+            (dummy_acct_id,),
+            headers=make_headers(FAKE_TOKEN_ADMIN))
+
+        # check response code
+        self.assertEqual(204, response.status_code)
 
     # region account view/get tests
     def test_account_view_success(self):

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -346,17 +346,10 @@ def delete_dummy_accts():
                                                   override_locked=True)
 
                 # Dissociate any secondary surveys
-                # TODO: write these
-                #template_repo.delete_myfoodrepo(curr_acct_id, curr_source.id)
-                #template_repo.delete_vioscreen_ffq(curr_acct_id, curr_source.id)
-                #template_repo.delete_polyphenol_ffq(curr_acct_id, curr_source.id)
-                #template_repo.delete_spain_ffq(curr_acct_id, curr_source.id)
-                # placeholder
-                cur = t.cursor()
-                cur.execute("""DELETE FROM ag.myfoodrepo_registry
-                               WHERE account_id=%s AND source_id=%s""",
-                            (curr_acct_id, curr_source.id))
-                cur.commit()
+                template_repo.delete_myfoodrepo(curr_acct_id, curr_source.id)
+                template_repo.delete_vioscreen_ffq(curr_acct_id, curr_source.id)
+                template_repo.delete_polyphenol_ffq(curr_acct_id, curr_source.id)
+                template_repo.delete_spain_ffq(curr_acct_id, curr_source.id)
 
                 # Finally, delete the source
                 source_repo.delete_source(curr_acct_id, curr_source.id)

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -339,7 +339,7 @@ class SurveyTemplateRepo(BaseRepo):
                            WHERE account_id=%s AND source_id=%s""",
                         (mfr_id, account_id, source_id))
 
-    def delete_myfoodrepo_entry(self, account_id, source_id):
+    def delete_myfoodrepo(self, account_id, source_id):
         """Intended for admin use, remove a MyFoodRepo entry from the system
 
         This method is idempotent
@@ -496,7 +496,7 @@ class SurveyTemplateRepo(BaseRepo):
             else:
                 return res
 
-    def delete_polyphenol_ffq_entry(self, account_id, source_id):
+    def delete_polyphenol_ffq(self, account_id, source_id):
         """Intended for admin use, remove a Polyphenol FFQ entry
 
         This method is idempotent.
@@ -588,7 +588,7 @@ class SurveyTemplateRepo(BaseRepo):
             else:
                 return res[0]
 
-    def delete_spain_ffq_entry(self, account_id, source_id):
+    def delete_spain_ffq(self, account_id, source_id):
         """Intended for admin use, remove a Spain FFQ entry from the system
 
         This method is idempotent

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -344,6 +344,8 @@ class SurveyTemplateRepo(BaseRepo):
 
         This method is idempotent
 
+        This method deletes ALL surveys associated with an account and source
+
         Parameters
         ----------
         account_id : str, UUID
@@ -494,6 +496,35 @@ class SurveyTemplateRepo(BaseRepo):
             else:
                 return res
 
+    def delete_polyphenol_ffq_entry(self, account_id, source_id):
+        """Intended for admin use, remove a Polyphenol FFQ entry
+
+        This method is idempotent.
+
+        This method deletes ALL surveys associated with an account and source
+
+        Parameters
+        ----------
+        account_id : str, UUID
+            The account UUID
+        source_id : str, UUID
+            The source UUID
+        """
+        with self._transaction.cursor() as cur:
+            existing, _ = self.get_polyphenol_ffq_id_if_exists(account_id,
+                                                               source_id)
+            if existing is not None:
+                cur.execute("""DELETE FROM ag.ag_login_surveys
+                               WHERE ag_login_id=%s
+                                   AND source_id=%s
+                                   AND survey_id=%s""",
+                            (account_id, source_id, existing))
+
+            cur.execute("""DELETE FROM ag.polyphenol_ffq_registry
+                           WHERE account_id=%s
+                               AND source_id=%s""",
+                        (account_id, source_id))
+
     def create_spain_ffq_entry(self, account_id, source_id):
         """Return a newly created Spain FFQ ID
 
@@ -561,6 +592,8 @@ class SurveyTemplateRepo(BaseRepo):
         """Intended for admin use, remove a Spain FFQ entry from the system
 
         This method is idempotent
+
+        This method deletes ALL surveys associated with an account and source
 
         Parameters
         ----------

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -557,6 +557,33 @@ class SurveyTemplateRepo(BaseRepo):
             else:
                 return res[0]
 
+    def delete_spain_ffq_entry(self, account_id, source_id):
+        """Intended for admin use, remove a Spain FFQ entry from the system
+
+        This method is idempotent
+
+        Parameters
+        ----------
+        account_id : str, UUID
+            The account UUID
+        source_id : str, UUID
+            The source UUID
+        """
+        with self._transaction.cursor() as cur:
+            existing = self.get_spain_ffq_id_if_exists(account_id,
+                                                       source_id)
+            if existing is not None:
+                cur.execute("""DELETE FROM ag.ag_login_surveys
+                               WHERE ag_login_id=%s
+                                   AND source_id=%s
+                                   AND survey_id=%s""",
+                            (account_id, source_id, existing))
+
+            cur.execute("""DELETE FROM ag.spain_ffq_registry
+                           WHERE account_id=%s
+                               AND source_id=%s""",
+                        (account_id, source_id))
+
     def get_vioscreen_sample_to_user(self):
         """Obtain a mapping of sample barcode to vioscreen user"""
         with self._transaction.cursor() as cur:

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -523,7 +523,6 @@ class SurveyTemplateRepo(BaseRepo):
                                    AND source_id=%s
                                    AND survey_id=%s""",
                             (account_id, source_id, existing))
-
             cur.execute("""DELETE FROM ag.polyphenol_ffq_registry
                            WHERE account_id=%s
                                AND source_id=%s""",

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -344,7 +344,8 @@ class SurveyTemplateRepo(BaseRepo):
 
         This method is idempotent
 
-        This method deletes ALL surveys associated with an account and source
+        This method deletes ALL MyFoodRepo surveys associated with an account
+        and source
 
         This is a hard delete, we REMOVE rows rather than setting a flag
 
@@ -503,7 +504,8 @@ class SurveyTemplateRepo(BaseRepo):
 
         This method is idempotent.
 
-        This method deletes ALL surveys associated with an account and source
+        This method deletes ALL Polyphenol FFQ surveys associated with an
+        account and source
 
         This is a hard delete, we REMOVE rows rather than setting a flag
 
@@ -596,7 +598,8 @@ class SurveyTemplateRepo(BaseRepo):
 
         This method is idempotent
 
-        This method deletes ALL surveys associated with an account and source
+        This method deletes ALL Spain FFQ surveys associated with an account
+        and source
 
         This is a hard delete, we REMOVE rows rather than setting a flag
 
@@ -731,7 +734,8 @@ class SurveyTemplateRepo(BaseRepo):
 
         This method is idempotent
 
-        This method deletes ALL surveys associated with an account and source
+        This method deletes ALL Vioscreen FFQ surveys associated with an
+        account and source
 
         This is a hard delete, we REMOVE rows rather than setting a flag
 

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -750,7 +750,6 @@ class SurveyTemplateRepo(BaseRepo):
                                AND source_id = %s""",
                         (account_id, source_id))
 
-
     def fetch_user_basic_physiology(self, account_id, source_id):
         """Given an account and source ID, obtain basic physiology properties
 

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -339,6 +339,33 @@ class SurveyTemplateRepo(BaseRepo):
                            WHERE account_id=%s AND source_id=%s""",
                         (mfr_id, account_id, source_id))
 
+    def delete_myfoodrepo_entry(self, account_id, source_id):
+        """Intended for admin use, remove a MyFoodRepo entry from the system
+
+        This method is idempotent
+
+        Parameters
+        ----------
+        account_id : str, UUID
+            The account UUID
+        source_id : str, UUID
+            The source UUID
+        """
+        with self._transaction.cursor() as cur:
+            existing, created = self.get_myfoodrepo_id_if_exists(account_id,
+                                                                 source_id)
+            if existing is not None:
+                cur.execute("""DELETE FROM ag.ag_login_surveys
+                               WHERE ag_login_id=%s
+                                   AND source_id=%s
+                                   AND survey_id=%s""",
+                            (account_id, source_id, existing))
+
+            cur.execute("""DELETE FROM ag.myfoodrepo_registry
+                           WHERE account_id=%s
+                               AND source_id=%s""",
+                        (account_id, source_id))
+
     def get_myfoodrepo_id_if_exists(self, account_id, source_id):
         """Return a MyFoodRepo ID if one exists
 

--- a/microsetta_private_api/repo/survey_template_repo.py
+++ b/microsetta_private_api/repo/survey_template_repo.py
@@ -910,11 +910,19 @@ class SurveyTemplateRepo(BaseRepo):
             otherwise
         """
         getters = (self.get_myfoodrepo_id_if_exists,
-                   self.get_polyphenol_id_if_exists,
+                   self.get_polyphenol_ffq_id_if_exists,
                    self.get_spain_ffq_id_if_exists,
                    self.get_vioscreen_all_ids_if_exists)
 
         for get in getters:
-            if get(account_id, source_id):
-                return True
+            res = get(account_id, source_id)
+
+            # the if_exists methods are inconsistent in return type, yay
+            if isinstance(res, tuple):
+                if res[0] is not None:
+                    return True
+            else:
+                if res is not None:
+                    return True
+
         return False

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -127,6 +127,11 @@ class SurveyTemplateTests(unittest.TestCase):
             e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
                                                              TEST2_SOURCE_ID)
             self.assertEqual(e, None)
+
+            # make sure we can delete something that doesn't exist
+            template_repo.delete_myfoodrepo_entry(TEST2_ACCOUNT_ID,
+                                                  TEST2_SOURCE_ID)
+
             t.rollback()
 
     def test_set_myfoodrepo_id_valid(self):
@@ -296,6 +301,24 @@ class SurveyTemplateTests(unittest.TestCase):
                 template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                               TEST1_SOURCE_ID)
             self.assertEqual(obs, (None, None))
+
+    def test_delete_spain_ffq_entry(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+            template_repo.create_spain_ffq_entry(TEST1_ACCOUNT_ID,
+                                                 TEST1_SOURCE_ID)
+            obs = template_repo.get_spain_ffq_id_if_exists(TEST1_ACCOUNT_ID,
+                                                           TEST1_SOURCE_ID)
+            self.assertTrue(obs is not None)
+            template_repo.delete_spain_ffq_entry(TEST1_ACCOUNT_ID,
+                                                 TEST1_SOURCE_ID)
+            obs = template_repo.get_spain_ffq_id_if_exists(TEST1_ACCOUNT_ID,
+                                                           TEST1_SOURCE_ID)
+            self.assertTrue(obs is None)
+
+            # test we can delete something that doesn't exist
+            template_repo.delete_spain_ffq_entry(TEST1_ACCOUNT_ID,
+                                                 TEST1_SOURCE_ID)
 
     def test_create_spain_ffq_entry_valid(self):
         with Transaction() as t:

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -483,3 +483,15 @@ class SurveyTemplateTests(unittest.TestCase):
                                                            TEST1_SOURCE_ID,
                                                            TEST1_SAMPLE_ID)
             self.assertEqual(obs, None)
+
+    def test_has_external_surveys(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+
+            obs = template_repo.has_external_surveys(TEST1_ACCOUNT_ID,
+                                                     TEST1_SOURCE_ID)
+            self.assertTrue(obs)
+
+            obs = template_repo.has_external_surveys(TEST2_ACCOUNT_ID,
+                                                     TEST2_SOURCE_ID)
+            self.assertFalse(obs)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -113,11 +113,11 @@ class SurveyTemplateTests(unittest.TestCase):
     def test_delete_myfoodrepo(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)
-            obs = template_repo.create_myfoodrepo_entry(TEST2_ACCOUNT_ID,
-                                                        TEST2_SOURCE_ID)
+            template_repo.create_myfoodrepo_entry(TEST2_ACCOUNT_ID,
+                                                  TEST2_SOURCE_ID)
             template_repo.set_myfoodrepo_id(TEST2_ACCOUNT_ID,
                                             TEST2_SOURCE_ID,
-                                           'foobar')
+                                            'foobar')
             e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
                                                              TEST2_SOURCE_ID)
             self.assertEqual(e, 'foobar')
@@ -323,6 +323,7 @@ class SurveyTemplateTests(unittest.TestCase):
             # test we can delete something that doesn't exist
             template_repo.delete_polyphenol_ffq(TEST1_ACCOUNT_ID,
                                                 TEST1_SOURCE_ID)
+
     def test_delete_spain_ffq(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -110,7 +110,7 @@ class SurveyTemplateTests(unittest.TestCase):
                 exp = (1973, 'Male', None, None)
                 self.assertEqual(obs, exp)
 
-    def test_delete_myfoodrepo(self):
+    def test_delete_myfoodrepo_entry(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)
             obs = template_repo.create_myfoodrepo_entry(TEST2_ACCOUNT_ID,
@@ -127,6 +127,7 @@ class SurveyTemplateTests(unittest.TestCase):
             e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
                                                              TEST2_SOURCE_ID)
             self.assertEqual(e, None)
+            t.rollback()
 
     def test_set_myfoodrepo_id_valid(self):
         with Transaction() as t:

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -429,6 +429,14 @@ class SurveyTemplateTests(unittest.TestCase):
                                                   TEST2_SOURCE_ID,
                                                   str(uuid.uuid4()))
 
+    def test_get_vioscreen_all_ids_if_exists_valid(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+            obs = \
+                template_repo.get_vioscreen_all_ids_if_exists(TEST1_ACCOUNT_ID,
+                                                              TEST1_SOURCE_ID)
+            self.assertEqual(obs, (TEST1_VIO_ID, ))
+
     def test_get_vioscreen_id_if_exists_valid(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -302,6 +302,27 @@ class SurveyTemplateTests(unittest.TestCase):
                                                               TEST1_SOURCE_ID)
             self.assertEqual(obs, (None, None))
 
+    def test_delete_polyphenol_ffq_entry(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+            template_repo.create_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
+                                                      TEST1_SOURCE_ID,
+                                                      'en_US',
+                                                      'THDMI')
+            obs = \
+                template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
+                                                              TEST1_SOURCE_ID)
+            self.assertTrue(obs is not None)
+            template_repo.delete_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
+                                                     TEST1_SOURCE_ID)
+            obs = \
+                template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
+                                                              TEST1_SOURCE_ID)
+            self.assertTrue(obs is None)
+
+            # test we can delete something that doesn't exist
+            template_repo.delete_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
+                                                      TEST1_SOURCE_ID)
     def test_delete_spain_ffq_entry(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -110,6 +110,24 @@ class SurveyTemplateTests(unittest.TestCase):
                 exp = (1973, 'Male', None, None)
                 self.assertEqual(obs, exp)
 
+    def test_delete_myfoodrepo(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
+            obs = template_repo.create_myfoodrepo_entry(TEST2_ACCOUNT_ID,
+                                                        TEST2_SOURCE_ID)
+            template_repo.set_myfoodrepo_id(TEST2_ACCOUNT_ID,
+                                            TEST2_SOURCE_ID,
+                                           'foobar')
+            e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
+                                                             TEST2_SOURCE_ID)
+            self.assertEqual(e, 'foobar')
+            template_repo.delete_myfoodrepo_entry(TEST2_ACCOUNT_ID,
+                                                  TEST2_SOURCE_ID)
+
+            e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
+                                                             TEST2_SOURCE_ID)
+            self.assertEqual(e, None)
+
     def test_set_myfoodrepo_id_valid(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -110,7 +110,7 @@ class SurveyTemplateTests(unittest.TestCase):
                 exp = (1973, 'Male', None, None)
                 self.assertEqual(obs, exp)
 
-    def test_delete_myfoodrepo_entry(self):
+    def test_delete_myfoodrepo(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)
             obs = template_repo.create_myfoodrepo_entry(TEST2_ACCOUNT_ID,
@@ -121,16 +121,16 @@ class SurveyTemplateTests(unittest.TestCase):
             e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
                                                              TEST2_SOURCE_ID)
             self.assertEqual(e, 'foobar')
-            template_repo.delete_myfoodrepo_entry(TEST2_ACCOUNT_ID,
-                                                  TEST2_SOURCE_ID)
+            template_repo.delete_myfoodrepo(TEST2_ACCOUNT_ID,
+                                            TEST2_SOURCE_ID)
 
             e, c = template_repo.get_myfoodrepo_id_if_exists(TEST2_ACCOUNT_ID,
                                                              TEST2_SOURCE_ID)
             self.assertEqual(e, None)
 
             # make sure we can delete something that doesn't exist
-            template_repo.delete_myfoodrepo_entry(TEST2_ACCOUNT_ID,
-                                                  TEST2_SOURCE_ID)
+            template_repo.delete_myfoodrepo(TEST2_ACCOUNT_ID,
+                                            TEST2_SOURCE_ID)
 
             t.rollback()
 
@@ -302,7 +302,7 @@ class SurveyTemplateTests(unittest.TestCase):
                                                               TEST1_SOURCE_ID)
             self.assertEqual(obs, (None, None))
 
-    def test_delete_polyphenol_ffq_entry(self):
+    def test_delete_polyphenol_ffq(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)
             template_repo.create_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
@@ -313,17 +313,17 @@ class SurveyTemplateTests(unittest.TestCase):
                 template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                               TEST1_SOURCE_ID)
             self.assertTrue(obs is not None)
-            template_repo.delete_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
-                                                     TEST1_SOURCE_ID)
+            template_repo.delete_polyphenol_ffq(TEST1_ACCOUNT_ID,
+                                                TEST1_SOURCE_ID)
             obs, _ = \
                 template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                               TEST1_SOURCE_ID)
             self.assertTrue(obs is None)
 
             # test we can delete something that doesn't exist
-            template_repo.delete_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
-                                                      TEST1_SOURCE_ID)
-    def test_delete_spain_ffq_entry(self):
+            template_repo.delete_polyphenol_ffq(TEST1_ACCOUNT_ID,
+                                                TEST1_SOURCE_ID)
+    def test_delete_spain_ffq(self):
         with Transaction() as t:
             template_repo = SurveyTemplateRepo(t)
             template_repo.create_spain_ffq_entry(TEST1_ACCOUNT_ID,
@@ -331,15 +331,15 @@ class SurveyTemplateTests(unittest.TestCase):
             obs = template_repo.get_spain_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                            TEST1_SOURCE_ID)
             self.assertTrue(obs is not None)
-            template_repo.delete_spain_ffq_entry(TEST1_ACCOUNT_ID,
-                                                 TEST1_SOURCE_ID)
+            template_repo.delete_spain_ffq(TEST1_ACCOUNT_ID,
+                                           TEST1_SOURCE_ID)
             obs = template_repo.get_spain_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                            TEST1_SOURCE_ID)
             self.assertTrue(obs is None)
 
             # test we can delete something that doesn't exist
-            template_repo.delete_spain_ffq_entry(TEST1_ACCOUNT_ID,
-                                                 TEST1_SOURCE_ID)
+            template_repo.delete_spain_ffq(TEST1_ACCOUNT_ID,
+                                           TEST1_SOURCE_ID)
 
     def test_create_spain_ffq_entry_valid(self):
         with Transaction() as t:
@@ -460,3 +460,6 @@ class SurveyTemplateTests(unittest.TestCase):
                  ('000023245', '52abc2ea83c08b96')]
         for sample, user in tests:
             self.assertEqual(obs.get(sample), user)
+
+    def test_delete_vioscreen(self):
+

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -309,13 +309,13 @@ class SurveyTemplateTests(unittest.TestCase):
                                                       TEST1_SOURCE_ID,
                                                       'en_US',
                                                       'THDMI')
-            obs = \
+            obs, _ = \
                 template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                               TEST1_SOURCE_ID)
             self.assertTrue(obs is not None)
             template_repo.delete_polyphenol_ffq_entry(TEST1_ACCOUNT_ID,
                                                      TEST1_SOURCE_ID)
-            obs = \
+            obs, _ = \
                 template_repo.get_polyphenol_ffq_id_if_exists(TEST1_ACCOUNT_ID,
                                                               TEST1_SOURCE_ID)
             self.assertTrue(obs is None)

--- a/microsetta_private_api/repo/tests/test_survey_template_repo.py
+++ b/microsetta_private_api/repo/tests/test_survey_template_repo.py
@@ -462,4 +462,24 @@ class SurveyTemplateTests(unittest.TestCase):
             self.assertEqual(obs.get(sample), user)
 
     def test_delete_vioscreen(self):
+        with Transaction() as t:
+            template_repo = SurveyTemplateRepo(t)
 
+            obs = template_repo.get_vioscreen_id_if_exists(TEST1_ACCOUNT_ID,
+                                                           TEST1_SOURCE_ID,
+                                                           TEST1_SAMPLE_ID)
+            self.assertEqual(obs, TEST1_VIO_ID)
+
+            template_repo.delete_vioscreen(TEST1_ACCOUNT_ID,
+                                           TEST1_SOURCE_ID)
+
+            obs = template_repo.get_vioscreen_id_if_exists(TEST1_ACCOUNT_ID,
+                                                           TEST1_SOURCE_ID,
+                                                           TEST1_SAMPLE_ID)
+            self.assertEqual(obs, None)
+
+            # test we can delete something that doesn't exist
+            obs = template_repo.get_vioscreen_id_if_exists(TEST1_ACCOUNT_ID,
+                                                           TEST1_SOURCE_ID,
+                                                           TEST1_SAMPLE_ID)
+            self.assertEqual(obs, None)


### PR DESCRIPTION
Fixes #469 

To do so, we needed to add admin-intended deletion methods for the external surveys in order support the testing framework. 

If a user has any external surveys, their account is scrubbed rather than deleted so the relationships can be preserved.