### PR TITLE
Fix Vioscreen RegCode Bug

### DIFF
--- a/microsetta_private_api/util/vioscreen.py
+++ b/microsetta_private_api/util/vioscreen.py
@@ -73,7 +73,7 @@ def gen_survey_url(user_id,
 
     # We'll default to the US version if there isn't a country specific one
     # available.
-    ffq = COUNTRY_CODE_TO_FFQ.get(country_code, 'US')
+    ffq = COUNTRY_CODE_TO_FFQ.get(country_code, '')
     if ffq == '':
         ffq = f"{regcode}"
     else:


### PR DESCRIPTION
#473 

It looks like the intent of the code was to default to the value of COUNTRY_CODE_TO_FFQ['US'], but it was instead defaulting to 'US'. Tested the logic using an account with France selected as country of residence and confirmed that the value of ffq went from [regcode]-US before the change to [regcode] after the change.