### PR TITLE
Metadata Push Adjustments

### DIFF
--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -28,6 +28,7 @@ TEMPLATES_TO_IGNORE = {SurveyTemplateRepo.VIOSCREEN_ID,
                        SurveyTemplateRepo.MYFOODREPO_ID,
                        SurveyTemplateRepo.POLYPHENOL_FFQ_ID,
                        SurveyTemplateRepo.SPAIN_FFQ_ID,
+                       SurveyTemplateRepo.SKIN_SCORING_APP_ID,
                        None}
 
 # NOTE 2025-01-09: We're contractually bound to withhold all of the skin

--- a/microsetta_private_api/repo/metadata_repo/_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/_repo.py
@@ -238,8 +238,11 @@ def drop_private_columns(df):
     pm_remove = {c.lower() for c in df.columns if c.lower().startswith('pm_')}
 
     freetext_fields = {c.lower() for c in _get_freetext_fields()}
+    ebi_remove_expanded = {
+        c.lower() for c in _expand_ebi_remove_fields(EBI_REMOVE)
+    }
 
-    remove = pm_remove | {c.lower() for c in EBI_REMOVE} | freetext_fields
+    remove = pm_remove | ebi_remove_expanded | freetext_fields
     to_drop = [c for c in df.columns if c.lower() in remove]
 
     return df.drop(columns=to_drop, inplace=False)
@@ -824,3 +827,71 @@ def _get_freetext_fields():
             )
             rows = cur.fetchall()
             return [x[0] for x in rows]
+
+
+def _expand_ebi_remove_fields(field_names):
+    """ Some fields in the EBI_REMOVE list are multiselect. We need to expand
+        the list to include the column names for all possible responses, as
+        the column removal takes place after fields have been mapped.
+
+        NB: I've set this up as a parameter (field_names) rather than directly
+        using EBI_REMOVE to facilitate unit testing.
+    
+    Parameters
+    ----------
+    field_names : list of str
+        The field names to check for multiselects and expand as-needed
+    Returns
+    -------
+    list of str
+        The column names to remove from output, including distinct column
+        names for all multiselect responses.
+    """
+    cols_to_block = []
+    with Transaction() as t:
+        with t.cursor() as cur:
+            for q_name in field_names:
+                cur.execute(
+                    "SELECT sqr.survey_response_type "
+                    "FROM ag.survey_question_response_type sqr "
+                    "INNER JOIN ag.survey_question sq "
+                    "ON sqr.survey_question_id = sq.survey_question_id "
+                    "WHERE sq.question_shortname ILIKE %s",
+                    (q_name, )
+                )
+                r = cur.fetchone()
+                if r is None:
+                    # Didn't find a question, but we'll add the column name to
+                    # the block list to be safe
+                    cols_to_block.append(q_name)
+                else:
+                    if r[0] == "MULTIPLE":
+                        # Block the root column name
+                        cols_to_block.append(q_name)
+
+                        # Then expand the column name to all possible
+                        # permutations and add them to the block list
+
+                        # First, grab the possible responses
+                        cur.execute(
+                            "SELECT sqr.response "
+                            "FROM ag.survey_question_response sqr "
+                            "INNER JOIN ag.survey_question sq "
+                            "ON sqr.survey_question_id "
+                            "= sq.survey_question_id "
+                            "WHERE sq.question_shortname ILIKE %s",
+                            (q_name, )
+                        )
+                        rows = cur.fetchall()
+                        for r in rows:
+                            # Build the new column name
+                            new_col_name = _build_col_name(q_name, r[0])
+
+                            # And append it to our block list
+                            cols_to_block.append(new_col_name)
+                    else:
+                        # Not a multiselect field, we can just add the column
+                        # name to the block list
+                        cols_to_block.append(q_name)
+
+    return cols_to_block

--- a/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
+++ b/microsetta_private_api/repo/metadata_repo/tests/test_repo.py
@@ -19,6 +19,7 @@ from microsetta_private_api.repo.metadata_repo._repo import (
     _find_best_answers,
     drop_private_columns,
     _get_freetext_fields,
+    _expand_ebi_remove_fields,
     EBI_REMOVE)
 from microsetta_private_api.repo.survey_template_repo import SurveyTemplateRepo
 from microsetta_private_api.model.account import Account
@@ -571,6 +572,67 @@ class MetadataUtilTests(unittest.TestCase):
         self.assertTrue("ABOUT_YOURSELF_TEXT" in freetext_fields)
         self.assertTrue("ALL_ROOMMATES" in freetext_fields)
         self.assertTrue("DIET_RESTRICTIONS" in freetext_fields)
+
+    def test_expand_ebi_remove_fields(self):
+        # First, let's assert that normal single-response fields are passed
+        # through as expected
+        col_names = ['ACNE_MEDICATION_OTC', 'SKIN_COLOR']
+        obs = _expand_ebi_remove_fields(col_names)
+        self.assertEqual(col_names, obs)
+
+        # Next, let's confirm that a multiselect field is expanded to include
+        # all options, and that the root question name is kept as well
+        col_names = ['SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES']
+        exp = [
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Abdomen',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Armpits',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Arms',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Back',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Chest',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Elbows',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Face',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Feet',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Hands',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Knees',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Legs',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Neck',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Other',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Scalp',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Unspecified'
+        ]
+        obs = _expand_ebi_remove_fields(col_names)
+        self.assertEqual(obs, exp)
+
+        # And lastly, confirm that a combination of single-response and
+        # multiselect fields works as expected
+        col_names = [
+            'ACNE_MEDICATION_OTC',
+            'SKIN_COLOR',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES'
+        ]
+        exp = [
+            'ACNE_MEDICATION_OTC',
+            'SKIN_COLOR',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Abdomen',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Armpits',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Arms',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Back',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Chest',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Elbows',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Face',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Feet',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Hands',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Knees',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Legs',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Neck',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Other',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Scalp',
+            'SKIN_CONDITIONS_RECENT_ACNE_BODY_SITES_Unspecified'
+        ]
+        obs = _expand_ebi_remove_fields(col_names)
+        self.assertEqual(obs, exp)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request makes two key adjustments to the metadata push code:
1) It ignores the exeternal Skin Scoring App survey, for which we do not have any metadata.
2) It gracefully handles multiselect fields in the blocked list of columns that we do not include in exported metadata.