### PR TITLE
Copy Barcodes

### DIFF
--- a/microsetta_private_api/db/patches/0139.sql
+++ b/microsetta_private_api/db/patches/0139.sql
@@ -1,0 +1,64 @@
+-- This database patch copies two samples into new barcodes to reflect
+-- adjustments that were necessary in the wet lab. We don't believe this
+-- will be an ongoing need, but if it proves to be, check for new
+-- barcode-related tables before using this as a template.
+
+-- Begin copying X00236845 to 0364352596
+INSERT INTO barcodes.barcode (barcode, assigned_on, status, sample_postmark_date, biomass_remaining, sequencing_status, obsolete, create_date_time, kit_id)
+    SELECT '0364352596', assigned_on, status, sample_postmark_date, biomass_remaining, sequencing_status, obsolete, create_date_time, kit_id
+    FROM barcodes.barcode
+    WHERE barcode = 'X00236845';
+
+INSERT INTO barcodes.project_barcode (project_id, barcode)
+    SELECT project_id, '0364352596'
+    FROM barcodes.project_barcode
+    WHERE barcode = 'X00236845';
+
+-- I'm omitting the sample_barcode_file and sample_barcode_file_md5 as they're
+-- no longer used and it would be inappropriate to directly clone a different
+-- barcode's associated file.
+INSERT INTO ag.ag_kit_barcodes (ag_kit_id, barcode, site_sampled, sample_date, sample_time, notes, moldy, overloaded, other, other_text, date_of_last_email, results_ready, withdrawn, refunded, deposited, source_id, latest_sample_information_update)
+    SELECT ag_kit_id, '0364352596', site_sampled, sample_date, sample_time, notes, moldy, overloaded, other, other_text, date_of_last_email, results_ready, withdrawn, refunded, deposited, source_id, latest_sample_information_update
+    FROM ag.ag_kit_barcodes
+    WHERE barcode = 'X00236845';
+
+INSERT INTO ag.source_barcodes_surveys (barcode, survey_id)
+    SELECT '0364352596', survey_id
+    FROM ag.source_barcodes_surveys
+    WHERE barcode = 'X00236845';
+
+INSERT INTO barcodes.barcode_scans (barcode, scan_timestamp, sample_status, technician_notes)
+    SELECT '0364352596', scan_timestamp, sample_status, technician_notes
+    FROM barcodes.barcode_scans
+    WHERE barcode = 'X00236845';
+-- End copying X00236845 to 0364352596
+
+-- Begin copying 000031307 to 0364406520
+INSERT INTO barcodes.barcode (barcode, assigned_on, status, sample_postmark_date, biomass_remaining, sequencing_status, obsolete, create_date_time, kit_id)
+    SELECT '0364406520', assigned_on, status, sample_postmark_date, biomass_remaining, sequencing_status, obsolete, create_date_time, kit_id
+    FROM barcodes.barcode
+    WHERE barcode = '000031307';
+
+INSERT INTO barcodes.project_barcode (project_id, barcode)
+    SELECT project_id, '0364406520'
+    FROM barcodes.project_barcode
+    WHERE barcode = '000031307';
+
+-- I'm omitting the sample_barcode_file and sample_barcode_file_md5 as they're
+-- no longer used and it would be inappropriate to directly clone a different
+-- barcode's associated file.
+INSERT INTO ag.ag_kit_barcodes (ag_kit_id, barcode, site_sampled, sample_date, sample_time, notes, moldy, overloaded, other, other_text, date_of_last_email, results_ready, withdrawn, refunded, deposited, source_id, latest_sample_information_update)
+    SELECT ag_kit_id, '0364406520', site_sampled, sample_date, sample_time, notes, moldy, overloaded, other, other_text, date_of_last_email, results_ready, withdrawn, refunded, deposited, source_id, latest_sample_information_update
+    FROM ag.ag_kit_barcodes
+    WHERE barcode = '000031307';
+
+INSERT INTO ag.source_barcodes_surveys (barcode, survey_id)
+    SELECT '0364406520', survey_id
+    FROM ag.source_barcodes_surveys
+    WHERE barcode = '000031307';
+
+INSERT INTO barcodes.barcode_scans (barcode, scan_timestamp, sample_status, technician_notes)
+    SELECT '0364406520', scan_timestamp, sample_status, technician_notes
+    FROM barcodes.barcode_scans
+    WHERE barcode = '000031307';
+-- End copying 000031307 to 0364406520


### PR DESCRIPTION
The wet lab recently had to move two samples into tubes with new barcodes. This pull request updates the state of the database to copy all information associated with the two samples into their new barcodes.