### PR TITLE
create barcodes for existing kits

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -268,7 +268,8 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
-def generate_barcodes(body):
+def generate_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     number_of_kits = body['number_of_kits']
     number_of_samples = body['number_of_samples']
@@ -281,7 +282,8 @@ def generate_barcodes(body):
     return barcode
 
 
-def insert_barcodes(body):
+def insert_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -275,8 +275,6 @@ def create_kits(body, token_info):
     kit_prefix = body.get('kit_id_prefix', None)
     project_ids = body['project_ids']
     user_barcodes = body.get('user_barcodes', [])
-    remaining_barcodes_to_generate = body.get(
-        'remaining_samples_to_generate', [])
 
     with Transaction() as t:
         admin_repo = AdminRepo(t)
@@ -286,7 +284,6 @@ def create_kits(body, token_info):
                                           number_of_samples,
                                           kit_prefix,
                                           user_barcodes,
-                                          remaining_barcodes_to_generate,
                                           project_ids)
         except KeyError:
             return jsonify(code=422, message="Unable to create kits"), 422

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -286,7 +286,8 @@ def generate_barcodes(body, token_info):
     return barcode
 
 
-def insert_barcodes(body):
+def insert_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -268,6 +268,31 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
+def generate_barcodes(body):
+
+    number_of_kits = body['number_of_kits']
+    number_of_samples = body['number_of_samples']
+
+    with Transaction() as t:
+        admin_repo = AdminRepo(t)
+        barcode = admin_repo._generate_novel_barcodes_admin(
+            number_of_kits, number_of_samples)
+        t.commit()
+    return barcode
+
+
+def insert_barcodes(body):
+
+    barcode = body['barcodes']
+    project_id = [body['project_id']]
+
+    with Transaction() as t:
+        admin_repo = AdminRepo(t)
+        admin_repo._insert_barcodes_to_existing_kit(barcode, project_id)
+        t.commit()
+    return '', 204
+
+
 def get_account_events(account_id, token_info):
     validate_admin_access(token_info)
 

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -253,13 +253,17 @@ def create_kits(body, token_info):
     number_of_samples = body['number_of_samples']
     kit_prefix = body.get('kit_id_prefix', None)
     project_ids = body['project_ids']
+    user_barcodes = body.get('user_barcodes', [])
 
     with Transaction() as t:
         admin_repo = AdminRepo(t)
 
         try:
-            kits = admin_repo.create_kits(number_of_kits, number_of_samples,
-                                          kit_prefix, project_ids)
+            kits = admin_repo.create_kits(number_of_kits,
+                                          number_of_samples,
+                                          kit_prefix,
+                                          user_barcodes,
+                                          project_ids)
         except KeyError:
             return jsonify(code=422, message="Unable to create kits"), 422
         else:

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -288,7 +288,7 @@ def generate_barcodes(body, token_info):
 
 def insert_barcodes(body, token_info):
     validate_admin_access(token_info)
-    
+
     barcode = body['barcodes']
     project_id = [body['project_id']]
 

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -286,8 +286,7 @@ def generate_barcodes(body, token_info):
     return barcode
 
 
-def insert_barcodes(body, token_info):
-    validate_admin_access(token_info)
+def insert_barcodes(body):
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -272,8 +272,7 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
-def generate_barcodes(body, token_info):
-    validate_admin_access(token_info)
+def generate_barcodes(body):
 
     number_of_kits = body['number_of_kits']
     number_of_samples = body['number_of_samples']

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -282,8 +282,7 @@ def generate_barcodes(body, token_info):
     return barcode
 
 
-def insert_barcodes(body, token_info):
-    validate_admin_access(token_info)
+def insert_barcodes(body):
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -272,8 +272,7 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
-def generate_barcodes(body, token_info):
-    validate_admin_access(token_info)
+def generate_barcodes(body):
 
     number_of_kits = body['number_of_kits']
     number_of_samples = body['number_of_samples']
@@ -286,8 +285,7 @@ def generate_barcodes(body, token_info):
     return barcode
 
 
