### PR TITLE
Remove Timeframe from Sample Is Valid Email

### DIFF
--- a/microsetta_private_api/templates/email/sample_is_valid.jinja2
+++ b/microsetta_private_api/templates/email/sample_is_valid.jinja2
@@ -221,7 +221,7 @@
 </p>
 <p class="c1"><span class="c0">&nbsp;</span></p>
 <p class="c8 c9">
-<span class="c0">{{ _("Thank you for your interest and participation in The Microsetta Initiative. We have received your microbiome sample. Samples are typically processed within 1 – 3 months. If you are part of a specific study, the timeframe could be longer. Once sequenced, you will receive an update and a report will be available in your online account.") }}</span>
+<span class="c0">{{ _("Thank you for your interest and participation in The Microsetta Initiative. We have received your microbiome sample. Once we sequence your sample, we will notify you that a new report is available in your online account.") }}</span>
 </p>
 <p class="c1"><span class="c0">&nbsp;</span></p>
 <p class="c1">


### PR DESCRIPTION
Re-wording the email participants receive when their sample is scanned as valid to remove any mention of turnaround time on sequencing.

As this is a simple string change, I'm going to merge it once workflow runs. Translation will be adjusted with any other text changes before I cut and deploy the next release.