### PR TITLE
added last_update column to ag_kit_barcodes

### DIFF
--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -3463,6 +3463,11 @@ components:
       type: string
       nullable: true
       example: "Oops, I dropped it"
+    latest_sample_information_update:
+      type: string
+      format: date-time
+      example: "2017-07-21T17:32:28Z"
+      nullable: true
     sample_site:
       enum: ["Blood (skin prick)", "Saliva", "Ear wax", "Forehead", "Fur", "Hair", "Left hand", "Left leg", "Mouth", "Nares", "Nasal mucus",
              "Right hand", "Right leg", "Stool", "Tears", "Torso", "Vaginal mucus", null]
@@ -3512,6 +3517,8 @@ components:
           $ref: '#/components/schemas/sample_datetime'
         sample_notes:
           $ref: '#/components/schemas/sample_notes'
+        latest_sample_information_update:
+          $ref: '#/components/schemas/latest_sample_information_update'
         sample_projects:
           $ref: '#/components/schemas/sample_projects'
         source_id:

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -176,7 +176,7 @@ DUMMY_EMPTY_SAMPLE_INFO = {
     'sample_edit_locked': False,
     'sample_remove_locked': False,
     'sample_notes': None,
-    'sample_last_update': None,
+    'sample_latest_sample_information_update': None,
     'sample_latest_scan_timestamp': None,
     'sample_projects': ['American Gut Project'],
     'account_id': None,
@@ -190,7 +190,7 @@ DUMMY_FILLED_SAMPLE_INFO = {
     'sample_edit_locked': False,
     'sample_remove_locked': False,
     'sample_notes': "Oops, I dropped it",
-    'sample_last_update': "2018-07-21T17:32:28Z",
+    'sample_latest_sample_information_update': "2018-07-21T17:32:28Z",
     'sample_latest_scan_timestamp': "2016-07-21T17:32:28Z",
     'sample_projects': ['American Gut Project'],
     'account_id': 'foobar',
@@ -2657,7 +2657,7 @@ class SampleTests(ApiTests):
             # make sure the sample's collection info is wiped
             sample_repo = SampleRepo(t)
             obs_sample = sample_repo._get_sample_by_id(MOCK_SAMPLE_ID)
-            obs_sample.last_update = None
+            obs_sample.latest_sample_information_update = None
             self.assertEqual(expected_sample.__dict__, obs_sample.__dict__)
 
             # make sure answered survey no longer associated with any samples

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -176,6 +176,8 @@ DUMMY_EMPTY_SAMPLE_INFO = {
     'sample_edit_locked': False,
     'sample_remove_locked': False,
     'sample_notes': None,
+    'sample_last_update': None,
+    'sample_latest_scan_timestamp': None,
     'sample_projects': ['American Gut Project'],
     'account_id': None,
     'source_id': None,
@@ -188,6 +190,8 @@ DUMMY_FILLED_SAMPLE_INFO = {
     'sample_edit_locked': False,
     'sample_remove_locked': False,
     'sample_notes': "Oops, I dropped it",
+    'sample_last_update': "2018-07-21T17:32:28Z",
+    'sample_latest_scan_timestamp': "2016-07-21T17:32:28Z",
     'sample_projects': ['American Gut Project'],
     'account_id': 'foobar',
     'source_id': 'foobarbaz',
@@ -588,6 +592,7 @@ def create_dummy_sample_objects(filled=False):
                     None,
                     info_dict['source_id'],
                     info_dict['account_id'],
+                    None,
                     info_dict["sample_projects"],
                     None)
 
@@ -2652,6 +2657,7 @@ class SampleTests(ApiTests):
             # make sure the sample's collection info is wiped
             sample_repo = SampleRepo(t)
             obs_sample = sample_repo._get_sample_by_id(MOCK_SAMPLE_ID)
+            obs_sample.last_update = None
             self.assertEqual(expected_sample.__dict__, obs_sample.__dict__)
 
             # make sure answered survey no longer associated with any samples

--- a/microsetta_private_api/db/patches/0135.sql
+++ b/microsetta_private_api/db/patches/0135.sql
@@ -1,7 +1,9 @@
 -- Jan 26, 2024
--- Add sample metadata update timestamp
+-- Add sample information update timestamp
+-- For UI enhancement. 
+-- We are not nulling the field out, though it may become necessary if used outside of the UI.
 ALTER TABLE ag.ag_kit_barcodes
-    ADD COLUMN last_update timestamp with time zone;
+    ADD COLUMN latest_sample_information_update timestamp with time zone;
 
-COMMENT ON COLUMN ag.ag_kit_barcodes.last_update
-    IS 'Sample metadata update timestamp';
+COMMENT ON COLUMN ag.ag_kit_barcodes.latest_sample_information_update
+    IS 'Sample information update timestamp.';

--- a/microsetta_private_api/db/patches/0135.sql
+++ b/microsetta_private_api/db/patches/0135.sql
@@ -1,0 +1,7 @@
+-- Jan 26, 2024
+-- Add sample metadata update timestamp
+ALTER TABLE ag.ag_kit_barcodes
+    ADD COLUMN last_update timestamp with time zone;
+
+COMMENT ON COLUMN ag.ag_kit_barcodes.last_update
+    IS 'Sample metadata update timestamp';

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -4,8 +4,9 @@ from microsetta_private_api.model.model_base import ModelBase
 
 class Sample(ModelBase):
     def __init__(self, sample_id, datetime_collected, site, notes, barcode,
-                 latest_scan_timestamp, source_id, account_id, latest_sample_information_update,
-                 sample_projects, latest_scan_status, kit_id=None):
+                 latest_scan_timestamp, source_id, account_id,
+                 latest_sample_information_update, sample_projects,
+                 latest_scan_status, kit_id=None):
         self.id = sample_id
         # NB: datetime_collected may be None if sample not yet used
         self.datetime_collected = datetime_collected
@@ -17,7 +18,8 @@ class Sample(ModelBase):
         # NB: _latest_scan_timestamp may be None if not yet returned to lab
         self._latest_scan_timestamp = latest_scan_timestamp
         self._latest_scan_status = latest_scan_status
-        self.latest_sample_information_update = latest_sample_information_update
+        self.latest_sample_information_update \
+            = latest_sample_information_update
         self.sample_projects = sample_projects
 
         self.source_id = source_id
@@ -43,8 +45,9 @@ class Sample(ModelBase):
 
     @classmethod
     def from_db(cls, sample_id, date_collected, time_collected,
-                site, notes, barcode, latest_scan_timestamp, latest_sample_information_update,
-                source_id, account_id, sample_projects, latest_scan_status):
+                site, notes, barcode, latest_scan_timestamp,
+                latest_sample_information_update, source_id,
+                account_id, sample_projects, latest_scan_status):
         datetime_collected = None
         # NB a sample may NOT have date and time collected if it has been sent
         # out but not yet used
@@ -52,8 +55,8 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                   latest_scan_timestamp, latest_sample_information_update, source_id,
-                   account_id, sample_projects, latest_scan_status)
+                   latest_scan_timestamp, latest_sample_information_update,
+                   source_id, account_id, sample_projects, latest_scan_status)
 
     def to_api(self):
         return {
@@ -65,7 +68,8 @@ class Sample(ModelBase):
             "sample_datetime": self.datetime_collected,
             "sample_latest_scan_timestamp": self._latest_scan_timestamp,
             "sample_notes": self.notes,
-            "sample_latest_sample_information_update": self.latest_sample_information_update,
+            "sample_latest_sample_information_update":
+                self.latest_sample_information_update,
             "source_id": self.source_id,
             "account_id": self.account_id,
             "sample_projects": list(self.sample_projects),

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -52,7 +52,7 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                latest_scan_timestamp, last_update, source_id,
+                   latest_scan_timestamp, last_update, source_id,
                    account_id, sample_projects, latest_scan_status)
 
     def to_api(self):