-def insert_barcodes(body, token_info):
-    validate_admin_access(token_info)
+def insert_barcodes(body):
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -272,7 +272,8 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
-def generate_barcodes(body):
+def generate_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     number_of_kits = body['number_of_kits']
     number_of_samples = body['number_of_samples']
@@ -285,8 +286,9 @@ def generate_barcodes(body):
     return barcode
 
 
-def insert_barcodes(body):
-
+def insert_barcodes(body, token_info):
+    validate_admin_access(token_info)
+    
     barcode = body['barcodes']
     project_id = [body['project_id']]
 

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -272,7 +272,8 @@ def create_kits(body, token_info):
     return jsonify(kits), 201
 
 
-def generate_barcodes(body):
+def generate_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     number_of_kits = body['number_of_kits']
     number_of_samples = body['number_of_samples']
@@ -285,7 +286,8 @@ def generate_barcodes(body):
     return barcode
 
 
-def insert_barcodes(body):
+def insert_barcodes(body, token_info):
+    validate_admin_access(token_info)
 
     barcode = body['barcodes']
     project_id = [body['project_id']]

--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -301,7 +301,7 @@ def handle_barcodes(body, token_info):
 
     if action == 'create':
         if 'generate_barcode_single' in body:
-            if body['generate_barcode_single'] == 'on':
+            if body['generate_barcode_single']:
                 number_of_kits = 1
                 number_of_samples = 1
         elif 'generate_barcodes' in body:

--- a/microsetta_private_api/admin/sample_summary.py
+++ b/microsetta_private_api/admin/sample_summary.py
@@ -83,6 +83,7 @@ def per_sample(project, barcodes, strip_sampleid):
                 ffq_complete, ffq_taken, _ = vs_repo.get_ffq_status_by_sample(
                     sample.id
                 )
