### PR TITLE
Update Legacy Sources' age_range

### DIFF
--- a/microsetta_private_api/api/_consent.py
+++ b/microsetta_private_api/api/_consent.py
@@ -5,9 +5,11 @@ from microsetta_private_api.api._account import \
     _validate_account_access
 from microsetta_private_api.model.consent import ConsentSignature
 from microsetta_private_api.repo.consent_repo import ConsentRepo
+from microsetta_private_api.repo.source_repo import SourceRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.api.literals import CONSENT_DOC_NOT_FOUND_MSG
 from werkzeug.exceptions import NotFound
+from microsetta_private_api.api.literals import SRC_NOT_FOUND_MSG
 
 
 def render_consent_doc(account_id, language_tag, token_info):
@@ -56,6 +58,24 @@ def sign_consent_doc(account_id, source_id, consent_type, body, token_info):
     _validate_account_access(token_info, account_id)
 
     with Transaction() as t:
+        # Sources with an age_range of "legacy" will select an age range
+        # the first time they sign a new consent document. We need to
+        # catch legacy sources as they come in and update their age.
+        source_repo = SourceRepo(t)
+        source = source_repo.get_source(account_id, source_id)
+        if source is None:
+            return jsonify(code=404, message=SRC_NOT_FOUND_MSG), 404
+
+        if source.source_data.age_range == "legacy":
+            update_success = source_repo.update_legacy_source_age_range(
+                source_id, body['age_range']
+            )
+            if not update_success:
+                return jsonify(
+                    code=403, message="Invalid age_range update"
+                ), 403
+
+        # Now back to the normal flow of signing a consent document
         consent_repo = ConsentRepo(t)
         sign_id = str(uuid.uuid4())
         consent_sign = ConsentSignature.from_dict(body, source_id, sign_id)

--- a/microsetta_private_api/repo/source_repo.py
+++ b/microsetta_private_api/repo/source_repo.py
@@ -144,6 +144,18 @@ class SourceRepo(BaseRepo):
                         )
             return cur.rowcount == 1
 
+    def update_legacy_source_age_range(self, source_id, age_range):
+        # We need to allow sources with an age_range of 'legacy' to update
+        # their age_range, but we do not want to expose this to any other
+        # update paths.
+        with self._transaction.cursor() as cur:
+            cur.execute("UPDATE ag.source "
+                        "SET age_range = %s "
+                        "WHERE id = %s AND age_range = 'legacy'",
+                        (age_range, source_id)
+                        )
+            return cur.rowcount == 1
+
     def create_source(self, source):
         with self._transaction.cursor() as cur:
             acct_repo = AccountRepo(self._transaction)

--- a/microsetta_private_api/repo/tests/test_source.py
+++ b/microsetta_private_api/repo/tests/test_source.py
@@ -75,6 +75,36 @@ class SourceRepoTests(unittest.TestCase):
 
             self.assertTrue(obs.source_data.date_revoked is not None)
 
+    def test_update_legacy_source_age_range_succeed(self):
+        with Transaction() as t:
+            # First, we need to update the test source to an age_range of
+            # 'legacy'
+            cur = t.cursor()
+            cur.execute("UPDATE ag.source "
+                        "SET age_range = 'legacy' "
+                        "WHERE id = %s",
+                        (HUMAN_SOURCE.id, )
+                        )
+
+            # Now, let's update it
+            sr = SourceRepo(t)
+            obs = sr.update_legacy_source_age_range(
+                HUMAN_SOURCE.id,
+                "18-plus"
+            )
+            self.assertTrue(obs)
+
+    def test_update_legacy_source_age_range_fail(self):
+        # We'll try to update the human source without setting its age range
+        # to 'legacy'
+        with Transaction() as t:
+            sr = SourceRepo(t)
+            obs = sr.update_legacy_source_age_range(
+                HUMAN_SOURCE.id,
+                "18-plus"
+            )
+            self.assertFalse(obs)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When a source with an `age_range` value of `legacy` signs a new consent document, the API will store their selected `age_range` to bring the source in line with the convention of falling into one of four age ranges.