### PR TITLE
Changes for THDMI Japan signups

### DIFF
--- a/microsetta_private_api/admin/email_templates.py
+++ b/microsetta_private_api/admin/email_templates.py
@@ -71,6 +71,14 @@ class EmailMessage(Enum):
         EventType.EMAIL,
         EventSubtype.EMAIL_ADDRESS_INVALID
     )
+    submit_interest_confirmation = (
+        gettext(
+            "We received your sign-up"),
+        "email/submit_interest_confirmation.jinja2",
+        ("contact_name",),
+        EventType.EMAIL,
+        EventSubtype.EMAIL_SUBMIT_INTEREST_CONFIRMATION
+    )
 
     def __init__(self, subject, html, required, event_type, event_sub):
         self.subject = subject

--- a/microsetta_private_api/api/_interested_user.py
+++ b/microsetta_private_api/api/_interested_user.py
@@ -6,6 +6,7 @@ from microsetta_private_api.repo.interested_user_repo import InterestedUserRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.repo.campaign_repo import CampaignRepo
+from microsetta_private_api.tasks import send_email
 
 
 def create_interested_user(body):

--- a/microsetta_private_api/api/_interested_user.py
+++ b/microsetta_private_api/api/_interested_user.py
@@ -5,6 +5,7 @@ from microsetta_private_api.model.interested_user import InterestedUser
 from microsetta_private_api.repo.interested_user_repo import InterestedUserRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.exceptions import RepoException
+from microsetta_private_api.repo.campaign_repo import CampaignRepo
 
 
 def create_interested_user(body):
@@ -28,6 +29,25 @@ def create_interested_user(body):
                 code=400,
                 message="Failed to create interested user."
             ), 400
+
+        if interested_user_id:
+            campaign_repo = CampaignRepo(t)
+            campaign_info =\
+                campaign_repo.get_campaign_by_id(interested_user.campaign_id)
+
+            if campaign_info.send_thdmi_confirmation:
+                try:
+                    # Send a confirmation email
+                    # TODO: Add more intelligent locale determination.
+                    # Punting on that since our current campaign use cases
+                    # are only a single language.
+                    send_email(interested_user.email,
+                               "submit_interest_confirmation",
+                               {"contact_name": interested_user.first_name},
+                               campaign_info.language_key)
+                except:  # noqa
+                    # try our best to email
+                    pass
 
         t.commit()
 

--- a/microsetta_private_api/api/_interested_user.py
+++ b/microsetta_private_api/api/_interested_user.py
@@ -31,24 +31,23 @@ def create_interested_user(body):
                 message="Failed to create interested user."
             ), 400
 
-        if interested_user_id:
-            campaign_repo = CampaignRepo(t)
-            campaign_info =\
-                campaign_repo.get_campaign_by_id(interested_user.campaign_id)
+        campaign_repo = CampaignRepo(t)
+        campaign_info =\
+            campaign_repo.get_campaign_by_id(interested_user.campaign_id)
 
-            if campaign_info.send_thdmi_confirmation:
-                try:
-                    # Send a confirmation email
-                    # TODO: Add more intelligent locale determination.
-                    # Punting on that since our current campaign use cases
-                    # are only a single language.
-                    send_email(interested_user.email,
-                               "submit_interest_confirmation",
-                               {"contact_name": interested_user.first_name},
-                               campaign_info.language_key)
-                except:  # noqa
-                    # try our best to email
-                    pass
+        if campaign_info.send_thdmi_confirmation:
+            try:
+                # Send a confirmation email
+                # TODO: Add more intelligent locale determination.
+                # Punting on that since our current campaign use cases
+                # are only a single language.
+                send_email(interested_user.email,
+                           "submit_interest_confirmation",
+                           {"contact_name": interested_user.first_name},
+                           campaign_info.language_key)
+            except:  # noqa
+                # try our best to email
+                pass
 
         t.commit()
 

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1482,6 +1482,8 @@ paths:
                   type: string
                 'extension':
                   type: string
+                'send_thdmi_confirmation':
+                  type: string
               required:
                 - title
                 - associated_projects
@@ -1530,6 +1532,8 @@ paths:
                 'instructions_alt':
                   type: string
                 'extension':
+                  type: string
+                'send_thdmi_confirmation':
                   type: string
               required:
                 - campaign_id
@@ -2731,7 +2735,7 @@ components:
       example: "standard"
     language:
       type: string
-      enum: ["en_US", "es_MX", "es_ES"]
+      enum: ["en_US", "es_MX", "es_ES", "ja_JP"]
       example: "en_US"
     creation_time:
       type: string

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -1799,7 +1799,7 @@ class SampleTests(ApiTests):
 
         # if sample date is less than 10 years
         now = datetime.datetime.now()
