### PR TITLE
Drop Free-text Columns in Metadata Repo

### DIFF
--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -74,7 +74,7 @@ def drop_private_columns(df):
     # sensitive in nature
     pm_remove = {c.lower() for c in df.columns if c.lower().startswith('pm_')}
 
-    freetext_fields = {c.lower () for c in _get_freetext_fields()}
+    freetext_fields = {c.lower() for c in _get_freetext_fields()}
 
     remove = pm_remove | {c.lower() for c in EBI_REMOVE} | freetext_fields
     to_drop = [c for c in df.columns if c.lower() in remove]
@@ -640,7 +640,7 @@ def _find_duplicates(barcodes):
 
 def _get_freetext_fields():
     """ Retrieve a list of all free-text survey fields from the database
-    
+
     Returns
     -------
     list of str

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -332,7 +332,7 @@ class MetadataUtilTests(unittest.TestCase):
         obs = drop_private_columns(df)
         pdt.assert_frame_equal(obs, exp)
 
-    def test_drop_private_columns(self):
+    def test_drop_private_columns_freetext(self):
         # This test specifically asserts that the new code to drop free-text
         # fields works, even if those fields are not represented in the
         # EBI_REMOVE list

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -17,10 +17,13 @@ from microsetta_private_api.repo.metadata_repo._repo import (
     _fetch_observed_survey_templates,
     _construct_multiselect_map,
     _find_best_answers,
-    drop_private_columns)
+    drop_private_columns,
+    _get_freetext_fields,
+    EBI_REMOVE)
 from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
 from microsetta_private_api.model.account import Account
 from microsetta_private_api.model.address import Address
+from microsetta_private_api.repo.transaction import Transaction
 
 
 class MM:
@@ -329,6 +332,32 @@ class MetadataUtilTests(unittest.TestCase):
         obs = drop_private_columns(df)
         pdt.assert_frame_equal(obs, exp)
 
+    def test_drop_private_columns(self):
+        # This test specifically asserts that the new code to drop free-text
+        # fields works, even if those fields are not represented in the
+        # EBI_REMOVE list
+
+        # First, assert that ALL_ROOMMATES is not in EBI_REMOVE
+        self.assertFalse("ALL_ROOMMATES" in EBI_REMOVE)
+
+        # Next, assert that ALL_ROOMMATES is a free-text field
+        freetext_fields = _get_freetext_fields()
+        self.assertTrue("ALL_ROOMMATES" in freetext_fields)
+
+        # Now, set up a test dataframe, based on the existing
+        # test_drop_private_columns df, but with the ALL_ROOMMATES field added
+        df = pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8]],
+                          columns=[
+                              'pM_foo',
+                              'okay',
+                              'ABOUT_yourSELF_TEXT',
+                              'ALL_ROOMMATES'])
+
+        # We only expect the "okay" column to remain
+        exp = pd.DataFrame([[2, ], [6, ]], columns=['okay'])
+        obs = drop_private_columns(df)
+        pdt.assert_frame_equal(obs, exp)
+
     def test_build_col_name(self):
         tests_and_expected = [('foo', 'bar', 'foo_bar'),
                               ('foo', 'bar baz', 'foo_bar_baz')]
@@ -511,6 +540,30 @@ class MetadataUtilTests(unittest.TestCase):
             _ = obs[0]['response']['110']
         with self.assertRaises(KeyError):
             _ = obs[0]['response']['111']
+
+    def test_get_freetext_fields(self):
+        with Transaction() as t:
+            with t.cursor() as cur:
+                # Grab the count for the number of free-text fields that exist
+                # in the database
+                cur.execute(
+                    "SELECT COUNT(*) "
+                    "FROM ag.survey_question_response_type "
+                    "WHERE survey_response_type IN ('TEXT', 'STRING')"
+                )
+                row = cur.fetchone()
+                freetext_count = row[0]
+
+        # Use the _get_freetext_fields() function to pull the actual list
+        freetext_fields = _get_freetext_fields()
+
+        # Assert that the field count matches
+        self.assertEqual(len(freetext_fields), freetext_count)
+
+        # Assert that a few known free-text fields exist in the list
+        self.assertTrue("ABOUT_YOURSELF_TEXT" in freetext_fields)
+        self.assertTrue("ALL_ROOMMATES" in freetext_fields)
+        self.assertTrue("DIET_RESTRICTIONS" in freetext_fields)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR includes code to automatically include any free-text survey field in the metadata repo's `drop_private_columns` function, rather than the manually curated `EBI_REMOVE` list.