### PR TITLE
Pin flask-babel

### DIFF
--- a/ci/pip_requirements.txt
+++ b/ci/pip_requirements.txt
@@ -11,6 +11,6 @@ celery[redis]
 redis
 requests
 requests_oauthlib
-flask-babel
+flask-babel < 3.0.0
 html2text
 https://github.com/qiita-spots/qiita_client/archive/refs/heads/master.zip


### PR DESCRIPTION
@wasade I had pinned flask-babel in master-overhaul when this issue popped up in January, but not master. This should be a formality but can you merge this so that workflow can re-run on my other PR? (Going to open one on Interface momentarily as well)