-        delta = relativedelta(year=now.year-11)
+        delta = relativedelta(years=now.year-11)
         date = now+delta
         post_resp = self.client.put(
             '%s?%s' % (base_url, self.default_lang_querystring),
@@ -1818,7 +1818,7 @@ class SampleTests(ApiTests):
 
         # if sample date is greater than 30 days
         now = datetime.datetime.now()
-        delta = relativedelta(month=now.month+2)
+        delta = relativedelta(months=now.month+2)
         date = now+delta
         post_resp = self.client.put(
             '%s?%s' % (base_url, self.default_lang_querystring),

--- a/microsetta_private_api/db/patches/0103.sql
+++ b/microsetta_private_api/db/patches/0103.sql
@@ -1,1 +1,1 @@
-ALTER TABLE campaign.campaigns ADD COLUMN send_thdmi_confirmation BOOLEAN DEFAULT FALSE;
+ALTER TABLE campaign.campaigns ADD COLUMN send_thdmi_confirmation BOOLEAN NOT NULL DEFAULT FALSE;

--- a/microsetta_private_api/db/patches/0103.sql
+++ b/microsetta_private_api/db/patches/0103.sql
@@ -1,0 +1,1 @@
+ALTER TABLE campaign.campaigns ADD COLUMN send_thdmi_confirmation BOOLEAN DEFAULT FALSE;

--- a/microsetta_private_api/localization.py
+++ b/microsetta_private_api/localization.py
@@ -5,6 +5,7 @@ EN_US = "en_US"
 EN_GB = "en_GB"
 ES_MX = "es_MX"
 ES_ES = "es_ES"
+JA_JP = "ja_JP"
 
 NEW_PARTICIPANT_KEY = "new_participant"
 LANG_NAME_KEY = "lang_name"

--- a/microsetta_private_api/model/campaign.py
+++ b/microsetta_private_api/model/campaign.py
@@ -316,7 +316,7 @@ class Campaign(ModelBase):
     def __init__(self, campaign_id, title, instructions, header_image,
                  permitted_countries, language_key, accepting_participants,
                  associated_projects, language_key_alt, title_alt,
-                 instructions_alt):
+                 instructions_alt, send_thdmi_confirmation):
         self.campaign_id = campaign_id
         self.title = title
         self.instructions = instructions
@@ -328,6 +328,7 @@ class Campaign(ModelBase):
         self.language_key_alt = language_key_alt
         self.title_alt = title_alt
         self.instructions_alt = instructions_alt
+        self.send_thdmi_confirmation = send_thdmi_confirmation
 
     def to_api(self):
         return self.__dict__.copy()

--- a/microsetta_private_api/model/log_event.py
+++ b/microsetta_private_api/model/log_event.py
@@ -46,6 +46,8 @@ class EventSubtype(Enum):
     EMAIL_PER_PROJECT_SUMMARY = "per_project_summary"
     # for addresses that Melissa deems invalid
     EMAIL_ADDRESS_INVALID = "address_invalid"
+    # for confirmation emails of interested user signups
+    EMAIL_SUBMIT_INTEREST_CONFIRMATION = "submit_interest_confirmation"
 
 
 class LogEvent(ModelBase):

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -107,6 +107,9 @@ class CampaignRepo(BaseRepo):
             if campaign_id is None:
                 raise RepoException("Error inserting campaign into database")
             else:
+                # Python is assuming associated_project is a tuple.
+                # Convert to string so we can then convert to a list.
+                associated_projects = ','.join(associated_projects)
                 associated_projects = associated_projects.split(",")
                 cur.executemany(
                     "INSERT INTO campaign.campaigns_projects ("

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -112,10 +112,7 @@ class CampaignRepo(BaseRepo):
                 if isinstance(associated_projects, tuple):
                     associated_projects = list(associated_projects)
                 elif isinstance(associated_projects, str):
-                    if "," in associated_projects:
-                        associated_projects = associated_projects.split(",")
-                    else:
-                        associated_projects = [associated_projects, ]
+                    associated_projects = associated_projects.split(",")
                 elif isinstance(associated_projects, int):
                     associated_projects = [associated_projects, ]
 

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -28,7 +28,8 @@ class CampaignRepo(BaseRepo):
         return (c.campaign_id, c.title, c.instructions, c.header_image,
                 c.permitted_countries, c.language_key,
                 c.accepting_participants, '',
-                c.language_key_alt, c.title_alt, c.instructions_alt)
+                c.language_key_alt, c.title_alt, c.instructions_alt,
+                send_thdmi_confirmation)
 
     def _row_to_campaign(self, r):
         associated_projects = ", ".join(self._get_projects(r['campaign_id']))
@@ -36,7 +37,8 @@ class CampaignRepo(BaseRepo):
                         r['header_image'], r['permitted_countries'],
                         r['language_key'], r['accepting_participants'],
                         associated_projects, r['language_key_alt'],
-                        r['title_alt'], r['instructions_alt'])
+                        r['title_alt'], r['instructions_alt'],
+                        r['send_thdmi_confirmation'])
 
     def _get_projects(self, campaign_id):
         with self._transaction.cursor() as cur:
@@ -66,7 +68,7 @@ class CampaignRepo(BaseRepo):
                 "SELECT campaign_id, title, instructions, header_image, "
                 "permitted_countries, language_key, accepting_participants, "
                 "language_key_alt, title_alt, "
-                "instructions_alt "
+                "instructions_alt, send_thdmi_confirmation "
                 "FROM campaign.campaigns ORDER BY title"
             )
             rows = cur.fetchall()
@@ -86,24 +88,26 @@ class CampaignRepo(BaseRepo):
         title_alt = kwargs.get('title_alt')
         instructions_alt = kwargs.get('instructions_alt')
         extension = kwargs.get('extension')
+        send_thdmi_confirmation = kwargs.get('send_thdmi_confirmation')
 
         with self._transaction.cursor() as cur:
             cur.execute(
                 "INSERT INTO campaign.campaigns (title, instructions, "
                 "permitted_countries, language_key, accepting_participants, "
                 "language_key_alt, title_alt, "
-                "instructions_alt) "
-                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s) "
+                "instructions_alt, send_thdmi_confirmation) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) "
                 "RETURNING campaign_id",
                 (title, instructions, permitted_countries, language_key,
                  accepting_participants, language_key_alt, title_alt,
-                 instructions_alt)
+                 instructions_alt, send_thdmi_confirmation)
             )
             campaign_id = cur.fetchone()[0]
 
             if campaign_id is None:
                 raise RepoException("Error inserting campaign into database")
             else:
+                associated_projects = associated_projects.split(",")
                 cur.executemany(
                     "INSERT INTO campaign.campaigns_projects ("
                     "campaign_id,project_id"
@@ -132,17 +136,19 @@ class CampaignRepo(BaseRepo):
         title_alt = kwargs.get('title_alt')
         instructions_alt = kwargs.get('instructions_alt')
         extension = kwargs.get('extension')
+        send_thdmi_confirmation = kwargs.get('send_thdmi_confirmation')
 
         with self._transaction.cursor() as cur:
             cur.execute(
                 "UPDATE campaign.campaigns SET title = %s, instructions = %s, "
                 "permitted_countries = %s, language_key = %s, "
                 "accepting_participants = %s, language_key_alt = %s, "
-                "title_alt = %s, instructions_alt = %s "
+                "title_alt = %s, instructions_alt = %s, "
+                "send_thdmi_confirmation = %s "
                 "WHERE campaign_id = %s",
                 (title, instructions, permitted_countries, language_key,
                  accepting_participants, language_key_alt, title_alt,
-                 instructions_alt, campaign_id)
+                 instructions_alt, send_thdmi_confirmation, campaign_id)
             )
 
             self.update_header_image(campaign_id, extension)
@@ -156,7 +162,8 @@ class CampaignRepo(BaseRepo):
                     "SELECT campaign_id, title, instructions, header_image, "
                     "permitted_countries, language_key, "
                     "accepting_participants, "
-                    "language_key_alt, title_alt, instructions_alt "
+                    "language_key_alt, title_alt, instructions_alt, "
+                    "send_thdmi_confirmation "
                     "FROM campaign.campaigns WHERE campaign_id = %s",
                     (campaign_id,)
                 )

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -107,10 +107,18 @@ class CampaignRepo(BaseRepo):
             if campaign_id is None:
                 raise RepoException("Error inserting campaign into database")
             else:
-                # Python is assuming associated_project is a tuple.
-                # Convert to string so we can then convert to a list.
-                associated_projects = ','.join(associated_projects)
-                associated_projects = associated_projects.split(",")
+                # This code is not ideal but the various campaign creation
+                # methods pass several different datatypes in.
+                if isinstance(associated_projects, tuple):
+                    associated_projects = list(associated_projects)
+                elif isinstance(associated_projects, str):
+                    if "," in associated_projects:
+                        associated_projects = associated_projects.split(",")
+                    else:
+                        associated_projects = [associated_projects, ]
+                elif isinstance(associated_projects, int):
+                    associated_projects = [associated_projects, ]
+
                 cur.executemany(
                     "INSERT INTO campaign.campaigns_projects ("
                     "campaign_id,project_id"

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -88,7 +88,7 @@ class CampaignRepo(BaseRepo):
         title_alt = kwargs.get('title_alt')
         instructions_alt = kwargs.get('instructions_alt')
         extension = kwargs.get('extension')
-        send_thdmi_confirmation = kwargs.get('send_thdmi_confirmation')
+        send_thdmi_confirmation = kwargs.get('send_thdmi_confirmation', False)
 
         with self._transaction.cursor() as cur:
             cur.execute(

--- a/microsetta_private_api/repo/campaign_repo.py
+++ b/microsetta_private_api/repo/campaign_repo.py
@@ -29,7 +29,7 @@ class CampaignRepo(BaseRepo):
                 c.permitted_countries, c.language_key,
                 c.accepting_participants, '',
                 c.language_key_alt, c.title_alt, c.instructions_alt,
-                send_thdmi_confirmation)
+                c.send_thdmi_confirmation)
 
     def _row_to_campaign(self, r):
         associated_projects = ", ".join(self._get_projects(r['campaign_id']))

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -4,7 +4,6 @@ from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.model.interested_user import InterestedUser
 from microsetta_private_api.util.melissa import verify_address
-from microsetta_private_api.tasks import send_email
 
 
 class InterestedUserRepo(BaseRepo):

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -4,6 +4,7 @@ from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.model.interested_user import InterestedUser
 from microsetta_private_api.util.melissa import verify_address
+from microsetta_private_api.tasks import send_email
 
 
 class InterestedUserRepo(BaseRepo):

--- a/microsetta_private_api/repo/tests/test_campaign_repo.py
+++ b/microsetta_private_api/repo/tests/test_campaign_repo.py
@@ -310,44 +310,47 @@ class CampaignRepoTests(unittest.TestCase):
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": "45"
+                "associated_projects": "46"
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "45")
+            self.assertEqual(obs.associated_projects, "Project - qó1]øJçY\@")
             t.rollback()
 
         # verify that a comma-delimited string stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": "45, 47"
+                "associated_projects": "46, 48"
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "45, 47")
+            self.assertEqual(obs.associated_projects,
+                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
         # verify that a list of strings stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": ["45", "47"]
+                "associated_projects": ["46", "48"]
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "45, 47")
+            self.assertEqual(obs.associated_projects,
+                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
         # verify that a list of ints stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": [45, 47]
+                "associated_projects": [46, 48]
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "45, 47")
+            self.assertEqual(obs.associated_projects,
+                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
     def test_get_campaign_by_id_valid(self):

--- a/microsetta_private_api/repo/tests/test_campaign_repo.py
+++ b/microsetta_private_api/repo/tests/test_campaign_repo.py
@@ -314,7 +314,7 @@ class CampaignRepoTests(unittest.TestCase):
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "Project - qó1]øJçY\@")
+            self.assertEqual(obs.associated_projects, "Project - qó1]øJçY\\@")
             t.rollback()
 
         # verify that a comma-delimited string stores separate IDs
@@ -326,7 +326,7 @@ class CampaignRepoTests(unittest.TestCase):
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
             self.assertEqual(obs.associated_projects,
-                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
+                             "Project - qó1]øJçY\\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
         # verify that a list of strings stores separate IDs
@@ -338,7 +338,7 @@ class CampaignRepoTests(unittest.TestCase):
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
             self.assertEqual(obs.associated_projects,
-                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
+                             "Project - qó1]øJçY\\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
         # verify that a list of ints stores separate IDs
@@ -350,7 +350,7 @@ class CampaignRepoTests(unittest.TestCase):
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
             self.assertEqual(obs.associated_projects,
-                             "Project - qó1]øJçY\@, Project - ÅQ%PáiZ!š@")
+                             "Project - qó1]øJçY\\@, Project - ÅQ%PáiZ!š@")
             t.rollback()
 
     def test_get_campaign_by_id_valid(self):

--- a/microsetta_private_api/repo/tests/test_campaign_repo.py
+++ b/microsetta_private_api/repo/tests/test_campaign_repo.py
@@ -306,48 +306,48 @@ class CampaignRepoTests(unittest.TestCase):
                 campaign_repo.create_campaign(**campaign_bad_projects)
 
     def test_create_campaign_projects_bug(self):
-        # verify that a three-digit number is treated as one project ID
+        # verify that a two-digit number is treated as one project ID
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": "145"
+                "associated_projects": "45"
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "145")
+            self.assertEqual(obs.associated_projects, "45")
             t.rollback()
 
         # verify that a comma-delimited string stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": "145, 147"
+                "associated_projects": "45, 47"
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "145, 147")
+            self.assertEqual(obs.associated_projects, "45, 47")
             t.rollback()
 
         # verify that a list of strings stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": ["145", "147"]
