### PR TITLE
scrub interested users

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -835,6 +835,7 @@ def delete_account(account_id, token_info):
         src_repo = SourceRepo(t)
         samp_repo = SampleRepo(t)
         sar_repo = SurveyAnswersRepo(t)
+        interested_users_repo = InterestedUserRepo(t)
 
         acct = acct_repo.get_account(account_id)
         if acct is None:
@@ -871,6 +872,8 @@ def delete_account(account_id, token_info):
                 src_repo.scrub(account_id, source.id)
 
         acct_repo.scrub(account_id)
+
+        interested_users_repo.scrub(acct.email)
 
         t.commit()
 

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -207,3 +207,45 @@ class InterestedUserRepo(BaseRepo):
                         (interested_user_id,)
                     )
                     return False
+
+    def get_interested_user_by_just_email(self, email):
+        # email = "%" + email + "%"
+        with self._transaction.dict_cursor() as cur:
+            cur.execute(
+                "SELECT * FROM campaign.interested_users "
+                "WHERE lower(email) = lower(%s)",
+                (email,)
+            )
+            rs = cur.fetchall()
+            return [__class__._row_to_interested_user(r) for r in rs]
+
+    def scrub(self, interested_user_email):
+        interested_users = self. \
+            get_interested_user_by_just_email(interested_user_email)
+        updated = False
+
+        for interested_user in interested_users:
+            interested_user.first_name = "scrubbed"
+            interested_user.last_name = "scrubbed"
+            interested_user.email = "scrubbed"
+            interested_user.phone = "scrubbed"
+            interested_user.address_1 = "scrubbed"
+            interested_user.address_2 = "scrubbed"
+            interested_user.address_3 = "scrubbed"
+            interested_user.city = "scrubbed"
+            interested_user.state = "scrubbed"
+            interested_user.postal_code = "scrubbed"
+            interested_user.country = "scrubbed"
+            interested_user.latitude = 0
+            interested_user.longitude = 0
+            interested_user.confirm_consent = False
+            interested_user.ip_address = "scrubbed"
+            interested_user.address_checked = False
+            interested_user.address_valid = False
+            interested_user.residential_address = False
+
+            if self.update_interested_user(interested_user) == 1:
+                updated = True
+            else:
+                updated = False
+        return updated

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -242,7 +242,6 @@ class InterestedUserRepo(BaseRepo):
             interested_user.address_valid = False
             interested_user.residential_address = False
 
-            if self.update_interested_user(interested_user) == 1:
-                pass
-            else:
-                raise RepoException("Error scrubbing interested user")
+            if not self.update_interested_user(interested_user):
+                raise RepoException("Error scrubbing interested user: "
+                                    + interested_user.interested_user_id)

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -66,6 +66,9 @@ class InterestedUserRepo(BaseRepo):
                 "state = %s, "
                 "postal_code = %s, "
                 "country = %s, "
+                "latitude = %s, "
+                "longitude = %s, "
+                "confirm_consent = %s, "
                 "address_checked = %s, "
                 "address_valid = %s, "
                 "residential_address = %s, "
@@ -82,6 +85,9 @@ class InterestedUserRepo(BaseRepo):
                  interested_user.state,
                  interested_user.postal_code,
                  interested_user.country,
+                 interested_user.latitude,
+                 interested_user.longitude,
+                 interested_user.confirm_consent,
                  interested_user.address_checked,
                  interested_user.address_valid,
                  interested_user.residential_address,

--- a/microsetta_private_api/repo/interested_user_repo.py
+++ b/microsetta_private_api/repo/interested_user_repo.py
@@ -209,7 +209,6 @@ class InterestedUserRepo(BaseRepo):
                     return False
 
     def get_interested_user_by_just_email(self, email):
-        # email = "%" + email + "%"
         with self._transaction.dict_cursor() as cur:
             cur.execute(
                 "SELECT * FROM campaign.interested_users "
@@ -222,7 +221,6 @@ class InterestedUserRepo(BaseRepo):
     def scrub(self, interested_user_email):
         interested_users = self. \
             get_interested_user_by_just_email(interested_user_email)
-        updated = False
 
         for interested_user in interested_users:
             interested_user.first_name = "scrubbed"
@@ -236,8 +234,8 @@ class InterestedUserRepo(BaseRepo):
             interested_user.state = "scrubbed"
             interested_user.postal_code = "scrubbed"
             interested_user.country = "scrubbed"
-            interested_user.latitude = 0
-            interested_user.longitude = 0
+            interested_user.latitude = None
+            interested_user.longitude = None
             interested_user.confirm_consent = False
             interested_user.ip_address = "scrubbed"
             interested_user.address_checked = False
@@ -245,7 +243,6 @@ class InterestedUserRepo(BaseRepo):
             interested_user.residential_address = False
 
             if self.update_interested_user(interested_user) == 1:
-                updated = True
+                pass
             else:
-                updated = False
-        return updated
+                raise RepoException("Error scrubbing interested user")


### PR DESCRIPTION
Once the account scrub is done we want to also scrub the campaign.interested_users entry as well per https://github.com/biocore/microsetta-private-api/issues/424. Currently, this uses the account email address and finds the entry in the interested_users table.