### PR TITLE
handle setuptools-scm version inference when .git is absent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,9 @@ PYTHON_VERSION = 3.11
 deploy:
 	conda env remove -n $(ENV_NAME) --yes 2>/dev/null; \
 	conda create --yes -n $(ENV_NAME) python=$(PYTHON_VERSION) setuptools=78 && \
-	conda run -n $(ENV_NAME) conda install --yes --file ci/conda_requirements.txt && \
+	conda run -n $(ENV_NAME) conda install --yes -c conda-forge --file ci/conda_requirements.txt && \
 	conda run -n $(ENV_NAME) pip install -r ci/pip_requirements.txt && \
+	conda run -n $(ENV_NAME) conda install --yes -c conda-forge gunicorn && \
 	if [ ! -d .git ]; then export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0; fi && \
 	conda run -n $(ENV_NAME) pip install -e . --no-deps
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ deploy:
 	conda create --yes -n $(ENV_NAME) python=$(PYTHON_VERSION) setuptools=78 && \
 	conda run -n $(ENV_NAME) conda install --yes --file ci/conda_requirements.txt && \
 	conda run -n $(ENV_NAME) pip install -r ci/pip_requirements.txt && \
+	if [ ! -d .git ]; then export SETUPTOOLS_SCM_PRETEND_VERSION=0.0.0; fi && \
 	conda run -n $(ENV_NAME) pip install -e . --no-deps
 
 clean:


### PR DESCRIPTION
When the repo is downloaded as a tarball/zip rather than cloned, setuptools-scm cannot determine the version. Set a fallback pretend version so make deploy works in both cases.