### PR TITLE
Add Box ID to Sample Summary

### DIFF
--- a/microsetta_private_api/admin/admin_impl.py
+++ b/microsetta_private_api/admin/admin_impl.py
@@ -31,7 +31,7 @@ from microsetta_private_api import localization
 from microsetta_private_api.admin.sample_summary import per_sample
 from microsetta_private_api.admin.sample_summary import \
     get_barcodes_by_project_id,\
-    get_barcodes_by_kit_ids, get_barcodes_by_emails,\
+    get_barcodes_by_kit_ids, get_barcodes_by_box_ids, get_barcodes_by_emails,\
     get_barcodes_by_outbound_tracking_numbers,\
     get_barcodes_by_inbound_tracking_numbers, get_barcodes_by_dak_order_ids
 from microsetta_private_api.util.melissa import verify_address
@@ -511,6 +511,8 @@ def query_barcode_stats(body, token_info, strip_sampleid):
         barcodes = body["sample_barcodes"]
     elif 'kit_ids' in body:
         barcodes = get_barcodes_by_kit_ids(body["kit_ids"])
+    elif 'box_ids' in body:
+        barcodes = get_barcodes_by_box_ids(body["box_ids"])
     elif 'emails' in body:
         barcodes = get_barcodes_by_emails(body["emails"])
     elif 'outbound_tracking_numbers' in body:

--- a/microsetta_private_api/admin/sample_summary.py
+++ b/microsetta_private_api/admin/sample_summary.py
@@ -17,6 +17,11 @@ def get_barcodes_by_kit_ids(kit_ids):
         return AdminRepo(t).get_barcodes_filter(kit_ids=kit_ids)
 
 
+def get_barcodes_by_box_ids(box_ids):
+    with Transaction() as t:
+        return AdminRepo(t).get_barcodes_filter(box_ids=box_ids)
+
+
 def get_barcodes_by_emails(emails):
     with Transaction() as t:
         return AdminRepo(t).get_barcodes_filter(emails=emails)
@@ -142,11 +147,13 @@ def per_sample(project, barcodes, strip_sampleid):
                 info = kit_by_barcode[0]
 
                 kit_id_name = info['kit_id']
+                box_id = info['box_id']
                 outbound_fedex_tracking = info['outbound_tracking']
                 inbound_fedex_tracking = info['inbound_tracking']
                 daklapack_order_id = info['dak_order_id']
             else:
                 kit_id_name = None
+                box_id = None
                 outbound_fedex_tracking = None
                 inbound_fedex_tracking = None
                 daklapack_order_id = None
@@ -171,6 +178,7 @@ def per_sample(project, barcodes, strip_sampleid):
                 "latest-scan-timestamp": latest_scan_timestamp,
                 "latest-scan-status": latest_scan_status,
                 "kit-id": kit_id_name,
+                "box-id": box_id,
                 "outbound-tracking": outbound_fedex_tracking,
                 "inbound-tracking": inbound_fedex_tracking,
                 "daklapack-order-id": daklapack_order_id

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1531,7 +1531,7 @@ class AdminRepoTests(AdminTests):
                     "VALUES (%s, %s)",
                     (barcode, kit_id)
                 )
-            
+
             admin_repo = AdminRepo(t)
 
             # Retrieve barcodes by Box ID

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1699,6 +1699,7 @@ class AdminRepoTests(AdminTests):
         outbound_tracking = 'FEDEX_OUT_1234'
         inbound_tracking = 'FEDEX_IN_5678'
         barcode = '00001234'
+        box_id = '0001e15f-4170-4b28-b111-191cd567c348'
 
         with Transaction() as t:
             with t.cursor() as cur:
@@ -1715,9 +1716,9 @@ class AdminRepoTests(AdminTests):
                     "INSERT INTO barcodes.kit "
                     "(kit_uuid, kit_id, box_id, outbound_fedex_tracking, "
                     "inbound_fedex_tracking) "
-                    "VALUES (%s, %s, '0001e15f-4170-4b28-b111-191cd567c348', "
-                    "%s, %s)",
-                    (kit_uuid, kit_id, outbound_tracking, inbound_tracking)
+                    "VALUES (%s, %s, %s, %s, %s)",
+                    (kit_uuid, kit_id, box_id, outbound_tracking,
+                     inbound_tracking)
                 )
 
                 # Insert Daklapack order to kit record
@@ -1743,6 +1744,7 @@ class AdminRepoTests(AdminTests):
                 'outbound_tracking': outbound_tracking,
                 'inbound_tracking': inbound_tracking,
                 'kit_id': kit_id,
+                'box_id': box_id,
                 'dak_order_id': dak_order_id
             }]
             self.assertEqual(kit_info, expected)

--- a/microsetta_private_api/admin/tests/test_admin_repo.py
+++ b/microsetta_private_api/admin/tests/test_admin_repo.py
@@ -1511,6 +1511,47 @@ class AdminRepoTests(AdminTests):
             barcodes = admin_repo.get_barcodes_filter(kit_ids=['notarealkit'])
             self.assertEqual(barcodes, [])
 
