### PR TITLE
Fix query of FFQ registration code to check not null

### DIFF
--- a/microsetta_private_api/repo/vioscreen_repo.py
+++ b/microsetta_private_api/repo/vioscreen_repo.py
@@ -1772,7 +1772,7 @@ class VioscreenRepo(BaseRepo):
                 "    SELECT ffq_registration_code "
                 "    FROM campaign.ffq_registration_codes "
                 "    WHERE ffq_registration_code = %s AND "
-                "    registration_code_used IS NULL)",
+                "    registration_code_used IS NOT NULL)",
                 (ffq_code, )
             )
             return cur.fetchone()[0]


### PR DESCRIPTION
Fix query of registration FFQ code where previous SQL was "ffq_registration_code = <passed FFQ code>" AND "registration_code_used IS NULL". The new SQL adds "IS NOT NULL".