### PR TITLE
SBI Pre-launch Adjustments

### DIFF
--- a/microsetta_private_api/repo/sample_repo.py
+++ b/microsetta_private_api/repo/sample_repo.py
@@ -612,26 +612,39 @@ class SampleRepo(BaseRepo):
         bc_valid = True
         for fn, fv in barcode_meta.items():
             if fn == "sample_site_last_washed_date":
-                try:
-                    ret_val = datetime.datetime.strptime(
-                        fv,
-                        self.SAMPLE_SITE_LAST_WASHED_DATE_FORMAT
-                    )
-                    ret_dict[fn] = ret_val
-                except ValueError:
-                    bc_valid = False
+                if fv is None or len(fv) == 0:
+                    # Null value is acceptable, bypass format validation
+                    ret_dict[fn] = None
+                else:
+                    try:
+                        ret_val = datetime.datetime.strptime(
+                            fv,
+                            self.SAMPLE_SITE_LAST_WASHED_DATE_FORMAT
+                        )
+                        ret_dict[fn] = ret_val
+                    except ValueError:
+                        bc_valid = False
             elif fn == "sample_site_last_washed_time":
-                try:
-                    ret_val = datetime.datetime.strptime(
-                        fv,
-                        self.SAMPLE_SITE_LAST_WASHED_TIME_FORMAT_STRPTIME
-                    )
-                    ret_dict[fn] = ret_val
-                except ValueError:
-                    bc_valid = False
+                if fv is None or len(fv) == 0:
+                    # Null value is acceptable, bypass format validation
+                    ret_dict[fn] = None
+                else:
+                    try:
+                        ret_val = datetime.datetime.strptime(
+                            fv,
+                            self.SAMPLE_SITE_LAST_WASHED_TIME_FORMAT_STRPTIME
+                        )
+                        ret_dict[fn] = ret_val
+                    except ValueError:
+                        bc_valid = False
             elif fn == "sample_site_last_washed_product":
-                # The ENUM type in the database will validate the value
-                ret_dict[fn] = fv
+                if fv is None or len(fv) == 0:
+                    # Ensure that blank value - None/Null or "" - is passed on
+                    # as None
+                    ret_dict[fn] = None
+                else:
+                    # The ENUM type in the database will validate the value
+                    ret_dict[fn] = fv
             else:
                 bc_valid = False
 

--- a/microsetta_private_api/repo/tests/test_sample.py
+++ b/microsetta_private_api/repo/tests/test_sample.py
@@ -184,6 +184,49 @@ class SampleTests(unittest.TestCase):
             bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
             self.assertNotEqual(bc_valid, False)
 
+            # Test each scenario where only one field is present to confirm
+            # that any other field can be nullable
+            bc_meta = {
+                "sample_site_last_washed_date": "01/10/2025",
+                "sample_site_last_washed_time": "",
+                "sample_site_last_washed_product": ""
+            }
+            exp = {
+                "sample_site_last_washed_date": datetime.datetime(
+                    2025, 1, 10),
+                "sample_site_last_washed_time": None,
+                "sample_site_last_washed_product": None
+            }
+            bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
+            self.assertEqual(bc_valid, exp)
+
+            bc_meta = {
+                "sample_site_last_washed_date": "",
+                "sample_site_last_washed_time": "9:30 AM",
+                "sample_site_last_washed_product": ""
+            }
+            exp = {
+                "sample_site_last_washed_date": None,
+                "sample_site_last_washed_time": datetime.datetime(
+                    1900, 1, 1, 9, 30),
+                "sample_site_last_washed_product": None
+            }
+            bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
+            self.assertEqual(bc_valid, exp)
+
+            bc_meta = {
+                "sample_site_last_washed_date": "",
+                "sample_site_last_washed_time": "",
+                "sample_site_last_washed_product": "Face cleanser"
+            }
+            exp = {
+                "sample_site_last_washed_date": None,
+                "sample_site_last_washed_time": None,
+                "sample_site_last_washed_product": "Face cleanser"
+            }
+            bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
+            self.assertEqual(bc_valid, exp)
+
             # Confirm that empty dicts pass, regardless of site
             bc_meta = {}
             bc_valid = sample_repo._validate_barcode_meta("Stool", bc_meta)
@@ -205,6 +248,24 @@ class SampleTests(unittest.TestCase):
             }
             bc_valid = sample_repo._validate_barcode_meta("Stool", bc_meta)
             self.assertFalse(bc_valid)
+
+            # Try using an invalid value for the date
+            bc_meta = {
+                "sample_site_last_washed_date": "Cookie monster",
+                "sample_site_last_washed_time": "",
+                "sample_site_last_washed_product": "Face cleanser"
+            }
+            bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
+            self.assertEqual(bc_valid, False)
+
+            # Try using an invalid value for the time
+            bc_meta = {
+                "sample_site_last_washed_date": "",
+                "sample_site_last_washed_time": "Rosemary focaccia",
+                "sample_site_last_washed_product": "Face cleanser"
+            }
+            bc_valid = sample_repo._validate_barcode_meta("Cheek", bc_meta)
+            self.assertEqual(bc_valid, False)
 
     def test_update_barcode_meta_via_update_info(self):
         # We're going to use a stable sample and override_locked to test


### PR DESCRIPTION
This pull request adjusts the validation functionality tied to the metadata associated with cheek samples. The intended behavior is for each field to be independently nullable, such that a user can answer any combination of the three questions.

To better exercise this validation functionality, I've expanded the unit tests to test a variety of permutations and assert the intended outcomes.