+                "associated_projects": ["45", "47"]
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "145, 147")
+            self.assertEqual(obs.associated_projects, "45, 47")
             t.rollback()
 
         # verify that a list of ints stores separate IDs
         with Transaction() as t:
             new_campaign = {
                 "title": "Unique Campaign Name",
-                "associated_projects": [145, 147]
+                "associated_projects": [45, 47]
             }
             campaign_repo = CampaignRepo(t)
             obs = campaign_repo.create_campaign(**new_campaign)
-            self.assertEqual(obs.associated_projects, "145, 147")
+            self.assertEqual(obs.associated_projects, "45, 47")
             t.rollback()
 
     def test_get_campaign_by_id_valid(self):

--- a/microsetta_private_api/repo/tests/test_campaign_repo.py
+++ b/microsetta_private_api/repo/tests/test_campaign_repo.py
@@ -305,6 +305,51 @@ class CampaignRepoTests(unittest.TestCase):
             with self.assertRaises(ForeignKeyViolation):
                 campaign_repo.create_campaign(**campaign_bad_projects)
 
+    def test_create_campaign_projects_bug(self):
+        # verify that a three-digit number is treated as one project ID
+        with Transaction() as t:
+            new_campaign = {
+                "title": "Unique Campaign Name",
+                "associated_projects": "145"
+            }
+            campaign_repo = CampaignRepo(t)
+            obs = campaign_repo.create_campaign(**new_campaign)
+            self.assertEqual(obs.associated_projects, "145")
+            t.rollback()
+
+        # verify that a comma-delimited string stores separate IDs
+        with Transaction() as t:
+            new_campaign = {
+                "title": "Unique Campaign Name",
+                "associated_projects": "145, 147"
+            }
+            campaign_repo = CampaignRepo(t)
+            obs = campaign_repo.create_campaign(**new_campaign)
+            self.assertEqual(obs.associated_projects, "145, 147")
+            t.rollback()
+
+        # verify that a list of strings stores separate IDs
+        with Transaction() as t:
+            new_campaign = {
+                "title": "Unique Campaign Name",
+                "associated_projects": ["145", "147"]
+            }
+            campaign_repo = CampaignRepo(t)
+            obs = campaign_repo.create_campaign(**new_campaign)
+            self.assertEqual(obs.associated_projects, "145, 147")
+            t.rollback()
+
+        # verify that a list of ints stores separate IDs
+        with Transaction() as t:
+            new_campaign = {
+                "title": "Unique Campaign Name",
+                "associated_projects": [145, 147]
+            }
+            campaign_repo = CampaignRepo(t)
+            obs = campaign_repo.create_campaign(**new_campaign)
+            self.assertEqual(obs.associated_projects, "145, 147")
+            t.rollback()
+
     def test_get_campaign_by_id_valid(self):
         # verify that it does not return None when using valid campaign_id
         with Transaction() as t:

--- a/microsetta_private_api/server.py
+++ b/microsetta_private_api/server.py
@@ -9,7 +9,7 @@ from flask_babel import Babel
 
 from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.celery_utils import celery, init_celery