+                print("ffq complete", ffq_complete, "ffq taken", ffq_taken)
 
             summary = {
                 "sampleid": None if strip_sampleid else barcode,

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1,4 +1,3 @@
-from collections import Counter
 from unittest import TestCase
 from datetime import date, datetime, timedelta, timezone
 import dateutil.parser
@@ -1502,7 +1501,7 @@ class AdminRepoTests(AdminTests):
 
             new_barcodes = admin_repo._generate_novel_barcodes(
                 number_of_kits, number_of_samples, kit_names)
-            
+
             self.assertEqual(len(new_barcodes[1]),
                              number_of_kits * number_of_samples)
             self.assertTrue(all(barcodes.startswith('X')
@@ -1520,7 +1519,7 @@ class AdminRepoTests(AdminTests):
 
             new_barcodes = admin_repo._generate_novel_barcodes(
                 number_of_kits, number_of_samples, kit_names)
-            
+
             self.assertTrue(new_barcodes[1] == [], [])
 
     def test_insert_barcodes_admin_success(self):
@@ -1535,11 +1534,12 @@ class AdminRepoTests(AdminTests):
 
             new_barcode = admin_repo._generate_novel_barcodes(
                     number_of_kits, number_of_samples, kit_names)
-        
+
         new_barcode[1].insert(0, 'test')
         kit_name_and_barcode_tuple = (new_barcode[1][0], new_barcode[1][1])
 
-        kit_name_and_barcode_tuples_list = [kit_name_and_barcode_tuple]        
+        kit_name_and_barcode_tuples_list = [
+            kit_name_and_barcode_tuple]
         project_ids = '1'
 
         with Transaction() as t:
@@ -1554,7 +1554,7 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                obs_first_element = obs[0][0]
+                obs_first_element = obs[4][0]
                 new_barcode_second_element = new_barcode[0][0][1]
                 self.assertEqual(obs_first_element, new_barcode_second_element)
 

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1433,10 +1433,10 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                print("OBS", obs, obs[0][0])
-                print("OBS indices", obs[1][0], obs[2][0], obs[3][0])
+                print("OBS", obs)
+                print("OBS indices", obs[0][0], obs[1][0], obs[2][0], obs[3][0])
                 print("Barcode gen", new_barcode[0])
-                self.assertEqual(obs[0][0], new_barcode[0])
+                self.assertEqual(obs[4][0], new_barcode[0])
 
     def test_insert_barcodes_admin_fail_nonexisting_kit(self):
         # test that inserting barcodes to a non-existent kit fails

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -880,7 +880,6 @@ class AdminRepoTests(AdminTests):
                 scans = [scan['observations'] for scan in diag['scans_info']]
                 scans_observation_ids = [obs['observation_id'] for scan in
                                          scans for obs in scan]
-
                 self.assertEqual(scans_observation_ids, observation_ids)
 
     def test_scan_with_wrong_observation(self):
@@ -1593,16 +1592,4 @@ class AdminRepoTests(AdminTests):
                                        1,
                                        '',
                                        [user_barcode],
-                                       [1])
-
-    def test_user_barcodes_num_samples_mismatch_create_kit_fail(self):
-        # When creating a kit, if a user selects just one sample, but
-        # provides two user barcodes, the transaction should fail
-        with Transaction() as t:
-            admin_repo = AdminRepo(t)
-            with self.assertRaises(ValueError):
-                admin_repo.create_kits(1,
-                                       1,
-                                       '',
-                                       ['X92384885', 'X92384886'],
                                        [1])

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1392,8 +1392,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            new_barcodes = admin_repo._generate_novel_barcodes_admin(
-                number_of_kits, number_of_samples)
+            new_barcodes = admin_repo._generate_novel_barcodes(
+                number_of_kits, number_of_samples, kit_names=None)
             self.assertEqual(len(new_barcodes),
                              number_of_kits * number_of_samples)
             self.assertTrue(all(barcode.startswith('X')
@@ -1405,8 +1405,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            new_barcodes = admin_repo._generate_novel_barcodes_admin(
-                number_of_kits, number_of_samples)
+            new_barcodes = admin_repo._generate_novel_barcodes(
+                number_of_kits, number_of_samples, kit_names=None)
             self.assertTrue(new_barcodes == [])
 
     def test_insert_barcodes_admin_success(self):
@@ -1415,8 +1415,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            new_barcode = admin_repo._generate_novel_barcodes_admin(
-                    number_of_kits, number_of_samples)
+            new_barcode = admin_repo._generate_novel_barcodes(
+                    number_of_kits, number_of_samples, kit_names=None)
 
         kit_barcode = [['test', new_barcode[0]]]
         project_ids = '1'

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1391,8 +1391,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            new_barcodes = admin_repo._generate_novel_barcodes_admin
-            (number_of_kits, number_of_samples)
+            new_barcodes = admin_repo._generate_novel_barcodes_admin(
+                number_of_kits, number_of_samples)
             self.assertEqual(len(new_barcodes),
                              number_of_kits * number_of_samples)
             self.assertTrue(all(barcode.startswith('X')
@@ -1404,8 +1404,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            new_barcodes = admin_repo._generate_novel_barcodes_admin
-            (number_of_kits, number_of_samples)
+            new_barcodes = admin_repo._generate_novel_barcodes_admin(
+                number_of_kits, number_of_samples)
             self.assertTrue(new_barcodes == [])
 
     def test_insert_barcodes_admin_success(self):
@@ -1414,8 +1414,8 @@ class AdminRepoTests(AdminTests):
 
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            admin_repo._insert_barcodes_to_existing_kit
-            (kit_barcode, project_id)
+            admin_repo._insert_barcodes_to_existing_kit(
+                kit_barcode, project_id)
             with t.cursor() as cur:
                 cur.execute(
                     "SELECT barcode "
@@ -1434,8 +1434,8 @@ class AdminRepoTests(AdminTests):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
             with self.assertRaises(psycopg2.errors.ForeignKeyViolation):
-                admin_repo._insert_barcodes_to_existing_kit
-                (kit_barcode, project_id)
+                admin_repo._insert_barcodes_to_existing_kit(
+                    kit_barcode, project_id)
 
     def test_insert_barcodes_admin_fail_dup_barcodes(self):
         # test that inserting duplicate barcode fails
@@ -1445,5 +1445,5 @@ class AdminRepoTests(AdminTests):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
             with self.assertRaises(psycopg2.errors.UniqueViolation):
-                admin_repo._insert_barcodes_to_existing_kit
-                (kit_barcode, project_id)
+                admin_repo._insert_barcodes_to_existing_kit(
+                    kit_barcode, project_id)

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -457,7 +457,6 @@ class AdminRepoTests(AdminTests):
                                              3,
                                              'foo',
                                              None,
-                                             0,
                                              [output_id, ])
 
             exp = []
@@ -614,15 +613,13 @@ class AdminRepoTests(AdminTests):
                                        3,
                                        '',
                                        None,
-                                       0,
                                        [10000,
                                         SurveyTemplateRepo.VIOSCREEN_ID])
 
     def test_create_kits_success_not_microsetta(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            non_tmi = admin_repo.create_kits(5, 3, '', None, 0,
-                                             [33])
+            non_tmi = admin_repo.create_kits(5, 3, '', None, [33])
             self.assertEqual(['created', ], list(non_tmi.keys()))
             self.assertEqual(len(non_tmi['created']), 5)
             for obj in non_tmi['created']:
@@ -649,8 +646,7 @@ class AdminRepoTests(AdminTests):
     def test_create_kits_success_is_microsetta(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            tmi = admin_repo.create_kits(4, 2, 'foo', None, 0,
-                                         [1])
+            tmi = admin_repo.create_kits(4, 2, 'foo', None, [1])
             self.assertEqual(['created', ], list(tmi.keys()))
             self.assertEqual(len(tmi['created']), 4)
             for obj in tmi['created']:
@@ -1573,33 +1569,30 @@ class AdminRepoTests(AdminTests):
     def test_user_barcode_create_kit_success(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            user_barcode = 'X99887769'
             admin_repo.create_kits(1,
                                    1,
                                    '',
-                                   [user_barcode],
-                                   0,
+                                   [['X99887769']],
                                    [1])
             with t.cursor() as cur:
                 cur.execute(
                     "SELECT barcode "
                     "FROM barcodes.barcode "
                     "WHERE barcode = %s",
-                    (user_barcode,)
+                    ('X99887769',)
                 )
                 obs = cur.fetchall()
-                self.assertEqual(obs[0][0], user_barcode)
+                self.assertEqual(obs[0][0], 'X99887769')
 
     def test_user_barcode_dup_create_kit_fail(self):
         with Transaction() as t:
             admin_repo = AdminRepo(t)
-            user_barcode = '000000001'
+            user_barcode = ['000000001']
             with self.assertRaises(psycopg2.errors.UniqueViolation):
                 admin_repo.create_kits(1,
                                        1,
                                        '',
                                        [user_barcode],
-                                       0,
                                        [1])
 
     def test_user_barcodes_num_samples_mismatch_create_kit_fail(self):
@@ -1612,5 +1605,4 @@ class AdminRepoTests(AdminTests):
                                        1,
                                        '',
                                        ['X92384885', 'X92384886'],
-                                       0,
                                        [1])

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1433,7 +1433,11 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
+                print("OBS", obs)
+                print("Barcode gen", new_barcode)
                 self.assertEqual(obs[0][0], new_barcode[0])
+                self.assertEqual(obs[0][1], new_barcode[0])
+
 
     def test_insert_barcodes_admin_fail_nonexisting_kit(self):
         # test that inserting barcodes to a non-existent kit fails

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1409,7 +1409,15 @@ class AdminRepoTests(AdminTests):
             self.assertTrue(new_barcodes == [])
 
     def test_insert_barcodes_admin_success(self):
-        kit_barcode = [['test', 'X00332312']]
+        number_of_kits = 1
+        number_of_samples = 1
+
+        with Transaction() as t:
+            admin_repo = AdminRepo(t)
+            new_barcode = admin_repo._generate_novel_barcodes_admin(
+                    number_of_kits, number_of_samples)
+
+        kit_barcode = [['test', new_barcode[0]]]
         project_id = '1'
 
         with Transaction() as t:
@@ -1424,7 +1432,7 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                self.assertEqual(obs[0][0], 'X00332312')
+                self.assertEqual(obs[0][0], new_barcode[0])
 
     def test_insert_barcodes_admin_fail_nonexisting_kit(self):
         # test that inserting barcodes to a non-existent kit fails

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1433,11 +1433,9 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                print("OBS", obs)
-                print("Barcode gen", new_barcode)
+                print("OBS", obs[0][0])
+                print("Barcode gen", new_barcode[0])
                 self.assertEqual(obs[0][0], new_barcode[0])
-                self.assertEqual(obs[0][1], new_barcode[0])
-
 
     def test_insert_barcodes_admin_fail_nonexisting_kit(self):
         # test that inserting barcodes to a non-existent kit fails

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1433,7 +1433,8 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                print("OBS", obs[0][0])
+                print("OBS", obs, obs[0][0])
+                print("OBS indices", obs[1][0], obs[2][0], obs[3][0])
                 print("Barcode gen", new_barcode[0])
                 self.assertEqual(obs[0][0], new_barcode[0])
 

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1433,9 +1433,6 @@ class AdminRepoTests(AdminTests):
                     ('test',)
                 )
                 obs = cur.fetchall()
-                print("OBS", obs)
-                print("OBS indices", obs[0][0], obs[1][0], obs[2][0], obs[3][0])
-                print("Barcode gen", new_barcode[0])
                 self.assertEqual(obs[4][0], new_barcode[0])
 
     def test_insert_barcodes_admin_fail_nonexisting_kit(self):

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -2781,64 +2781,42 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
-  '/admin/create/barcodes':
+  '/admin/barcodes':
     post:
-      operationId: microsetta_private_api.admin.admin_impl.generate_barcodes
+      operationId: microsetta_private_api.admin.admin_impl.handle_barcodes
       tags:
         - Admin
-      summary: Create barcodes
-      description: Create barcodes for an exisiting kit
-      requestBody:
-        content:
-          application/json:
-            schema:
-                type: "object"
-                properties:
-                  number_of_kits:
-                    type: integer
-                  number_of_samples:
-                    type: integer
-                required:
-                  - number_of_kits
-                  - number_of_samples
-      responses:
-        '201':
-          description: Barcodes were successfully created
-          content:
-            application/json:
-              schema:
-                type: array
-
-  '/admin/insert_barcodes':
-    post:
-      operationId: microsetta_private_api.admin.admin_impl.insert_barcodes
-      tags:
-        - Admin
-      summary: Insert barcodes into the database
-      description: Insert barcodes into the database
+      summary: Create or insert barcodes
+      description: Create barcodes for an existing kit or insert barcodes into the database
       requestBody:
         content:
           application/json:
             schema:
               type: "object"
               properties:
+                action:
+                  type: string
+                  enum: [create, insert]
+                  description: Specify 'create' to generate new barcodes or 'insert' to insert provided barcodes
                 barcodes:
                   type: array
                   items:
-                    type: array
+                    type: string
+                  description: Barcodes to insert (required if action is 'insert')
                 kit_id:
                   type: string
-                project_id:
-                  type: integer
+                  description: Kit ID to associate the barcodes with (required if action is 'insert')
+              required:
+                - action
       responses:
         '201':
-          description: Barcodes were successfully inserted
+          description: Barcodes were successfully created or inserted
           content:
             application/json:
               schema:
                 type: array
         '500':
-          description: Duplicate barcodes found
+          description: Duplicate barcodes found (only relevant for insert action)
           
   '/admin/events/accounts/{account_id}':
     get:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -2805,7 +2805,7 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
-  '/admin/barcodes':
+  '/admin/add_barcodes':
     post:
       operationId: microsetta_private_api.admin.admin_impl.handle_barcodes
       tags:

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -2764,6 +2764,65 @@ paths:
         '422':
           $ref: '#/components/responses/422UnprocessableEntity'
 
+  '/admin/create/barcodes':
+    post:
+      operationId: microsetta_private_api.admin.admin_impl.generate_barcodes
+      tags:
+        - Admin
+      summary: Create barcodes
+      description: Create barcodes for an exisiting kit
+      requestBody:
+        content:
+          application/json:
+            schema:
+                type: "object"
+                properties:
+                  number_of_kits:
+                    type: integer
+                  number_of_samples:
+                    type: integer
+                required:
+                  - number_of_kits
+                  - number_of_samples
+      responses:
+        '201':
+          description: Barcodes were successfully created
+          content:
+            application/json:
+              schema:
+                type: array
+
+  '/admin/insert_barcodes':
+    post:
+      operationId: microsetta_private_api.admin.admin_impl.insert_barcodes
+      tags:
+        - Admin
+      summary: Insert barcodes into the database
+      description: Insert barcodes into the database
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: "object"
+              properties:
+                barcodes:
+                  type: array
+                  items:
+                    type: array
+                kit_id:
+                  type: string
+                project_id:
+                  type: integer
+      responses:
+        '201':
+          description: Barcodes were successfully inserted
+          content:
+            application/json:
+              schema:
+                type: array
+        '500':
+          description: Duplicate barcodes found
+          
   '/admin/events/accounts/{account_id}':
     get:
       operationId: microsetta_private_api.admin.admin_impl.get_account_events

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -2839,6 +2839,10 @@ paths:
             application/json:
               schema:
                 type: array
+        '204':
+          description: No data was returned
+        '404':
+          description: Kit ID not found or barcode already exists
         '500':
           description: Duplicate barcodes found (only relevant for insert action)
           

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -747,7 +747,7 @@ class AdminRepo(BaseRepo):
         return prefix + '_' + rand_name
 
     def create_kits(self, number_of_kits, number_of_samples, kit_prefix,
-                    project_ids):
+                    user_barcodes, project_ids):
         """Create multiple kits, each with the same number of samples
 
         Parameters
@@ -763,9 +763,17 @@ class AdminRepo(BaseRepo):
         """
 
         kit_names = self._generate_novel_kit_names(number_of_kits, kit_prefix)
-        kit_name_and_barcode_tuples_list, new_barcodes = \
-            self._generate_novel_barcodes(
-                number_of_kits, number_of_samples, kit_names)
+
+        if user_barcodes:
+            new_barcodes = user_barcodes
+            kit_name_and_barcode_tuples_list = []
+            for i in range(number_of_samples * number_of_kits):
+                kit_name_and_barcode_tuples_list.append(
+                    (kit_names[0], user_barcodes[i]))
+        else:
+            kit_name_and_barcode_tuples_list, new_barcodes = \
+                self._generate_novel_barcodes(
+                    number_of_kits, number_of_samples, kit_names)
 
         return self._create_kits(kit_names, new_barcodes,
                                  kit_name_and_barcode_tuples_list,

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -923,9 +923,6 @@ class AdminRepo(BaseRepo):
         # integer project ids come in as strings ...
         project_ids = [int(x) for x in project_ids]
 
-        if len(set(project_ids)) > 1:
-            raise ValueError("All project_ids must be identical")
-
         is_tmi = self._are_any_projects_tmi(project_ids)
 
         with self._transaction.cursor() as cur:

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -863,24 +863,6 @@ class AdminRepo(BaseRepo):
             else:
                 return new_barcodes
 
-    def _generate_novel_barcodes_admin(self,
-                                       number_of_kits,
-                                       number_of_samples):
-        """Generate specified number of random barcodes for admin"""
-
-        total_barcodes = number_of_kits * number_of_samples
-
-        with self._transaction.cursor() as cur:
-            cur.execute(
-                "SELECT max(right(barcode,8)::integer) "
-                "FROM barcodes.barcode "
-                "WHERE barcode LIKE 'X%' OR barcode LIKE '0%'"
-            )
-            start_bc = cur.fetchone()[0] + 1
-            new_barcodes = ['X%0.8d' % (start_bc + i)
-                            for i in range(total_barcodes)]
-        return new_barcodes
-
     def _insert_barcodes_to_existing_kit(self,
                                          kit_name_and_barcode_tuples_list,
                                          project_ids):

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -801,7 +801,7 @@ class AdminRepo(BaseRepo):
             Number of samples that each kit will contain
         kit_prefix : str or None
             A prefix to put on to the kit IDs, this is optional.
-        user_barcodes : list of str
+        user_barcodes : list of lists of str
             User provided barcodes to use for the kits. If None, barcodes will
             be generated.
         project_ids : list of int

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -870,7 +870,7 @@ class AdminRepo(BaseRepo):
     def _generate_novel_barcodes(self, number_of_kits, number_of_samples,
                                  kit_names):
         """Generate specified number of random barcodes for input kit names"""
-        print("kit name", kit_names)
+
         total_barcodes = number_of_kits * number_of_samples
 
         with self._transaction.cursor() as cur:
@@ -913,7 +913,7 @@ class AdminRepo(BaseRepo):
         project_ids : list of int
             Project ids that all barcodes are to be associated with
         """
-        print("Insert", kit_name_and_barcode_tuples_list)
+
         # check for empty input
         if kit_name_and_barcode_tuples_list \
                 is None or len(kit_name_and_barcode_tuples_list) == 0:
@@ -932,7 +932,7 @@ class AdminRepo(BaseRepo):
             # add new barcodes to barcode table
             barcode_insertions = [(n, b, 'unassigned')
                                   for n, b in kit_name_and_barcode_tuples_list]
-            print("Barcode insertions: ", barcode_insertions)
+
             cur.executemany("INSERT INTO barcode (kit_id, barcode, status) "
                             "VALUES (%s, %s, %s)",
                             barcode_insertions)

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -1166,6 +1166,19 @@ class AdminRepo(BaseRepo):
 
         return row
 
+    def check_barcode_exists(self, barcode):
+        with self._transaction.dict_cursor() as cur:
+            cur.execute(
+                "SELECT barcode "
+                "FROM "
+                "barcodes.barcode "
+                "WHERE "
+                "barcode = %s",
+                (barcode,))
+            row = cur.fetchone()
+
+        return row
+
     def retrieve_diagnostics_by_kit_id(self, supplied_kit_id):
         kit_repo = KitRepo(self._transaction)
         kit = kit_repo.get_kit_all_samples(supplied_kit_id)

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -152,6 +152,7 @@ class SampleTests(unittest.TestCase):
                 1,
                 1,
                 "UNITTEST",
+                None,
                 [1]
             )
 

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -153,7 +153,6 @@ class SampleTests(unittest.TestCase):
                 1,
                 "UNITTEST",
                 None,
-                0,
                 [1]
             )
 

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -153,6 +153,7 @@ class SampleTests(unittest.TestCase):
                 1,
                 "UNITTEST",
                 None,
+                0,
                 [1]
             )
 


### PR DESCRIPTION
Taking from task description, this PR covers part 1:

Add a barcode to an existing kit (new feature). In this scenario, there already exists a kit in the database with one or more barcodes. The user will log into microsetta-admin and add barcodes to one or more kits, and it needs to provide the following options:

- Add barcodes to a single kit. The user would enter a Kit ID into a text field, then have the option to either enter a barcode to add to the kit OR dynamically generate a new barcode to add to the kit (using the existing barcode generation function). If it's a generated barcode, the output should inform the user of the newly created barcode. Otherwise, the output should be a success/failure message.

- Add barcodes to several kits. The user would upload a CSV file with Kit IDs in the first column. They would then have the option to either add a dynamically generated barcode to each kit OR put a barcode in the second column of the CSV file. In either case, the tool should return a CSV file with the Kit IDs and the newly added barcodes.
