### PR TITLE
Functionality to allow interested users to opt out

### DIFF
--- a/microsetta_private_api/api/__init__.py
+++ b/microsetta_private_api/api/__init__.py
@@ -45,7 +45,7 @@ from ._campaign import (
 
 from ._interested_user import (
     create_interested_user, get_interested_user_address_update,
-    put_interested_user_address_update
+    put_interested_user_address_update, get_opt_out, put_opt_out
 )
 
 from ..config_manager import SERVER_CONFIG

--- a/microsetta_private_api/api/_interested_user.py
+++ b/microsetta_private_api/api/_interested_user.py
@@ -180,6 +180,56 @@ def put_interested_user_address_update(body):
         return jsonify(user_id=interested_user_id), 200
 
 
+def get_opt_out(interested_user_id):
+    with Transaction() as t:
+        i_u_repo = InterestedUserRepo(t)
+        i_u = i_u_repo.get_interested_user_by_id(interested_user_id)
+
+        if i_u is None:
+            return jsonify(
+                code=404,
+                message="Interested user not found."
+            ), 404
+        else:
+            campaign_repo = CampaignRepo(t)
+            campaign_info = \
+                campaign_repo.get_campaign_by_id(i_u.campaign_id)
+
+            return jsonify(
+                interested_user_id=interested_user_id,
+                force_primary_language=campaign_info.force_primary_language,
+                language_key=campaign_info.language_key
+            ), 200
+
+
+def put_opt_out(interested_user_id):
+    with Transaction() as t:
+        i_u_repo = InterestedUserRepo(t)
+        i_u = i_u_repo.get_interested_user_by_id(interested_user_id)
+
+        if i_u is None:
+            return jsonify(
+                code=404,
+                message="Interested user not found."
+            ), 404
+        else:
+            # We don't care if they've already opted out, we're just going to
+            # tell them we've removed them from the list
+            _ = i_u_repo.opt_out_interested_user(interested_user_id)
+
+            campaign_repo = CampaignRepo(t)
+            campaign_info = \
+                campaign_repo.get_campaign_by_id(i_u.campaign_id)
+
+            t.commit()
+
+            return jsonify(
+                interested_user_id=interested_user_id,
+                force_primary_language=campaign_info.force_primary_language,
+                language_key=campaign_info.language_key
+            ), 200
+
+
 def _validate_iuid_and_email_syntax(interested_user_id, email):
     try:
         uuid.UUID(interested_user_id)

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -1615,6 +1615,68 @@ paths:
         '400':
           description: Creation or validation issue with the interested user
 
+  '/opt_out':
+    get:
+      operationId: microsetta_private_api.api.get_opt_out
+      tags:
+        - Campaigns
+      summary: Verify that an interested user exists for a given ID and can be opted out
+      description: Verify that an interested user exists for a given ID and can be opted out
+      security: [ ]
+      parameters:
+        - in: query
+          name: interested_user_id
+          description: unique identifier of interested user
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: interested user's id & campaign-oriented language information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  'interested_user_id':
+                    type: string
+                  'force_primary_language':
+                    type: boolean
+                  'language_key':
+                    type: string
+        '404':
+          $ref: '#/components/responses/404NotFound'
+    put:
+      operationId: microsetta_private_api.api.put_opt_out
+      tags:
+        - Campaigns
+      summary: Opt an interested user out of a campaign
+      description: Opt an interested user out of a campaign
+      security: [ ]
+      parameters:
+        - in: query
+          name: interested_user_id
+          description: unique identifier of interested user
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: interested user's id & campaign-oriented language information
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  'interested_user_id':
+                    type: string
+                  'force_primary_language':
+                    type: boolean
+                  'language_key':
+                    type: string
+        '404':
+          $ref: '#/components/responses/404NotFound'
+
   '/update_address':
     get:
       operationId: microsetta_private_api.api.get_interested_user_address_update

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -89,6 +89,16 @@ class InterestedUserRepo(BaseRepo):
             )
             return cur.rowcount == 1
 
+    def opt_out_interested_user(self, interested_user_id):
+        with self._transaction.cursor() as cur:
+            cur.execute(
+                "UPDATE campaign.interested_users "
+                "SET confirm_consent = FALSE "
+                "WHERE interested_user_id = %s",
+                (interested_user_id, )
+            )
+            return cur.rowcount
+
     def get_interested_user_by_id(self, interested_user_id):
         with self._transaction.dict_cursor() as cur:
             try:

--- a/microsetta_private_api/repo/tests/test_interested_user_repo.py
+++ b/microsetta_private_api/repo/tests/test_interested_user_repo.py
@@ -295,6 +295,35 @@ class InterestedUserRepoTests(unittest.TestCase):
                 interested_user_repo.get_interested_user_by_email(t_e)
             self.assertFalse(obs is False)
 
+    def test_opt_out_interested_user(self):
+        dummy_user = {
+            "campaign_id": self.test_campaign_id,
+            "first_name": "Test",
+            "last_name": "McTesterson",
+            "email": "test@testing.com",
+            "confirm_consent": True
+        }
+        interested_user = InterestedUser.from_dict(dummy_user)
+        with Transaction() as t:
+            i_u_repo = InterestedUserRepo(t)
+            user_id = i_u_repo.insert_interested_user(interested_user)
+            i_u = i_u_repo.get_interested_user_by_id(user_id)
+
+            # Verify that the user has provided consent (is opted in)
+            self.assertTrue(i_u.confirm_consent)
+
+            # Opt the user out
+            r_c = i_u_repo.opt_out_interested_user(user_id)
+
+            # Verify that a row was updated
+            self.assertEqual(r_c, 1)
+
+            # Pull a fresh instance of the interested user
+            i_u = i_u_repo.get_interested_user_by_id(user_id)
+
+            # Verify that the user is now opted out
+            self.assertFalse(i_u.confirm_consent)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For THDMI Japan, we'll be emailing people who signed up to join the cohort, giving them the opportunity to opt out if they've decided they don't want to receive a kit. This PR exposes new API endpoints and implements corresponding repo functionality to reflect a given interested_user deciding they no longer want to participate, using the confirm_consent column.