### PR TITLE
japan locale change

### DIFF
--- a/microsetta_private_api/api/_account.py
+++ b/microsetta_private_api/api/_account.py
@@ -101,6 +101,12 @@ def register_account(body, token_info):
 
 def read_account(account_id, token_info):
     acc = _validate_account_access(token_info, account_id)
+    if acc.language == "ja_JP":
+        with Transaction() as t:
+            acct_repo = AccountRepo(t)
+            acc.language = "en_US"
+            acct_repo.update_account(acc)
+            t.commit()
     return jsonify(acc.to_api()), 200
 
 


### PR DESCRIPTION
 If an account with ja_JP in the language field logs in their preferred language will be changed to en_US.
 
 For this part of the task

- Automated emails from microsetta-private-api to accounts with Japanese selected should be switched to English.

Are we wanting to do this for all users that have Japanese as their preferred language or just the one's that log in from here on out? If just the one's that have logged in, once a language has been changed for an account, all automated emails will now be in en_US? 