@@ -63,9 +63,9 @@ class Sample(ModelBase):
             "sample_edit_locked": self.edit_locked,
             "sample_remove_locked": self.remove_locked,
             "sample_datetime": self.datetime_collected,
-            "latest_scan_timestamp": self._latest_scan_timestamp,
+            "sample_latest_scan_timestamp": self._latest_scan_timestamp,
             "sample_notes": self.notes,
-            "last_update": self.last_update,
+            "sample_last_update": self.last_update,
             "source_id": self.source_id,
             "account_id": self.account_id,
             "sample_projects": list(self.sample_projects),

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -4,7 +4,7 @@ from microsetta_private_api.model.model_base import ModelBase
 
 class Sample(ModelBase):
     def __init__(self, sample_id, datetime_collected, site, notes, barcode,
-                 latest_scan_timestamp, source_id, account_id,
+                 latest_scan_timestamp, source_id, account_id, last_update,
                  sample_projects, latest_scan_status, kit_id=None):
         self.id = sample_id
         # NB: datetime_collected may be None if sample not yet used
@@ -17,6 +17,7 @@ class Sample(ModelBase):
         # NB: _latest_scan_timestamp may be None if not yet returned to lab
         self._latest_scan_timestamp = latest_scan_timestamp
         self._latest_scan_status = latest_scan_status
