### PR TITLE
Block Shipping Emails on Staging

### DIFF
--- a/microsetta_private_api/util/perk_fulfillment.py
+++ b/microsetta_private_api/util/perk_fulfillment.py
@@ -82,21 +82,24 @@ def process_subscription_fulfillments():
 def check_shipping_updates():
     with Transaction() as t:
         pfr = PerkFulfillmentRepo(t)
-        emails_sent, error_report = pfr.check_for_shipping_updates()
+        pf_active = pfr.check_perk_fulfillment_active()
 
-        if emails_sent > 0 or len(error_report) > 0:
-            t.commit()
+        if pf_active:
+            emails_sent, error_report = pfr.check_for_shipping_updates()
 
-            email_content = f"Emails sent: {emails_sent}\n"\
-                            f"Errors: {error_report}"
-            try:
-                send_email(SERVER_CONFIG['pester_email'], "pester_daniel",
-                           {"what": "Automated Tracking Updates Output",
-                            "content": email_content},
-                           EN_US)
-            except:  # noqa
-                # try our best to email
-                pass
+            if emails_sent > 0 or len(error_report) > 0:
+                t.commit()
+
+                email_content = f"Emails sent: {emails_sent}\n"\
+                                f"Errors: {error_report}"
+                try:
+                    send_email(SERVER_CONFIG['pester_email'], "pester_daniel",
+                               {"what": "Automated Tracking Updates Output",
+                                "content": email_content},
+                               EN_US)
+                except:  # noqa
+                    # try our best to email
+                    pass
 
 
 @celery.task(ignore_result=True)


### PR DESCRIPTION
This PR adds a check on whether perk fulfillment is active to the Celery task that sends tracking numbers to participants. This is needed in the Staging environment, as we need to test other Celery tasks but don't want duplicate emails going out to participants. The Celery tasks that fulfill pending orders already pay attention to the `perk_fulfillment_active` setting.
