### PR TITLE
survey association lock change

### DIFF
--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -9,25 +9,24 @@ from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 class QiitaRepo(BaseRepo):
     def lock_completed_surveys_to_barcodes(self, barcodes):
         # lock survey-sample association
-        with self._transaction as t:
-            admin_repo = AdminRepo(t)
-            sar_repo = SurveyAnswersRepo(t)
+        admin_repo = AdminRepo(self._transaction)
+        sar_repo = SurveyAnswersRepo(self._transaction)
 
-            for sample_barcode in barcodes:
-                ids = admin_repo._get_ids_relevant_to_barcode(sample_barcode)
+        for sample_barcode in barcodes:
+            ids = admin_repo._get_ids_relevant_to_barcode(sample_barcode)
 
-                if ids is not None:
-                    account_id = ids.get('account_id')
-                    source_id = ids.get('source_id')
-                    sample_id = ids.get('sample_id')
+            if ids is not None:
+                account_id = ids.get('account_id')
+                source_id = ids.get('source_id')
+                sample_id = ids.get('sample_id')
 
-                    survey_ids = sar_repo.list_answered_surveys(
-                        account_id, source_id)
+                survey_ids = sar_repo.list_answered_surveys(
+                    account_id, source_id)
 
-                    if survey_ids is not None:
-                        for survey_id in survey_ids:
-                            sar_repo.associate_answered_survey_with_sample(
-                                account_id, source_id, sample_id, survey_id)
+                if survey_ids is not None:
+                    for survey_id in survey_ids:
+                        sar_repo.associate_answered_survey_with_sample(
+                            account_id, source_id, sample_id, survey_id)
 
     def push_metadata_to_qiita(self, barcodes=None):
         """Attempt to format and push metadata for the set of barcodes

--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -61,8 +61,6 @@ class QiitaRepo(BaseRepo):
         list
             Any error detail when constructing metadata
         """
-        # lock survey-sample association
-        self.lock_sample_to_survey(barcodes)
 
         if barcodes is None:
             with self._transaction.cursor() as cur:
@@ -93,6 +91,9 @@ class QiitaRepo(BaseRepo):
                 barcodes = {r[0] for r in cur.fetchall()}
         else:
             barcodes = set(barcodes)
+
+        # lock survey-sample association
+        self.lock_sample_to_survey(barcodes)
 
         # determine what samples are already known in qiita
         samples_in_qiita = set(qclient.get('/api/v1/study/10317/samples'))

--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -51,7 +51,7 @@ class QiitaRepo(BaseRepo):
                     source_id = ids.get('source_id')
                     sample_id = ids.get('sample_id')
 