-from microsetta_private_api.localization import EN_US, ES_MX, ES_ES
+from microsetta_private_api.localization import EN_US, ES_MX, ES_ES, JA_JP
 
 
 """
@@ -85,7 +85,8 @@ def build_app():
         if not flask.has_request_context():
             return EN_US
 
-        return request.accept_languages.best_match([EN_US, ES_ES, ES_MX],
+        return request.accept_languages.best_match([EN_US, ES_ES, ES_MX,
+                                                    JA_JP],
                                                    default=EN_US)
 
     init_celery(celery, app.app)

--- a/microsetta_private_api/templates/email/submit_interest_confirmation.jinja2
+++ b/microsetta_private_api/templates/email/submit_interest_confirmation.jinja2
@@ -1,0 +1,249 @@
+<html>
+<head>
+    <meta content="text/html; charset=UTF-8" http-equiv="content-type">
+    <style type="text/css">
+        ol
+        {
+            margin:0;
+            padding:0
+        }
+        table td,table th
+        {
+            padding:0
+        }
+        .c0
+        {
+            color:#000000;
+            font-weight:400;
+            text-decoration:none;
+            vertical-align:baseline;
+            font-size:12pt;
+            font-family:"Arial";
+            font-style:normal
+        }
+        .c1
+        {
+            background-color:#ffffff;
+            padding-top:0pt;
+            padding-bottom:0pt;
+            line-height:1.15;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        .c2
+        {
+            background-color:#ffffff;
+            padding-top:0pt;
+            padding-bottom:0pt;
+            line-height:1.15;
+            orphans:2;
+            widows:2;
+            text-align:left;
+            height:11pt
+        }
+        .c3
+        {
+            color:#000000;
+            font-weight:400;
+            text-decoration:none;
+            vertical-align:baseline;
+            font-size:11pt;font-family:"Arial";font-style:normal
+        }
+        .c4
+        {
+            font-size:12pt
+        }
+        .c5
+        {
+            height:11pt
+        }
+        .c6
+        {
+            color:#000000;
+            font-weight:700;
+            text-decoration:none;
+            vertical-align:baseline;
+            font-family:"Arial";
+            font-style:normal
+        }
+        .c7
+        {
+            font-weight:700
+        }
+        .c8
+        {
+            padding-top:0pt;
+            padding-bottom:0pt;
+            line-height:1.15;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        .c9
+        {
+            background-color:#ffffff;
+        }
+        .c10
+        {
+            background-color:#ffffff;
+            max-width:468pt;
+            padding:5%
+        }
+        .c11
+        {
+
+        }
+        .title
+        {
+            padding-top:0pt;
+            color:#000000;
+            font-size:26pt;
+            padding-bottom:3pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        .subtitle
+        {
+            padding-top:0pt;
+            color:#666666;
+            font-size:15pt;
+            padding-bottom:16pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        li
+        {
+            color:#000000;
+            font-size:11pt;
+            font-family:"Arial"
+        }
+        p
+        {
+            margin:0;
+            color:#000000;
+            font-size:11pt;
+            font-family:"Arial"
+        }
+        h1
+        {
+            padding-top:20pt;
+            color:#000000;
+            font-size:20pt;
+            padding-bottom:6pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        h2
+        {
+            padding-top:18pt;
+            color:#000000;
+            font-size:16pt;
+            padding-bottom:6pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        h3
+        {
+            padding-top:16pt;
+            color:#434343;
+            font-size:14pt;
+            padding-bottom:4pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        h4
+        {
+            padding-top:14pt;
+            color:#666666;
+            font-size:12pt;
+            padding-bottom:4pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        h5
+        {
+            padding-top:12pt;
+            color:#666666;
+            font-size:11pt;
+            padding-bottom:4pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+        h6
+        {
+            padding-top:12pt;
+            color:#666666;
+            font-size:11pt;
+            padding-bottom:4pt;
+            font-family:"Arial";
+            line-height:1.15;
+            page-break-after:avoid;
+            font-style:italic;
+            orphans:2;
+            widows:2;
+            text-align:left
+        }
+    </style>
+</head>
+<body class="c10">
+<p class="c1 c5"><span class="c0"></span></p>
+<p class="c1">
+    <span class="c0">{{ _("Dear") }} {{contact_name |e}},</span>
+</p>
+<p class="c1"><span class="c0">&nbsp;</span></p>
+<p class="c8 c9">
+    <span class="c4">{{ _("On behalf of Danone Nutricia Research and The Microsetta Initiative (TMI) at UC San Diego, we would like to thank you for your interest in participating in our research study THDMI - The Human Diets and Microbiome Initiative.") }}</span>
+</p>
+<p class="c2">
+    <span class="c0"></span>
+</p>
+<p class="c8 c9">
+    <span class="c0">{{ _("Soon you will receive an email letting you know if you were one of the first 800 individuals who signed up to participate in the project and what the next steps will be to take part. ") }}</span>
+</p>
+<p class="c8 c9">
+    <span class="c0">&nbsp;</span>
+</p>
+<p class="c1">
+    <span class="c0">{{ _("We are also here to help! Our team is ready to assist you with any questions you may have. Please contact us at") }} <a href = "mailto: microsetta@ucsd.edu">microsetta@ucsd.edu</a></span>
+</p>
+<p class="c1"><span class="c0">&nbsp;</span></p>
+<p class="c1"><span class="c0">{{ _("Thank you,") }}</span></p>
+<p class="c1"><span class="c0">{{ _("The Microsetta Team") }}</span></p>
+<p class="c8 c9">
+    <span class="c0">&nbsp;</span>
+</p>
+<p class="c1">
+    <span class="c0"><strong>{{ _('Tip') }}:</strong> {{ _("To ensure our emails make it to your Inbox, not your SPAM folder, remember to add us to your safe sender's list.") }}</span>
+</p>
+
+</body>
+</html>

--- a/microsetta_private_api/translations/ja_JP/LC_MESSAGES/messages.po
+++ b/microsetta_private_api/translations/ja_JP/LC_MESSAGES/messages.po
@@ -1,0 +1,304 @@
+# Japanese (Japan) translations for PROJECT.
+# Copyright (C) 2022 ORGANIZATION
+# This file is distributed under the same license as the PROJECT project.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2022.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\n"
+"POT-Creation-Date: 2022-11-01 16:48-0700\n"
+"PO-Revision-Date: 2022-11-01 16:48-0700\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja_JP\n"
+"Language-Team: ja_JP <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.11.0\n"
+
+#: admin/email_templates.py:22
+msgid "Welcome to The Microsetta Initiative"
+msgstr ""
+
+#: admin/email_templates.py:29
+msgid "Your Microsetta Initiative status update: attention needed"
+msgstr ""
+
+#: admin/email_templates.py:37 admin/email_templates.py:67
+msgid "Your Microsetta Initiative status update: information needed"
+msgstr ""
+
+#: admin/email_templates.py:45
+msgid "Your Microsetta Initiative status update and next steps"
+msgstr ""
+
+#: admin/email_templates.py:52
+msgid "Your Microsetta Initiative status update: critical information needed"
+msgstr ""
+
+#: admin/email_templates.py:60
+msgid "[PESTER] a thing happened"
+msgstr ""
+
+#: admin/email_templates.py:75
+msgid "We received your sign-up"
+msgstr ""
+
+#: templates/email/activation_email.jinja2:221
+msgid ""
+"Thank you for your interest and participation in The Microsetta "
+"Initiative. We will be shipping out your sample collection kit(s) soon."
+msgstr ""
+
+#: templates/email/activation_email.jinja2:225
+msgid ""
+"The kit(s) may still be en route, but you don't have to pause your "
+"journey just yet.  You can sign up right now to get started at "
+msgstr ""
+
+#: templates/email/activation_email.jinja2:225
+msgid "using the following info:"
+msgstr ""
+
+#: templates/email/activation_email.jinja2:228
+msgid "Email:"
+msgstr ""
+
+#: templates/email/activation_email.jinja2:229
+msgid "Activation Code:"
+msgstr ""
+
+#: templates/email/activation_email.jinja2:234
+msgid ""
+"Not your first foray into the microbiome?  No problem, you don't need to "
+"sign up again, your kit(s) can be added to your existing account when the"
+" order arrives."
+msgstr ""
+
+#: templates/email/activation_email.jinja2:238
+#: templates/email/incorrect_sample_type.jinja2:239
+#: templates/email/missing_sample_info.jinja2:269
+#: templates/email/sample_is_valid.jinja2:228
+msgid "If you have any questions, please reply to us at "
+msgstr ""
+
+#: templates/email/activation_email.jinja2:238
+#: templates/email/incorrect_sample_type.jinja2:239
+#: templates/email/sample_is_valid.jinja2:228
+msgid "Thank you for supporting our project."
+msgstr ""
+
+#: templates/email/activation_email.jinja2:242
+#: templates/email/incorrect_sample_type.jinja2:243
+msgid "Sincerely,"
+msgstr ""
+
+#: templates/email/activation_email.jinja2:245
+#: templates/email/address_invalid.jinja2:250
+#: templates/email/incorrect_sample_type.jinja2:246
+#: templates/email/missing_sample_info.jinja2:273
+#: templates/email/no_associated_source.jinja2:276
+#: templates/email/sample_is_valid.jinja2:235
+#: templates/email/submit_interest_confirmation.jinja2:240
+msgid "The Microsetta Team"
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:220
+#: templates/email/incorrect_sample_type.jinja2:220
+#: templates/email/missing_sample_info.jinja2:220
+#: templates/email/no_associated_source.jinja2:220
+#: templates/email/sample_is_valid.jinja2:220
+msgid "Hello"
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:224
+msgid ""
+"Thank you for your interest and participation in The Microsetta "
+"Initiative. We are writing as we've encountered an issue processing your "
+"transaction, and we would appreciate your assistance in helping to "
+"resolve this matter."
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:226
+msgid ""
+"Specifically, we were unable to verify the address to which you requested"
+" we ship you kit(s)."
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:232
+msgid ""
+"To resolve this issue and ensure we have a valid shipping address, please"
+" click the following link or copy and paste the URL into your browser:"
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:246
+#: templates/email/no_associated_source.jinja2:272
+msgid "If you have any questions, please reply to us at"
+msgstr ""
+
+#: templates/email/address_invalid.jinja2:249
+#: templates/email/missing_sample_info.jinja2:272
+#: templates/email/no_associated_source.jinja2:275
+#: templates/email/submit_interest_confirmation.jinja2:239
+msgid "Thank you,"
+msgstr ""
+
+#: templates/email/incorrect_sample_type.jinja2:224
+msgid ""
+"We recently received the following microbiome sample from you and noticed"
+" that it might have been incorrectly labeled."
+msgstr ""
+
+#: templates/email/incorrect_sample_type.jinja2:229
+msgid "Marked"
+msgstr ""
+
+#: templates/email/incorrect_sample_type.jinja2:229
+msgid "but appears to be"
+msgstr ""
+
+#: templates/email/incorrect_sample_type.jinja2:236
+msgid ""
+"Our lab will need verification of the type of sample you sent in before "
+"they can begin processing it to ensure that your sample is sequenced "
+"correctly. If you know the sample type then please reply to this email"
+msgstr ""
+
+#: templates/email/incorrect_sample_type.jinja2:236
+msgid ""
+"with this information. We will then update your profile so the collection"
+" can be appropriately associated."
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:224
+msgid ""
+"Thank you for your interest and participation in The Microsetta "
+"Initiative. We are writing as we've encountered an issue processing your "
+"sample, and we would appreciate your assistance in helping to resolve "
+"this matter. To make sure we have the correct information, we require you"
+" to confirm the type of sample you sent and the collection date and time "
+"with our team. Please click on the URL below to view the collection "
+"information."
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:236
+msgid "Based on what we can see, we think the collection type is:"
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:250
+msgid ""
+"We require this information in order to process the collection in "
+"compliance with our human subjects research protocol. Therefore, editing "
+"online account information is currently locked as a preventative measure "
+"to ensure we meet regulations. Not to worry - by replying to this email "
+"our team is ready to assist you with updating the following information."
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:254
+#: templates/email/no_associated_source.jinja2:263
+msgid "Collection date"
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:255
+#: templates/email/no_associated_source.jinja2:264
+msgid "Collection time"
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:256
+#: templates/email/no_associated_source.jinja2:265
+msgid "Collection type"
+msgstr ""
+
+#: templates/email/missing_sample_info.jinja2:263
+msgid ""
+"Once we have these details, we will update the record so the specimen can"
+" be processed appropriately."
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:224
+msgid ""
+"Thank you for your interest and participation in The Microsetta "
+"Initiative. We are writing as we've encountered an issue processing your "
+"collection, and we would appreciate your assistance in helping to resolve"
+" this matter."
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:226
+msgid ""
+"Specifically, the following sample sent to the lab needs more information"
+" to be included before it can be processed:"
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:238
+msgid ""
+"We require this information to process this specimen in compliance with "
+"our human subjects research protocol. Please log back into the "
+"participant website by clicking or copying the following URL:"
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:245
+msgid "Your account"
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:252
+msgid ""
+"After accessing your account using the above URL, you will need to create"
+" a source by clicking on one of the buttons under the \"Sources\" "
+"section."
+msgstr ""
+
+#: templates/email/no_associated_source.jinja2:258
+msgid ""
+"Once a source has been created, please reply to this email with the "
+"following information so that we can link the collection to your source:"
+msgstr ""
+
+#: templates/email/sample_is_valid.jinja2:224
+msgid ""
+"Thank you for your interest and participation in The Microsetta "
+"Initiative. We have received your microbiome collection, and it is now in"
+" the processing queue. Samples are processed within 1 – 3 months. Once "
+"sequenced, you will receive an update with a link to your results."
+msgstr ""
+
+#: templates/email/sample_is_valid.jinja2:232
+msgid "Kind regards,"
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:220
+msgid "Dear"
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:224
+msgid ""
+"On behalf of Danone Nutricia Research and The Microsetta Initiative (TMI)"
+" at UC San Diego, we would like to thank you for your interest in "
+"participating in our research study THDMI - The Human Diets and "
+"Microbiome Initiative."
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:230
+msgid ""
+"Soon you will receive an email letting you know if you were one of the "
+"first 800 individuals who signed up to participate in the project and "
+"what the next steps will be to take part. "
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:236
+msgid ""
+"We are also here to help! Our team is ready to assist you with any "
+"questions you may have. Please contact us at"
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:245
+msgid "Tip"
+msgstr ""
+
+#: templates/email/submit_interest_confirmation.jinja2:245
+msgid ""
+"To ensure our emails make it to your Inbox, not your SPAM folder, "
+"remember to add us to your safe sender's list."
+msgstr ""
+


### PR DESCRIPTION
The scope of this PR is to support THDMI Japan signups using the Interested Users form on the existing platform. The actual THDMI Japan campaign will be launched on the new version of the TMI platform, so these PRs explicitly exclude Japanese translations for the consent documents and surveys.

To prevent the edge case of an existing account changing their account to Japanese and/or someone with an existing Kit ID/Activation Code from creating an account and selecting Japanese, I've prevented it from displaying as a language option in the Account Details screen.

Added:
- Confirmation email for THDMI signups
- True/False flag in campaign.campaigns table to determine whether confirmation email should be sent
- ja_JP locale

Fixed:
- Issue #468 
