### PR TITLE
allow users to claim received samples

### DIFF
--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -28,6 +28,7 @@ def read_sample_associations(account_id, source_id, token_info):
     with Transaction() as t:
         sample_repo = SampleRepo(t)
         samples = sample_repo.get_samples_by_source(account_id, source_id)
+        print("samples", dir(samples))
 
     api_samples = [x.to_api() for x in samples]
     return jsonify(api_samples), 200

--- a/microsetta_private_api/api/_sample.py
+++ b/microsetta_private_api/api/_sample.py
@@ -28,7 +28,6 @@ def read_sample_associations(account_id, source_id, token_info):
     with Transaction() as t:
         sample_repo = SampleRepo(t)
         samples = sample_repo.get_samples_by_source(account_id, source_id)
-        print("samples", dir(samples))
 
     api_samples = [x.to_api() for x in samples]
     return jsonify(api_samples), 200

--- a/microsetta_private_api/api/tests/test_api.py
+++ b/microsetta_private_api/api/tests/test_api.py
@@ -2319,6 +2319,7 @@ class SampleTests(ApiTests):
 
         base_url = '/api/accounts/{0}/sources/{1}/samples'.format(
             dummy_acct_id, dummy_source_id)
+        sample_url = "{0}/{1}".format(base_url, MOCK_SAMPLE_ID)
 
         # "scan" the sample in
         _ = create_dummy_acct(create_dummy_1=True,
@@ -2333,7 +2334,8 @@ class SampleTests(ApiTests):
                                      headers=make_headers(FAKE_TOKEN_ADMIN))
         self.assertEqual(201, post_resp.status_code)
 
-        # attempt to associate as a regular user
+        # allow users to claim samples not
+        # currently associated with a source
         post_resp = self.client.post(
             '%s?%s' % (base_url, self.default_lang_querystring),
             content_type='application/json',
@@ -2345,7 +2347,15 @@ class SampleTests(ApiTests):
         )
 
         # check response code
-        self.assertEqual(422, post_resp.status_code)
+        self.assertEqual(201, post_resp.status_code)
+
+        # delete as admin so that tearDown doesn't require admin
+        delete_resp = self.client.delete(
+            '%s?%s' % (sample_url, self.default_lang_querystring),
+            headers=make_headers(FAKE_TOKEN_ADMIN))
+
+        # verify the delete was successful
+        self.assertEqual(204, delete_resp.status_code)
 
         # associate as admin user
         post_resp = self.client.post(
@@ -2360,6 +2370,21 @@ class SampleTests(ApiTests):
 
         # check response code
         self.assertEqual(201, post_resp.status_code)
+
+        # attempt to associate as a regular user
+        # where the sample does have associated source id
+        post_resp = self.client.post(
+            '%s?%s' % (base_url, self.default_lang_querystring),
+            content_type='application/json',
+            data=json.dumps(
+                {
+                    'sample_id': MOCK_SAMPLE_ID,
+                }),
+            headers=self.dummy_auth
+        )
+
+        # check response code
+        self.assertEqual(422, post_resp.status_code)
 
     def test_edit_sample_locked(self):
         dummy_acct_id, dummy_source_id = create_dummy_source(

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -106,9 +106,6 @@ class SampleRepo(BaseRepo):
                                    override_locked=False):
         with self._transaction.cursor() as cur:
             existing_sample = self._get_sample_by_id(sample_id)
-            print("existing sample", dir(existing_sample))
-            print("existing samples source id", existing_sample.source_id)
-            print("source id", source_id)
             # if the sample is not associated with a source, then
             # we can skip the lock checks
             if existing_sample.source_id is not None \

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -106,7 +106,14 @@ class SampleRepo(BaseRepo):
                                    override_locked=False):
         with self._transaction.cursor() as cur:
             existing_sample = self._get_sample_by_id(sample_id)
-            if existing_sample.remove_locked and not override_locked:
+            print("existing sample", dir(existing_sample))
+            print("existing samples source id", existing_sample.source_id)
+            print("source id", source_id)
+            # if the sample is not associated with a source, then
+            # we can skip the lock checks
+            if existing_sample.source_id is not None \
+                    and existing_sample.remove_locked and not override_locked:
+                print("raise repo exception", existing_sample.source_id)
                 raise RepoException(
                     "Sample association locked: Sample already received")
 

--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -110,7 +110,6 @@ class SampleRepo(BaseRepo):
             # we can skip the lock checks
             if existing_sample.source_id is not None \
                     and existing_sample.remove_locked and not override_locked:
-                print("raise repo exception", existing_sample.source_id)
                 raise RepoException(
                     "Sample association locked: Sample already received")
 


### PR DESCRIPTION
Allow participants to claim a sample that is not currently associated with a source, even after it has been scanned.