+    def test_get_barcodes_filter_box_ids_success(self):
+        barcode = "barcode_20240422"
+        kit_id = "test_kit_20240422"
+        box_id = "box_id_20250422"
+
+        with Transaction() as t:
+            with t.cursor() as cur:
+                # Create kit with a known Box ID
+                cur.execute(
+                    "INSERT INTO barcodes.kit (kit_id, box_id) "
+                    "VALUES (%s, %s)",
+                    (kit_id, box_id)
+                )
+
+                # Add a barcode to that kit
+                cur.execute(
+                    "INSERT INTO barcodes.barcode (barcode, kit_id) "
+                    "VALUES (%s, %s)",
+                    (barcode, kit_id)
+                )
+            
+            admin_repo = AdminRepo(t)
+
+            # Retrieve barcodes by Box ID
+            barcodes = admin_repo.get_barcodes_filter(box_ids=[box_id])
+
+            # Assert that the result is what we expect
+            self.assertEqual(barcodes, [barcode])
+
+    def test_get_barcodes_filter_box_ids_failure(self):
+        with Transaction() as t:
+            admin_repo = AdminRepo(t)
+
+            # Retrieve barcodes by a Box ID that doesn't exist
+            barcodes = admin_repo.get_barcodes_filter(
+                box_ids=["definitely_not_a_real_box_id_20250422"]
+            )
+
+            # Assert that the result is an empty list
+            self.assertEqual(barcodes, [])
+
     def test_get_barcodes_filter_emails_success(self):
         with Transaction() as t:
             setup_sql = """

--- a/microsetta_private_api/api/microsetta_private_api.yaml
+++ b/microsetta_private_api/api/microsetta_private_api.yaml
@@ -3060,6 +3060,10 @@ paths:
                   type: array
                   items:
                     type: string
+                'box_ids':
+                  type: array
+                  items:
+                    type: string
                 'emails':
                   type: array
                   items:

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -553,7 +553,7 @@ class AdminRepo(BaseRepo):
                 cur.execute(query, [project_id, ])
                 return list([v[0] for v in cur.fetchall()])
 
-    def get_barcodes_filter(self, kit_ids=None, emails=None,
+    def get_barcodes_filter(self, kit_ids=None, box_ids=None, emails=None,
                             outbound_tracking_numbers=None,
                             inbound_tracking_numbers=None,
                             dak_order_ids=None):
@@ -563,6 +563,8 @@ class AdminRepo(BaseRepo):
         ----------
         kit_ids : list, optional
             List of kit IDs to obtain barcodes for.
+        box_ids : list, optional
+            List of box IDs to obtain barcodes for.
         emails : list, optional
             List of emails to obtain barcodes for.
         outbound_tracking_numbers : list, optional
@@ -589,6 +591,10 @@ class AdminRepo(BaseRepo):
         if kit_ids:
             conditions.append("k.kit_id IN %s")
             params.append(tuple(kit_ids))
+
+        if box_ids:
+            conditions.append("k.box_id IN %s")
+            params.append(tuple(box_ids))
 
         if emails:
             query += """
@@ -626,7 +632,8 @@ class AdminRepo(BaseRepo):
 
     def get_kit_by_barcode(self, barcodes):
         """Obtain the outbound tracking, inbound tracking numbers,
-        kit ID, and Daklapack order ID associated with a list of barcodes.
+        kit ID, box ID, and Daklapack order ID associated with a list of
+        barcodes.
 
         Parameters
         ----------
@@ -645,6 +652,7 @@ class AdminRepo(BaseRepo):
                 k.outbound_fedex_tracking,
                 k.inbound_fedex_tracking,
                 k.kit_id,
+                k.box_id,
                 dotk.dak_order_id
             FROM
                 barcodes.barcode b
@@ -674,7 +682,8 @@ class AdminRepo(BaseRepo):
                     "outbound_tracking": row[1],
                     "inbound_tracking": row[2],
                     "kit_id": row[3],
-                    "dak_order_id": row[4]
+                    "box_id": row[4],
+                    "dak_order_id": row[5]
                 }
                 for row in rows
             ]

--- a/microsetta_private_api/repo/admin_repo.py
+++ b/microsetta_private_api/repo/admin_repo.py
@@ -553,10 +553,10 @@ class AdminRepo(BaseRepo):
                 cur.execute(query, [project_id, ])
                 return list([v[0] for v in cur.fetchall()])
 
-    def get_barcodes_filter(self, kit_ids=None, box_ids=None, emails=None,
+    def get_barcodes_filter(self, kit_ids=None, emails=None,
                             outbound_tracking_numbers=None,
                             inbound_tracking_numbers=None,
-                            dak_order_ids=None):
+                            dak_order_ids=None, box_ids=None):
         """Obtain the barcodes based on different filtering criteria.
 
         Parameters


### PR DESCRIPTION
This PR adds the Box ID to the Sample Summary report in microsetta-admin, both as a search parameter and an output field.

Corresponding microsetta-admin PR: https://github.com/biocore/microsetta-admin/pull/111