+        self.last_update = last_update
         self.sample_projects = sample_projects
 
         self.source_id = source_id
@@ -42,7 +43,7 @@ class Sample(ModelBase):
 
     @classmethod
     def from_db(cls, sample_id, date_collected, time_collected,
-                site, notes, barcode, latest_scan_timestamp,
+                site, notes, barcode, latest_scan_timestamp, last_update,
                 source_id, account_id, sample_projects, latest_scan_status):
         datetime_collected = None
         # NB a sample may NOT have date and time collected if it has been sent
@@ -51,7 +52,7 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                   latest_scan_timestamp, source_id,
+                latest_scan_timestamp, last_update, source_id,
                    account_id, sample_projects, latest_scan_status)
 
     def to_api(self):
@@ -62,7 +63,9 @@ class Sample(ModelBase):
             "sample_edit_locked": self.edit_locked,
             "sample_remove_locked": self.remove_locked,
             "sample_datetime": self.datetime_collected,
+            "latest_scan_timestamp": self._latest_scan_timestamp,
             "sample_notes": self.notes,
+            "last_update": self.last_update,
             "source_id": self.source_id,
             "account_id": self.account_id,
             "sample_projects": list(self.sample_projects),

--- a/microsetta_private_api/model/sample.py
+++ b/microsetta_private_api/model/sample.py
@@ -4,7 +4,7 @@ from microsetta_private_api.model.model_base import ModelBase
 
 class Sample(ModelBase):
     def __init__(self, sample_id, datetime_collected, site, notes, barcode,
-                 latest_scan_timestamp, source_id, account_id, last_update,
+                 latest_scan_timestamp, source_id, account_id, latest_sample_information_update,
                  sample_projects, latest_scan_status, kit_id=None):
         self.id = sample_id
         # NB: datetime_collected may be None if sample not yet used
@@ -17,7 +17,7 @@ class Sample(ModelBase):
         # NB: _latest_scan_timestamp may be None if not yet returned to lab
         self._latest_scan_timestamp = latest_scan_timestamp
         self._latest_scan_status = latest_scan_status
-        self.last_update = last_update
+        self.latest_sample_information_update = latest_sample_information_update
         self.sample_projects = sample_projects
 
         self.source_id = source_id
@@ -43,7 +43,7 @@ class Sample(ModelBase):
 
     @classmethod
     def from_db(cls, sample_id, date_collected, time_collected,
-                site, notes, barcode, latest_scan_timestamp, last_update,
+                site, notes, barcode, latest_scan_timestamp, latest_sample_information_update,
                 source_id, account_id, sample_projects, latest_scan_status):
         datetime_collected = None
         # NB a sample may NOT have date and time collected if it has been sent
