### PR TITLE
Overhaul Adjustments + Bugfix

### DIFF
--- a/microsetta_private_api/celery_utils.py
+++ b/microsetta_private_api/celery_utils.py
@@ -45,18 +45,18 @@ def init_celery(celery, app):
            "task": "microsetta_private_api.util.fundrazr.get_fundrazr_transactions",  # noqa
            "schedule": 60 * 60  # every hour
         },
-        "fulfill_new_transactions": {
-           "task": "microsetta_private_api.util.perk_fulfillment.fulfill_new_transactions",  # noqa
-           "schedule": 60 * 60  # every hour
-        },
+        # "fulfill_new_transactions": {
+        #    "task": "microsetta_private_api.util.perk_fulfillment.fulfill_new_transactions",  # noqa
+        #    "schedule": 60 * 60  # every hour
+        # },
         # "fulfill_subscriptions": {
         #    "task": "microsetta_private_api.util.perk_fulfillment.process_subscription_fulfillments",  # noqa
         #    "schedule": 60 * 60 * 24  # every 24 hours
         # },
-        # "check_shipping_updates": {
-        #    "task": "microsetta_private_api.util.perk_fulfillment.check_shipping_updates",  # noqa
-        #    "schedule": 60 * 60 * 4  # every 4 hours
-        # },
+        "check_shipping_updates": {
+           "task": "microsetta_private_api.util.perk_fulfillment.check_shipping_updates",  # noqa
+           "schedule": 60 * 60 * 4  # every 4 hours
+        },
         # "perks_without_fulfillment_details": {
         #    "task": "microsetta_private_api.util.perk_fulfillment.perks_without_fulfillment_details",  # noqa
         #    "schedule": 60 * 60 * 24  # every 24 hours

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -6,9 +6,9 @@ from psycopg2 import sql
 
 
 class Transaction:
-    # Note: SimpleConnectionPool works only for single threaded applications
-    #  Should we make the server multi threaded, we must switch to a
-    #  ThreadedConnectionPool
+    # Note: Using ThreadedConnectionPool as we've switched Celery to threaded
+    # mode. If we change that back to prefork, recommend changing the pool
+    # back to SimpleConnectionPool.
     _POOL = psycopg2.pool.ThreadedConnectionPool(
         1,
         20,

--- a/microsetta_private_api/repo/transaction.py
+++ b/microsetta_private_api/repo/transaction.py
@@ -9,7 +9,7 @@ class Transaction:
     # Note: SimpleConnectionPool works only for single threaded applications
     #  Should we make the server multi threaded, we must switch to a
     #  ThreadedConnectionPool
-    _POOL = psycopg2.pool.SimpleConnectionPool(
+    _POOL = psycopg2.pool.ThreadedConnectionPool(
         1,
         20,
         user=AMGUT_CONFIG.user,

--- a/microsetta_private_api/util/perk_fulfillment.py
+++ b/microsetta_private_api/util/perk_fulfillment.py
@@ -73,6 +73,8 @@ def check_shipping_updates():
         emails_sent, error_report = pfr.check_for_shipping_updates()
 
         if emails_sent > 0 or len(error_report) > 0:
+            t.commit()
+
             email_content = f"Emails sent: {emails_sent}\n"\
                             f"Errors: {error_report}"
             try:


### PR DESCRIPTION
This PR addresses three issues:
1) It changes our psycopg2 pool from `SimpleConnectionPool` to `ThreadedConnectionPool`, which is necessary as we'll be running Celery in threaded mode, rather than prefork.
2) It adds a `t.commit()` that was missing from the `check_shipping_updates()` task in util/perk_fulfillment.py.
3) It switches all perk fulfillment communication from the `payer_email` that Fundrazr returns to the `contact_email`, which is stored as` interested_users.email`.