-                    survey_ids = sar_repo.list_answered_surveys_by_sample(
+                    survey_ids = sar_repo.list_answered_surveys(
                         account_id, source_id, sample_id)
 
                     for survey_id in survey_ids:

--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -4,13 +4,12 @@ from microsetta_private_api.qiita import qclient
 from microsetta_private_api.repo.metadata_repo import retrieve_metadata
 from microsetta_private_api.repo.metadata_repo._constants import MISSING_VALUE
 from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
-from microsetta_private_api.repo.transaction import Transaction
 
 
 class QiitaRepo(BaseRepo):
     def lock_completed_surveys_to_barcodes(self, barcodes):
         # lock survey-sample association
-        with Transaction() as t:
+        with self._transaction as t:
             admin_repo = AdminRepo(t)
             sar_repo = SurveyAnswersRepo(t)
 
@@ -29,8 +28,6 @@ class QiitaRepo(BaseRepo):
                         for survey_id in survey_ids:
                             sar_repo.associate_answered_survey_with_sample(
                                 account_id, source_id, sample_id, survey_id)
-
-            t.commit()
 
     def push_metadata_to_qiita(self, barcodes=None):
         """Attempt to format and push metadata for the set of barcodes

--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -113,7 +113,7 @@ class QiitaRepo(BaseRepo):
         to_push = list(barcodes - samples_in_qiita)[:1000]
 
         # lock survey-sample association
-        self.lock_completed_surveys_to_barcodes(barcodes)
+        self.lock_completed_surveys_to_barcodes(to_push)
 
         # short circuit if we do not have anything to push
         if len(to_push) == 0:

--- a/microsetta_private_api/repo/qiita_repo.py
+++ b/microsetta_private_api/repo/qiita_repo.py
@@ -1,3 +1,4 @@
+from microsetta_private_api.exceptions import RepoException
 from microsetta_private_api.repo.admin_repo import AdminRepo
 from microsetta_private_api.repo.base_repo import BaseRepo
 from microsetta_private_api.qiita import qclient
@@ -25,9 +26,12 @@ class QiitaRepo(BaseRepo):
                     survey_ids = sar_repo.list_answered_surveys(
                         account_id, source_id)
 
-                    for survey_id in survey_ids:
-                        sar_repo.associate_answered_survey_with_sample(
-                            account_id, source_id, sample_id, survey_id)
+                    if survey_ids is not None:
+                        for survey_id in survey_ids:
+                            sar_repo.associate_answered_survey_with_sample(
+                                account_id, source_id, sample_id, survey_id)
+                    else:
+                        raise RepoException("Survey IDs not found for barcode")
 
             t.commit()
 

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -120,7 +120,7 @@ class AdminTests(TestCase):
         # now lock the barcode to the survey that was recently submitted
         with Transaction() as t:
             qiita_repo = QiitaRepo(t)
-            qiita_repo.lock_sample_to_survey(test_barcodes)
+            qiita_repo.lock_completed_surveys_to_barcodes(test_barcodes)
 
             with t.dict_cursor() as cur:
                 cur.execute("SELECT * FROM source_barcodes_surveys "

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -70,7 +70,7 @@ class AdminTests(TestCase):
                                       "associated with any surveys "
                                       "matching this template id")}])
 
-    def test_lock_sample_to_survey(self):
+    def test_lock_completed_surveys_to_barcodes(self):
 
         test_barcode = '000069747'
         test_barcodes = [test_barcode]
@@ -115,7 +115,6 @@ class AdminTests(TestCase):
                 account_id,
                 source_id,
                 'en_US', 10, survey_10)
-            t.commit()
 
         # now lock the barcode to the survey that was recently submitted
         with Transaction() as t:

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -124,7 +124,6 @@ class AdminTests(TestCase):
                 cur.execute("SELECT * FROM source_barcodes_surveys "
                             "WHERE barcode = '000069747'")
                 rows_after = cur.fetchall()
-            t.commit()
 
         self.assertGreater(len(rows_after), len(rows_before))
 

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -115,6 +115,7 @@ class AdminTests(TestCase):
                 account_id,
                 source_id,
                 'en_US', 10, survey_10)
+            t.commit()
 
         # now lock the barcode to the survey that was recently submitted
         with Transaction() as t:

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -71,12 +71,12 @@ class AdminTests(TestCase):
                                       "matching this template id")}])
 
     def test_lock_sample_to_survey(self):
-        test_account_id = 'ed5ab96f-fc55-ead5-e040-8a80115d1c4b'
-        test_source_id = '1d7138e7-f1a7-421b-8c58-9245b2bc343e'
-        test_sample_id = 'ed5ab96f-fc57-ead5-e040-8a80115d1c4b'
-        test_barcode = '000012914'
+        test_account_id = 'd8592c74-85ee-2135-e040-8a80115d6401'
+        test_source_id = '6c1c628e-7d78-4dc7-afd9-3061fa9866ba'
+        test_sample_id = 'd8592c74-85f0-2135-e040-8a80115d6401'
+        test_barcode = '000001766'
         test_barcodes = [test_barcode]
-        test_survey_id = '000a1da7d9d7e35b'
+        test_survey_id = 'd089fe280548bb96'
 
         # first we need to disassociate the sample with the survey
         with Transaction() as t:

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -115,10 +115,8 @@ class AdminTests(TestCase):
                 account_id,
                 source_id,
                 'en_US', 10, survey_10)
-            t.commit()
 
-        # now lock the barcode to the survey that was recently submitted
-        with Transaction() as t:
+            # now lock the barcode to the survey that was recently submitted
             qiita_repo = QiitaRepo(t)
             qiita_repo.lock_completed_surveys_to_barcodes(test_barcodes)
 
@@ -126,6 +124,7 @@ class AdminTests(TestCase):
                 cur.execute("SELECT * FROM source_barcodes_surveys "
                             "WHERE barcode = '000069747'")
                 rows_after = cur.fetchall()
+            t.commit()
 
         self.assertGreater(len(rows_after), len(rows_before))
 

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, main
 from unittest.mock import patch
+from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.qiita_repo import QiitaRepo
 
@@ -68,6 +69,65 @@ class AdminTests(TestCase):
                 {skin_valid_barcode: ("This barcode is not "
                                       "associated with any surveys "
                                       "matching this template id")}])
+
+    def test_lock_sample_to_survey(self):
+
+        test_barcode = '000069747'
+        test_barcodes = [test_barcode]
+
+        with Transaction() as t:
+            with t.dict_cursor() as cur:
+                # first, find the ids for the barcode and survey we're using
+                # as they are dynamically generated.
+                cur.execute("select ag_login_id, source_id from "
+                            "ag_login_surveys a join source_barcodes_surveys b"
+                            " on a.survey_id = b.survey_id and b.barcode = "
+                            "'000069747' and survey_template_id = 1")
+                row = cur.fetchone()
+                account_id = row[0]
+                source_id = row[1]
+
+                cur.execute("select ag_kit_barcode_id from ag_kit_barcodes "
+                            "where barcode = '000069747'")
+                row = cur.fetchone()
+
+                cur.execute("SELECT * FROM source_barcodes_surveys "
+                            "WHERE barcode = '000069747'")
+                rows_before = cur.fetchall()
+
+            # submit a survey for the barcode
+            sar = SurveyAnswersRepo(t)
+            survey_10 = {
+                '22': 'Unspecified',
+                '108': 'Unspecified',
+                '109': 'Unspecified',
+                '110': 'Unspecified',
+                '111': 'Unspecified',
+                '112': '1990',
+                '113': 'Unspecified',
+                '115': 'Unspecified',
+                '148': 'Unspecified',
+                '492': 'Unspecified',
+                '493': 'Unspecified',
+                '502': 'Male'
+            }
+            sar.submit_answered_survey(
+                account_id,
+                source_id,
+                'en_US', 10, survey_10)
+            t.commit()
+
+        # now lock the barcode to the survey that was recently submitted
+        with Transaction() as t:
+            qiita_repo = QiitaRepo(t)
+            qiita_repo.lock_sample_to_survey(test_barcodes)
+
+            with t.dict_cursor() as cur:
+                cur.execute("SELECT * FROM source_barcodes_surveys "
+                            "WHERE barcode = '000069747'")
+                rows_after = cur.fetchall()
+
+        self.assertGreater(len(rows_after), len(rows_before))
 
 
 if __name__ == '__main__':

--- a/microsetta_private_api/repo/tests/test_qiita.py
+++ b/microsetta_private_api/repo/tests/test_qiita.py
@@ -1,5 +1,6 @@
 from unittest import TestCase, main
 from unittest.mock import patch
+from microsetta_private_api.repo.survey_answers_repo import SurveyAnswersRepo
 from microsetta_private_api.repo.transaction import Transaction
 from microsetta_private_api.repo.qiita_repo import QiitaRepo
 
@@ -70,9 +71,24 @@ class AdminTests(TestCase):
                                       "matching this template id")}])
 
     def test_lock_sample_to_survey(self):
+        test_account_id = 'ed5ab96f-fc55-ead5-e040-8a80115d1c4b'
+        test_source_id = '1d7138e7-f1a7-421b-8c58-9245b2bc343e'
+        test_sample_id = 'ed5ab96f-fc57-ead5-e040-8a80115d1c4b'
         test_barcode = '000012914'
         test_barcodes = [test_barcode]
         test_survey_id = '000a1da7d9d7e35b'
+
+        with Transaction() as t:
+            answers_repo = SurveyAnswersRepo(t)
+            answered_survey_ids = answers_repo.list_answered_surveys_by_sample(
+                test_account_id, test_source_id, test_sample_id)
+
+            for curr_answered_survey_id in answered_survey_ids:
+                answers_repo.dissociate_answered_survey_from_sample(
+                    test_account_id, test_source_id,
+                    test_sample_id, curr_answered_survey_id)
+
+            t.commit()
 
         with Transaction() as t:
             with t.cursor() as cur:

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -86,3 +86,5 @@ def update_qiita_metadata():
                        {"what": "qiita metadata push errors",
                         "content": json.dumps(error, indent=2)},
                        EN_US)
+        else:
+            t.commit()

--- a/microsetta_private_api/tasks.py
+++ b/microsetta_private_api/tasks.py
@@ -86,5 +86,4 @@ def update_qiita_metadata():
                        {"what": "qiita metadata push errors",
                         "content": json.dumps(error, indent=2)},
                        EN_US)
-        else:
-            t.commit()
+        t.commit()


### PR DESCRIPTION
Moved the point at which sample-survey associations are locked from the frontend microsetta-interface to immediately before the sample’s metadata is pushed up to Qiita on the backend.