@@ -52,7 +52,7 @@ class Sample(ModelBase):
             datetime_collected = datetime.combine(date_collected,
                                                   time_collected)
         return cls(sample_id, datetime_collected, site, notes, barcode,
-                   latest_scan_timestamp, last_update, source_id,
+                   latest_scan_timestamp, latest_sample_information_update, source_id,
                    account_id, sample_projects, latest_scan_status)
 
     def to_api(self):
@@ -65,7 +65,7 @@ class Sample(ModelBase):
             "sample_datetime": self.datetime_collected,
             "sample_latest_scan_timestamp": self._latest_scan_timestamp,
             "sample_notes": self.notes,
-            "sample_last_update": self.last_update,
+            "sample_latest_sample_information_update": self.latest_sample_information_update,
             "source_id": self.source_id,
             "account_id": self.account_id,
             "sample_projects": list(self.sample_projects),

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -314,7 +314,7 @@ class SampleRepo(BaseRepo):
                             sample_time,
                             sample_info.site,
                             sample_info.notes,
-                            datetime.datetime.utcnow(),
+                            datetime.datetime.now(),
                             sample_info.id
                         ))
 

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -1,3 +1,4 @@
+import datetime
 import werkzeug
 from werkzeug.exceptions import NotFound
 
@@ -19,7 +20,8 @@ class SampleRepo(BaseRepo):
         ag.ag_kit_barcodes.barcode,
         latest_scan.scan_timestamp,
         ag.source.id,
-        ag.source.account_id
+        ag.source.account_id,
+        ag.ag_kit_barcodes.last_update
         FROM ag.ag_kit_barcodes
         LEFT JOIN (
             SELECT barcode, max(scan_timestamp) AS scan_timestamp
@@ -43,7 +45,8 @@ class SampleRepo(BaseRepo):
         ag.ag_kit_barcodes.barcode,
         latest_scan.scan_timestamp,
         ag.source.id,
-        ag.source.account_id
+        ag.source.account_id,
+        ag.ag_kit_barcodes.last_update
         FROM ag.ag_kit_barcodes
         LEFT JOIN (
             SELECT barcode, max(scan_timestamp) AS scan_timestamp
@@ -302,7 +305,8 @@ class SampleRepo(BaseRepo):
                         "sample_date = %s, "
                         "sample_time = %s, "
                         "site_sampled = %s, "
-                        "notes = %s "
+                        "notes = %s, "
+                        "last_update = %s "
                         "WHERE "
                         "ag_kit_barcode_id = %s",
                         (
@@ -310,6 +314,7 @@ class SampleRepo(BaseRepo):
                             sample_time,
                             sample_info.site,
                             sample_info.notes,
+                            datetime.datetime.utcnow(),
                             sample_info.id
                         ))
 

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -21,7 +21,7 @@ class SampleRepo(BaseRepo):
         latest_scan.scan_timestamp,
         ag.source.id,
         ag.source.account_id,
-        ag.ag_kit_barcodes.last_update
+        ag.ag_kit_barcodes.latest_sample_information_update
         FROM ag.ag_kit_barcodes
         LEFT JOIN (
             SELECT barcode, max(scan_timestamp) AS scan_timestamp
@@ -46,7 +46,7 @@ class SampleRepo(BaseRepo):
         latest_scan.scan_timestamp,
         ag.source.id,
         ag.source.account_id,
-        ag.ag_kit_barcodes.last_update
+        ag.ag_kit_barcodes.latest_sample_information_update
         FROM ag.ag_kit_barcodes
         LEFT JOIN (
             SELECT barcode, max(scan_timestamp) AS scan_timestamp
@@ -306,7 +306,7 @@ class SampleRepo(BaseRepo):
                         "sample_time = %s, "
                         "site_sampled = %s, "
                         "notes = %s, "
-                        "last_update = %s "
+                        "latest_sample_information_update = %s "
                         "WHERE "
                         "ag_kit_barcode_id = %s",
                         (


### PR DESCRIPTION
Added last_update column to ag_kit_barcodes table. This will enable a more descriptive sample status on the 'My Reports' tab. See [PR](https://github.com/biocore/microsetta-interface/pull/311) for microsetta-interface for FE changes. 