### PR TITLE
Resolve external survey account deletion bug.

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -808,10 +808,17 @@ def delete_account(account_id, token_info):
 
         sample_count = 0
         account_has_external = False
-        sources = src_repo.get_sources_in_account(account_id)
+        sources = src_repo.get_sources_in_account(
+            account_id,
+            allow_revoked=True
+        )
 
         for source in sources:
-            samples = samp_repo.get_samples_by_source(account_id, source.id)
+            samples = samp_repo.get_samples_by_source(
+                account_id,
+                source.id,
+                allow_revoked=True
+            )
 
             has_samples = len(samples) > 0
             sample_count += len(samples)
@@ -832,7 +839,11 @@ def delete_account(account_id, token_info):
                 # survey / source free text
                 for survey_id in surveys:
                     sar_repo.scrub(account_id, source.id, survey_id)
-                src_repo.scrub(account_id, source.id)
+
+                # We're including scrubbed sources to detect external surveys
+                # so we need to make sure the source isn't already scrubbed
+                if source.source_data.date_revoked is None:
+                    src_repo.scrub(account_id, source.id)
 
             if not has_samples and not has_external:
                 # if we do not have associated samples, or external surveys,

--- a/microsetta_private_api/api/_source.py
+++ b/microsetta_private_api/api/_source.py
@@ -4,11 +4,14 @@ from datetime import date
 from flask import jsonify
 
 from microsetta_private_api.api._account import _validate_account_access
-from microsetta_private_api.api.literals import SRC_NOT_FOUND_MSG
+from microsetta_private_api.api.literals import SRC_NOT_FOUND_MSG,\
+    SRC_NO_DELETE_MSG
 from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.model.source import Source, HumanInfo, NonHumanInfo
 from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
+from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
+from microsetta_private_api.repo.sample_repo import SampleRepo
 from microsetta_private_api.repo.transaction import Transaction
 
 
@@ -109,18 +112,44 @@ def delete_source(account_id, source_id, token_info):
     with Transaction() as t:
         source_repo = SourceRepo(t)
         survey_answers_repo = SurveyAnswersRepo(t)
+        template_repo = SurveyTemplateRepo(t)
+        sample_repo = SampleRepo(t)
 
-        answers = survey_answers_repo.list_answered_surveys(account_id,
-                                                            source_id)
-        for survey_id in answers:
-            survey_answers_repo.delete_answered_survey(account_id,
-                                                       survey_id)
+        # The interface has historically enforced this constraint, but it
+        # wasn't codified into the API
+        samples = sample_repo.get_samples_by_source(account_id, source_id)
+        if len(samples) > 0:
+            return jsonify(code=422, message=SRC_NO_DELETE_MSG), 422
+        else:
+            has_external = template_repo.has_external_surveys(
+                account_id,
+                source_id
+            )
+            answers = survey_answers_repo.list_answered_surveys(
+                account_id,
+                source_id
+            )
 
-        if not source_repo.delete_source(account_id, source_id):
-            return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
-        # TODO: 422?
-        t.commit()
-        return '', 204
+            if has_external:
+                for survey_id in answers:
+                    survey_answers_repo.scrub(
+                        account_id,
+                        source_id,
+                        survey_id
+                    )
+                if not source_repo.scrub(account_id, source_id):
+                    return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
+            else:
+                for survey_id in answers:
+                    survey_answers_repo.delete_answered_survey(
+                        account_id,
+                        survey_id
+                    )
+                if not source_repo.delete_source(account_id, source_id):
+                    return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
+
+            t.commit()
+            return '', 204
 
 
 def create_human_source_from_consent(account_id, body, token_info):

--- a/microsetta_private_api/api/_source.py
+++ b/microsetta_private_api/api/_source.py
@@ -140,9 +140,9 @@ def delete_source(account_id, source_id, token_info):
                 if not source_repo.scrub(account_id, source_id):
                     return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
             else:
-                # If we reach this point, then the user does not have external surveys
-                # nor do they have samples associated. Therefore it is safe to remove
-                # their surveys and source entirely 
+                # If we reach this point, then the user does not have external
+                # surveys nor do they have samples associated. Therefore it is
+                # safe to remove their surveys and source entirely
                 for survey_id in answers:
                     survey_answers_repo.delete_answered_survey(
                         account_id,

--- a/microsetta_private_api/api/_source.py
+++ b/microsetta_private_api/api/_source.py
@@ -140,6 +140,9 @@ def delete_source(account_id, source_id, token_info):
                 if not source_repo.scrub(account_id, source_id):
                     return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
             else:
+                # If we reach this point, then the user does not have external surveys
+                # nor do they have samples associated. Therefore it is safe to remove
+                # their surveys and source entirely 
                 for survey_id in answers:
                     survey_answers_repo.delete_answered_survey(
                         account_id,

--- a/microsetta_private_api/api/literals.py
+++ b/microsetta_private_api/api/literals.py
@@ -13,4 +13,6 @@ JWT_SUB_CLAIM_KEY = 'sub'
 JWT_EMAIL_CLAIM_KEY = 'email'
 ACCT_NOT_FOUND_MSG = "Account not found"
 SRC_NOT_FOUND_MSG = "Source not found"
+SRC_NO_DELETE_MSG = "A source cannot be deleted while samples are "\
+    "associated with it"
 INVALID_TOKEN_MSG = "Invalid token"

--- a/microsetta_private_api/client/tests/test_fundrazr.py
+++ b/microsetta_private_api/client/tests/test_fundrazr.py
@@ -41,7 +41,7 @@ class FundrazrClientTests(TestCase):
         obs = self.c.campaigns()
 
         # staging has two campaigns, let's assume that's stable...
-        self.assertEqual(len(obs), 2)
+        self.assertEqual(len(obs), 3)
         self.assertTrue(len(obs[0].items) > 0)
 
     @skipIf(SERVER_CONFIG['fundrazr_url'] in ('', 'fundrazr_url_placeholder'),

--- a/microsetta_private_api/db/patches/0112.sql
+++ b/microsetta_private_api/db/patches/0112.sql
@@ -1,0 +1,4 @@
+-- We need to clean up stale state on an account that requested deletion.
+-- Using a non-sequential patch filename to ease merging master and master-overhaul soon.
+DELETE FROM ag.polyphenol_ffq_registry WHERE account_id = 'b499417a-0840-44da-b269-d243f6eb02ae';
+DELETE FROM ag.spain_ffq_registry WHERE account_id = 'b499417a-0840-44da-b269-d243f6eb02ae';


### PR DESCRIPTION
https://github.com/biocore/microsetta-private-api/issues/492

This PR addresses a few related issues:
1) Fixes stale state for an account that we need to delete.
2) Changes the user-facing source deletion code to scrub, rather than delete, if they've taken external surveys. This is then leveraged by the admin-facing account deletion code to detect the external surveys that could be left dangling before this change.
3) Implemented a 422 response scenario for delete_source(). Prior to this code, it was declared as a possibility in the yaml file, but wasn't actually implemented in the API.