### PR TITLE
Add Toggle for Perk Fulfillment to Settings

### DIFF
--- a/microsetta_private_api/db/patches/0131.sql
+++ b/microsetta_private_api/db/patches/0131.sql
@@ -1,0 +1,2 @@
+-- Add column to settings that controls whether Perk Fulfillment jobs run
+ALTER TABLE ag.settings ADD COLUMN perk_fulfillment_active BOOLEAN DEFAULT FALSE NOT NULL;

--- a/microsetta_private_api/repo/perk_fulfillment_repo.py
+++ b/microsetta_private_api/repo/perk_fulfillment_repo.py
@@ -780,3 +780,12 @@ class PerkFulfillmentRepo(BaseRepo):
                 "template_args": email_args
             })
         EventLogRepo(self._transaction).add_event(event)
+
+    def check_perk_fulfillment_active(self):
+        with self._transaction.dict_cursor() as cur:
+            cur.execute(
+                "SELECT perk_fulfillment_active "
+                "FROM ag.settings "
+            )
+            row = cur.fetchone()
+            return row['perk_fulfillment_active']

--- a/microsetta_private_api/repo/tests/test_perk_fulfillment_repo.py
+++ b/microsetta_private_api/repo/tests/test_perk_fulfillment_repo.py
@@ -964,6 +964,32 @@ class PerkFulfillmentRepoTests(unittest.TestCase):
                 error_list = pfr.process_subscription_fulfillment(f_id)
                 self.assertEqual(len(error_list), 0)
 
+    def test_check_perk_fulfillment_active_true(self):
+        with Transaction() as t:
+            # Update the database column to reflect a state of True
+            cur = t.cursor()
+            cur.execute(
+                "UPDATE ag.settings SET perk_fulfillment_active = TRUE"
+            )
+
+            # Now verify that our helper function returns the correct state
+            pfr = PerkFulfillmentRepo(t)
+            res = pfr.check_perk_fulfillment_active()
+            self.assertTrue(res)
+
+    def test_check_perk_fulfillment_active_false(self):
+        with Transaction() as t:
+            # Update the database column to reflect a state of False
+            cur = t.cursor()
+            cur.execute(
+                "UPDATE ag.settings SET perk_fulfillment_active = FALSE"
+            )
+
+            # Now verify that our helper function returns the correct state
+            pfr = PerkFulfillmentRepo(t)
+            res = pfr.check_perk_fulfillment_active()
+            self.assertFalse(res)
+
     def _count_ffq_registration_codes(self, t):
         cur = t.cursor()
         cur.execute(


### PR DESCRIPTION
This pull request adds a new column to `ag.settings` - `perk_fulfillment_active`. When this column is True, the Celery jobs for fulfilling transactions will run as normal. When it's False, the jobs will abort immediately after checking the `perk_fulfillment_active` setting.

I've allowed the jobs that check for shipping updates and perks without fulfillment details to bypass the check, as there's no harm in allowing them to run even when perk fulfillment is off (and in some cases would actually be beneficial).