### PR TITLE
Add Language Tag/Locale to Reconsent Check

### DIFF
--- a/microsetta_private_api/api/_consent.py
+++ b/microsetta_private_api/api/_consent.py
@@ -44,17 +44,21 @@ def get_consent_doc(account_id, consent_id, token_info):
         return jsonify(code=404, message=CONSENT_DOC_NOT_FOUND_MSG), 404
 
 
-def check_consent_signature(account_id, source_id, consent_type, language_tag, token_info):
+def check_consent_signature(
+        account_id, source_id, consent_type, language_tag, token_info
+):
     _validate_account_access(token_info, account_id)
 
     with Transaction() as t:
         consent_repo = ConsentRepo(t)
-        res = consent_repo.is_consent_required(source_id, consent_type, language_tag)
+        res = consent_repo.is_consent_required(
+            source_id, consent_type, language_tag
+        )
 
     return jsonify({"result": res}), 200
 
 
-def sign_consent_doc(account_id, source_id, consent_type, body, token_info):
+def sign_consent_doc(account_id, source_id, body, token_info):
     _validate_account_access(token_info, account_id)
 
     with Transaction() as t:

--- a/microsetta_private_api/api/_consent.py
+++ b/microsetta_private_api/api/_consent.py
@@ -49,7 +49,7 @@ def check_consent_signature(account_id, source_id, consent_type, language_tag, t
 
     with Transaction() as t:
         consent_repo = ConsentRepo(t)
-        res = consent_repo.is_consent_required(source_id, consent_type)
+        res = consent_repo.is_consent_required(source_id, consent_type, language_tag)
 
     return jsonify({"result": res}), 200
 

--- a/microsetta_private_api/api/_consent.py
+++ b/microsetta_private_api/api/_consent.py
@@ -44,7 +44,7 @@ def get_consent_doc(account_id, consent_id, token_info):
         return jsonify(code=404, message=CONSENT_DOC_NOT_FOUND_MSG), 404
 
 
-def check_consent_signature(account_id, source_id, consent_type, token_info):
+def check_consent_signature(account_id, source_id, consent_type, language_tag, token_info):
     _validate_account_access(token_info, account_id)
 
     with Transaction() as t:

--- a/microsetta_private_api/api/_consent.py
+++ b/microsetta_private_api/api/_consent.py
@@ -58,7 +58,7 @@ def check_consent_signature(
     return jsonify({"result": res}), 200
 
 
-def sign_consent_doc(account_id, source_id, body, token_info):
+def sign_consent_doc(account_id, source_id, consent_type, body, token_info):
     _validate_account_access(token_info, account_id)
 
     with Transaction() as t:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -410,6 +410,7 @@ paths:
         - $ref: '#/components/parameters/account_id'
         - $ref: '#/components/parameters/source_id'
         - $ref: '#/components/parameters/consent_type'
+        - $ref: '#/components/parameters/language_tag'
       responses:
         '200':
           description: Consent Signature Status

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -1120,7 +1120,7 @@ class IntegrationTests(TestCase):
         self.assertTrue(consent_res["result"])
 
         response = self.client.post(
-            '/api/accounts/%s/source/%s/consent/%s?language_tag=en_US' %
+            '/api/accounts/%s/source/%s/consent/%s' %
             (ACCT_ID, new_source["source_id"], "data"),
             content_type='application/json',
             data=json.dumps(SOURCE_DATA),

--- a/microsetta_private_api/api/tests/test_integration.py
+++ b/microsetta_private_api/api/tests/test_integration.py
@@ -1111,7 +1111,7 @@ class IntegrationTests(TestCase):
         new_source = json.loads(resp.data)
 
         consent_status = self.client.get(
-            '/api/accounts/%s/source/%s/consent/%s' %
+            '/api/accounts/%s/source/%s/consent/%s?language_tag=en_US' %
             (ACCT_ID, new_source["source_id"], "data"),
             headers=MOCK_HEADERS)
 
@@ -1120,7 +1120,7 @@ class IntegrationTests(TestCase):
         self.assertTrue(consent_res["result"])
 
         response = self.client.post(
-            '/api/accounts/%s/source/%s/consent/%s' %
+            '/api/accounts/%s/source/%s/consent/%s?language_tag=en_US' %
             (ACCT_ID, new_source["source_id"], "data"),
             content_type='application/json',
             data=json.dumps(SOURCE_DATA),

--- a/microsetta_private_api/repo/consent_repo.py
+++ b/microsetta_private_api/repo/consent_repo.py
@@ -125,6 +125,7 @@ class ConsentRepo(BaseRepo):
                 "ORDER BY sign_date DESC",
                 (source_id, ('%' + consent_type + '%'), language_tag)
             )
+            print(cur.query)
 
             r = cur.fetchone()
             if r is None:

--- a/microsetta_private_api/repo/consent_repo.py
+++ b/microsetta_private_api/repo/consent_repo.py
@@ -145,10 +145,6 @@ class ConsentRepo(BaseRepo):
                     sign_date = r["sign_date"]
                     doc_date = s["date_time"]
 
-                    print("Sign Date: " + sign_date.strftime("%m/%d/%Y, %H:%M:%S"))
-                    print("Doc Date: " + doc_date.strftime("%m/%d/%Y, %H:%M:%S"))
-
-                    print("Fail 150")
                     return doc_date > sign_date
             else:
                 return r["reconsent_required"]

--- a/microsetta_private_api/repo/consent_repo.py
+++ b/microsetta_private_api/repo/consent_repo.py
@@ -125,11 +125,9 @@ class ConsentRepo(BaseRepo):
                 "ORDER BY sign_date DESC",
                 (source_id, ('%' + consent_type + '%'), language_tag)
             )
-            print(cur.query)
 
             r = cur.fetchone()
             if r is None:
-                print("Fail 131")
                 return True
             elif r['reconsent_required']:
                 consent_doc_type = r["consent_type"]
@@ -142,11 +140,13 @@ class ConsentRepo(BaseRepo):
 
                 s = cur.fetchone()
                 if s is None:
-                    print("Fail 144")
                     return True
                 else:
                     sign_date = r["sign_date"]
                     doc_date = s["date_time"]
+
+                    print("Sign Date: " + sign_date)
+                    print("Doc Date: " + doc_date)
 
                     print("Fail 150")
                     return doc_date > sign_date

--- a/microsetta_private_api/repo/consent_repo.py
+++ b/microsetta_private_api/repo/consent_repo.py
@@ -145,8 +145,8 @@ class ConsentRepo(BaseRepo):
                     sign_date = r["sign_date"]
                     doc_date = s["date_time"]
 
-                    print("Sign Date: " + sign_date)
-                    print("Doc Date: " + doc_date)
+                    print("Sign Date: " + sign_date.strftime("%m/%d/%Y, %H:%M:%S"))
+                    print("Doc Date: " + doc_date.strftime("%m/%d/%Y, %H:%M:%S"))
 
                     print("Fail 150")
                     return doc_date > sign_date

--- a/microsetta_private_api/repo/consent_repo.py
+++ b/microsetta_private_api/repo/consent_repo.py
@@ -128,6 +128,7 @@ class ConsentRepo(BaseRepo):
 
             r = cur.fetchone()
             if r is None:
+                print("Fail 131")
                 return True
             elif r['reconsent_required']:
                 consent_doc_type = r["consent_type"]
@@ -140,11 +141,13 @@ class ConsentRepo(BaseRepo):
 
                 s = cur.fetchone()
                 if s is None:
+                    print("Fail 144")
                     return True
                 else:
                     sign_date = r["sign_date"]
                     doc_date = s["date_time"]
 
+                    print("Fail 150")
                     return doc_date > sign_date
             else:
                 return r["reconsent_required"]

--- a/microsetta_private_api/repo/tests/test_consent.py
+++ b/microsetta_private_api/repo/tests/test_consent.py
@@ -431,5 +431,6 @@ class ConsentRepoTests(unittest.TestCase):
             res = consent_repo.is_consent_required(source, "data", "en_US")
             self.assertTrue(res)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/microsetta_private_api/repo/tests/test_consent.py
+++ b/microsetta_private_api/repo/tests/test_consent.py
@@ -356,6 +356,17 @@ class ConsentRepoTests(unittest.TestCase):
                     "'000fc4cd-8fa4-db8b-e050-8a800c5d81b7')"
                 )
 
+                # GitHub workflow stores the consent creation time as GMT
+                # so we're going to pretend the English one day older to allow
+                # the reconsent check to work properly. This is not an issue
+                # in the production environment.
+                cur.execute(
+                    "UPDATE ag.consent_documents "
+                    "SET date_time = CURRENT_DATE - INTERVAL '1 day' "
+                    "WHERE consent_id = %s",
+                    (self.adult_data_consent, )
+                )
+
             # Now verify that our English source doesn't need to reconsent
             res = consent_repo.is_consent_required(source, "data", "en_US")
             self.assertFalse(res)
@@ -427,6 +438,16 @@ class ConsentRepoTests(unittest.TestCase):
                     "'000fc4cd-8fa4-db8b-e050-8a800c5d81b7')"
                 )
 
+                # GitHub workflow stores the consent creation time as GMT
+                # so we're going to pretend the English one day older to allow
+                # the reconsent check to work properly. This is not an issue
+                # in the production environment.
+                cur.execute(
+                    "UPDATE ag.consent_documents "
+                    "SET date_time = CURRENT_DATE - INTERVAL '1 day' "
+                    "WHERE consent_id = %s",
+                    (self.adult_data_consent, )
+                )
             # Now verify that our English source doesn't need to reconsent
             res = consent_repo.is_consent_required(source, "data", "en_US")
             self.assertTrue(res)


### PR DESCRIPTION
When the reconsent process was originally set up, it was assumed that whenever an update to consent agreements was necessary, it would be done for all languages at once. However, this was not the case in reality, as the Japanese documents were updated after the fact.

Based on this reality, the code that checks whether a user needs to reconsent needed to be made aware of the user's locale. This PR contains the code that does that, as well as updated unit tests to observe that it works as intended. No corresponding updates to microsetta-interface are necessary.